### PR TITLE
Simplify request/response handling

### DIFF
--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -26,8 +26,7 @@ module Kafka
       request = Protocol::TopicMetadataRequest.new(**options)
       response = Protocol::MetadataResponse.new
 
-      @connection.write_request(api_key, request)
-      @connection.read_response(response)
+      @connection.request(api_key, request, response)
 
       response
     end
@@ -35,12 +34,11 @@ module Kafka
     def produce(**options)
       api_key = Protocol::PRODUCE_API_KEY
       request = Protocol::ProduceRequest.new(**options)
+      response = request.requires_acks? ? Protocol::ProduceResponse.new : nil
 
-      @connection.write_request(api_key, request)
+      @connection.request(api_key, request, response)
 
       if request.requires_acks?
-        response = Protocol::ProduceResponse.new
-        @connection.read_response(response)
         response
       else
         nil

--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -26,9 +26,7 @@ module Kafka
       request = Protocol::TopicMetadataRequest.new(**options)
       response_class = Protocol::MetadataResponse
 
-      response = @connection.request(api_key, request, response_class)
-
-      response
+      @connection.request(api_key, request, response_class)
     end
 
     def produce(**options)
@@ -36,13 +34,7 @@ module Kafka
       request = Protocol::ProduceRequest.new(**options)
       response_class = request.requires_acks? ? Protocol::ProduceResponse : nil
 
-      response = @connection.request(api_key, request, response_class)
-
-      if request.requires_acks?
-        response
-      else
-        nil
-      end
+      @connection.request(api_key, request, response_class)
     end
   end
 end

--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -24,9 +24,9 @@ module Kafka
     def fetch_metadata(**options)
       api_key = Protocol::TOPIC_METADATA_API_KEY
       request = Protocol::TopicMetadataRequest.new(**options)
-      response = Protocol::MetadataResponse.new
+      response_class = Protocol::MetadataResponse
 
-      @connection.request(api_key, request, response)
+      response = @connection.request(api_key, request, response_class)
 
       response
     end
@@ -34,9 +34,9 @@ module Kafka
     def produce(**options)
       api_key = Protocol::PRODUCE_API_KEY
       request = Protocol::ProduceRequest.new(**options)
-      response = request.requires_acks? ? Protocol::ProduceResponse.new : nil
+      response_class = request.requires_acks? ? Protocol::ProduceResponse : nil
 
-      @connection.request(api_key, request, response)
+      response = @connection.request(api_key, request, response_class)
 
       if request.requires_acks?
         response

--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -46,9 +46,7 @@ module Kafka
       write_request(api_key, request)
 
       unless response_class.nil?
-        response = response_class.new
-        read_response(response)
-        response
+        read_response(response_class)
       end
     end
 
@@ -88,7 +86,7 @@ module Kafka
     #   response bytes.
     #
     # @return [nil]
-    def read_response(response)
+    def read_response(response_class)
       @logger.debug "Waiting for response #{@correlation_id}"
 
       bytes = @decoder.bytes
@@ -98,11 +96,11 @@ module Kafka
 
       correlation_id = response_decoder.int32
 
-      response.decode(response_decoder)
+      response = response_class.decode(response_decoder)
 
       @logger.debug "Received response #{@correlation_id}"
 
-      nil
+      response
     end
   end
 end

--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -42,11 +42,13 @@ module Kafka
       @correlation_id = 0
     end
 
-    def request(api_key, request, response)
+    def request(api_key, request, response_class)
       write_request(api_key, request)
 
-      unless response.nil?
+      unless response_class.nil?
+        response = response_class.new
         read_response(response)
+        response
       end
     end
 

--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -42,6 +42,16 @@ module Kafka
       @correlation_id = 0
     end
 
+    def request(api_key, request, response)
+      write_request(api_key, request)
+
+      unless response.nil?
+        read_response(response)
+      end
+    end
+
+    private
+
     # Writes a request over the connection.
     #
     # @param api_key [Integer] the integer code for the API that is invoked.

--- a/lib/kafka/protocol/metadata_response.rb
+++ b/lib/kafka/protocol/metadata_response.rb
@@ -77,6 +77,11 @@ module Kafka
       # @return [Array<TopicMetadata>] the list of topics in the cluster.
       attr_reader :topics
 
+      def initialize(brokers:, topics:)
+        @brokers = brokers
+        @topics = topics
+      end
+
       # Finds the node id of the broker that is acting as leader for the given topic
       # and partition per this metadata.
       #
@@ -111,8 +116,8 @@ module Kafka
       #
       # @param decoder [Decoder]
       # @return [nil]
-      def decode(decoder)
-        @brokers = decoder.array do
+      def self.decode(decoder)
+        brokers = decoder.array do
           node_id = decoder.int32
           host = decoder.string
           port = decoder.int32
@@ -124,7 +129,7 @@ module Kafka
           )
         end
 
-        @topics = decoder.array do
+        topics = decoder.array do
           topic_error_code = decoder.int16
           topic_name = decoder.string
 
@@ -145,7 +150,7 @@ module Kafka
           )
         end
 
-        nil
+        new(brokers: brokers, topics: topics)
       end
     end
   end

--- a/lib/kafka/protocol/produce_response.rb
+++ b/lib/kafka/protocol/produce_response.rb
@@ -26,8 +26,8 @@ module Kafka
         @topics = topics
       end
 
-      def decode(decoder)
-        @topics = decoder.array do
+      def self.decode(decoder)
+        topics = decoder.array do
           topic = decoder.string
 
           partitions = decoder.array do
@@ -40,6 +40,8 @@ module Kafka
 
           TopicInfo.new(topic: topic, partitions: partitions)
         end
+
+        new(topics: topics)
       end
     end
   end


### PR DESCRIPTION
* Rather than having clients of Connection call `write_request` and `read_response` directly, provide a single entrypoint: `request`.
* Instead of having response instances decode themselves, pass the class of the response and let that instantiate an object with the decoded data. This could be extended to use completely separate classes for decoding, e.g. ProduceResponseDecoder. Let's not go all Java on this, though.