### PR TITLE
Retry produce requests on node failure

### DIFF
--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -12,6 +12,8 @@ module Kafka
   LeaderNotAvailable = Class.new(Error)
   NotLeaderForPartition = Class.new(Error)
   RequestTimedOut = Class.new(Error)
+
+  # Raised if a replica is expected on a broker, but is not. Can be safely ignored.
   ReplicaNotAvailable = Class.new(Error)
 
   def self.new(**options)

--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -34,7 +34,12 @@ module Kafka
         Protocol.handle_error(topic.topic_error_code)
 
         topic.partitions.each do |partition|
-          Protocol.handle_error(partition.partition_error_code)
+          begin
+            Protocol.handle_error(partition.partition_error_code)
+          rescue ReplicaNotAvailable
+            # This error can be safely ignored per the protocol specification.
+            @logger.warn "Replica not available for topic #{topic.topic_name}, partition #{partition.partition_id}"
+          end
         end
       end
 

--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -8,6 +8,12 @@ module Kafka
   # partitions to the current leader for those partitions.
   class BrokerPool
 
+    # The number of times to try to connect to a broker before giving up.
+    MAX_CONNECTION_ATTEMPTS = 3
+
+    # The backoff period between connection retries, in seconds.
+    RETRY_BACKOFF_TIMEOUT = 5
+
     # Initializes a broker pool with a set of seed brokers.
     #
     # The pool will try to fetch cluster metadata from one of the brokers.
@@ -20,19 +26,83 @@ module Kafka
       @logger = logger
       @socket_timeout = socket_timeout
       @brokers = {}
+      @seed_brokers = seed_brokers
 
-      initialize_from_seed_brokers(seed_brokers)
+      refresh
     end
 
-    # Gets the leader of the given topic and partition.
+    # Refreshes the cluster metadata.
+    #
+    # This is used to update the partition leadership information, among other things.
+    # The methods will go through each node listed in `seed_brokers`, connecting to the
+    # first one that is available. This node will be queried for the cluster metadata.
+    #
+    # @raise [ConnectionError] if none of the nodes in `seed_brokers` are available.
+    # @return [nil]
+    def refresh
+      @seed_brokers.each do |node|
+        @logger.info "Trying to initialize broker pool from node #{node}"
+
+        begin
+          host, port = node.split(":", 2)
+
+          broker = Broker.connect(
+            host: host,
+            port: port.to_i,
+            client_id: @client_id,
+            socket_timeout: @socket_timeout,
+            logger: @logger,
+          )
+
+          @cluster_info = broker.fetch_metadata
+
+          @logger.info "Initialized broker pool with brokers: #{@cluster_info.brokers.inspect}"
+
+          return
+        rescue Error => e
+          @logger.error "Failed to fetch metadata from broker #{broker}: #{e}"
+        end
+      end
+
+      raise ConnectionError, "Could not connect to any of the seed brokers: #{@seed_brokers.inspect}"
+    end
+
+    # Finds the broker acting as the leader of the given topic and partition and connects to it.
+    #
+    # Note that this call may take a considerable amount of time, since the cached cluster
+    # metadata may be out of date. In that case, the cluster needs to be re-discovered. This
+    # can happen when a broker becomes unavailable, which would trigger a leader election for
+    # the partitions previously owned by that broker. Since this can take some time, this method
+    # will retry up to `MAX_CONNECTION_ATTEMPTS` times, waiting `RETRY_BACKOFF_TIMEOUT` seconds
+    # between each attempt.
     #
     # @param topic [String]
     # @param partition [Integer]
+    # @raise [ConnectionError] if it was not possible to connect to the leader.
     # @return [Broker] the broker that's currently acting as leader of the partition.
     def get_leader(topic, partition)
-      leader_id = @cluster_info.find_leader_id(topic, partition)
+      attempt = 0
 
