### PR TITLE
Allow automatic partition assignment

### DIFF
--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -34,6 +34,10 @@ module Kafka
       broker_for_id(leader_id)
     end
 
+    def partitions_for(topic)
+      @cluster_info.partitions_for(topic)
+    end
+
     def shutdown
       @brokers.each do |id, broker|
         @logger.info "Disconnecting broker #{id}"

--- a/lib/kafka/partitioner.rb
+++ b/lib/kafka/partitioner.rb
@@ -1,0 +1,13 @@
+require "zlib"
+
+module Kafka
+  class Partitioner
+    def initialize(partitions)
+      @partitions = partitions
+    end
+
+    def partition_for_key(key)
+      Zlib.crc32(key) % @partitions.count
+    end
+  end
+end

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -1,5 +1,6 @@
 require "kafka/message"
 require "kafka/message_set"
+require "kafka/partitioner"
 
 module Kafka
   class Producer
@@ -15,10 +16,50 @@ module Kafka
       @buffered_messages = []
     end
 
-    def write(value, key:, topic:, partition:)
-      @buffered_messages << Message.new(value, key: key, topic: topic, partition: partition)
+    # Writes a message to the specified topic. Note that messages are buffered in
+    # the producer until {#flush} is called.
+    #
+    # == Partitioning
+    #
+    # There are several options for specifying the partition that the message should
+    # be written to. The simplest option is to not specify a partition or partition
+    # key, in which case the message key will be used to select one of the available
+    # partitions. You can also specify the `partition` parameter yourself. This
+    # requires you to know which partitions are available, however. Oftentimes the
+    # best option is to specify the `partition_key` parameter: messages with the
+    # same partition key will always be assigned to the same partition, as long as
+    # the number of partitions doesn't change.
+    #
+    # @param value [String] the message data.
+    # @param key [String] the message key.
+    # @param topic [String] the topic that the message should be written to.
+    # @param partition [Integer] the partition that the message should be written to.
+    # @param partition_key [String] the key that should be used to assign a partition.
+    #
+    # @return [Message] the message that was written.
+    def write(value, key:, topic:, partition: nil, partition_key: nil)
+      if partition.nil?
+        # If no explicit partition key is specified we use the message key instead.
+        partition_key ||= key
+        partitioner = Partitioner.new(@broker_pool.partitions_for(topic))
+        partition = partitioner.partition_for_key(partition_key)
+      end
+
+      message = Message.new(value, key: key, topic: topic, partition: partition)
+
+      @buffered_messages << message
+
+      message
     end
 
+    # Flushes all messages to the Kafka brokers.
+    #
+    # Depending on the value of `required_acks` used when initializing the producer,
+    # this call may block until the specified number of replicas have acknowledged
+    # the writes. The `timeout` setting places an upper bound on the amount of time
+    # the call will block before failing.
+    #
+    # @return [nil]
     def flush
       messages_for_broker = {}
 
@@ -50,6 +91,8 @@ module Kafka
       end
 
       @buffered_messages.clear
+
+      nil
     end
 
     def shutdown

--- a/lib/kafka/protocol/metadata_response.rb
+++ b/lib/kafka/protocol/metadata_response.rb
@@ -116,6 +116,11 @@ module Kafka
         @brokers.find {|broker| broker.node_id == node_id }
       end
 
+      def partitions_for(topic_name)
+        topic = @topics.find {|t| t.topic_name == topic_name }
+        topic.partitions
+      end
+
       # Decodes a MetadataResponse from a {Decoder} containing response data.
       #
       # @param decoder [Decoder]

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -14,4 +14,18 @@ describe "Producer API" do
 
     producer.flush
   end
+
+  example "having the producer assign partitions based on partition keys" do
+    producer.write("hello1", key: "x", topic: "test-messages", partition_key: "xk")
+    producer.write("hello2", key: "y", topic: "test-messages", partition_key: "yk")
+
+    producer.flush
+  end
+
+  example "having the producer assign partitions based on message keys" do
+    producer.write("hello1", key: "x", topic: "test-messages")
+    producer.write("hello2", key: "y", topic: "test-messages")
+
+    producer.flush
+  end
 end


### PR DESCRIPTION
If `Producer#write` is passed a `partition_key` parameter, it will be used to compute the partition to which the message will be written. If neither `partition` nor `partition_key` is specified, the message key will be used instead.

Implements #9.