-      broker_for_id(leader_id)
+      begin
+        leader_id = @cluster_info.find_leader_id(topic, partition)
+        broker_for_id(leader_id)
+      rescue ConnectionError => e
+        @logger.error "Failed to connect to leader for topic `#{topic}`, partition #{partition}"
+
+        if attempt < MAX_CONNECTION_ATTEMPTS
+          attempt += 1
+
+          @logger.info "Rediscovering cluster and retrying"
+
+          sleep RETRY_BACKOFF_TIMEOUT
+          refresh
+          retry
+        else
+          @logger.error "Giving up trying to find leader for topic `#{topic}`, partition #{partition}"
+
+          raise e
+        end
+      end
     end
 
     def partitions_for(topic)
@@ -63,34 +133,6 @@ module Kafka
         socket_timeout: @socket_timeout,
         logger: @logger,
       )
-    end
-
-    def initialize_from_seed_brokers(seed_brokers)
-      seed_brokers.each do |node|
-        @logger.info "Trying to initialize broker pool from node #{node}"
-
-        begin
-          host, port = node.split(":", 2)
-
-          broker = Broker.connect(
-            host: host,
-            port: port.to_i,
-            client_id: @client_id,
-            socket_timeout: @socket_timeout,
-            logger: @logger,
-          )
-
-          @cluster_info = broker.fetch_metadata
-
-          @logger.info "Initialized broker pool with brokers: #{@cluster_info.brokers.inspect}"
-
-          return
-        rescue Error => e
-          @logger.error "Failed to fetch metadata from broker #{broker}: #{e}"
-        end
-      end
-
-      raise ConnectionError, "Could not connect to any of the seed brokers: #{seed_brokers.inspect}"
     end
   end
 end

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -28,4 +28,20 @@ describe "Producer API" do
 
     producer.flush
   end
+
+  example "handle a broker going down after the initial discovery" do
+    begin
+      producer
+
+      KAFKA_CLUSTER.kill_kafka_broker(0)
+
+      producer.write("hello1", key: "x", topic: "test-messages", partition: 0)
+      producer.write("hello1", key: "x", topic: "test-messages", partition: 1)
+      producer.write("hello1", key: "x", topic: "test-messages", partition: 2)
+
+      producer.flush
+    ensure
+      KAFKA_CLUSTER.start_kafka_broker(0)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ KAFKA_TOPIC = "test-messages"
 
 KAFKA_CLUSTER = TestCluster.new
 KAFKA_CLUSTER.start
-KAFKA_CLUSTER.create_topic(KAFKA_TOPIC, num_partitions: 2)
+KAFKA_CLUSTER.create_topic(KAFKA_TOPIC, num_partitions: 3, num_replicas: 2)
 
 KAFKA_BROKERS = KAFKA_CLUSTER.kafka_hosts
 

--- a/spec/test_cluster.rb
+++ b/spec/test_cluster.rb
@@ -64,6 +64,18 @@ class TestCluster
     }
   end
 
+  def kill_kafka_broker(number)
+    broker = @kafka_brokers[number]
+    puts "Killing broker #{number}"
+    broker.kill
+  end
+
+  def start_kafka_broker(number)
+    broker = @kafka_brokers[number]
+    puts "Starting broker #{number}"
+    broker.start
+  end
+
   def create_topic(topic, num_partitions: 1, num_replicas: 1)
     command = [
       "/opt/kafka_2.10-0.8.2.0/bin/kafka-topics.sh",


### PR DESCRIPTION
When flushing messages to the cluster, we initially discover the leaders for the partitions we need to write to. If one of the leaders has become unavailable since we last discovered the cluster, we'll have to rediscover it to find out which nodes have taken over leadership of the partitions previously owned by that node. Then we can retry. Since leader election is not instantaneous, we need to back off before trying again.

There's still a chance that one of the nodes becomes unavailable between the time we discover the partition leaders and the time we try to actually send the messages to those nodes – that case has not yet been handled, and is left for a future PR.