### PR TITLE
Log RETRY_BACKOFF_TIMEOUT

### DIFF
--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -92,7 +92,7 @@ module Kafka
         if attempt < MAX_CONNECTION_ATTEMPTS
           attempt += 1
 
-          @logger.info "Rediscovering cluster and retrying"
+          @logger.info "Rediscovering cluster and retrying in #{RETRY_BACKOFF_TIMEOUT} second(s)"
 
           sleep RETRY_BACKOFF_TIMEOUT
           refresh


### PR DESCRIPTION
A small PR to add the used RETRY_BACKOFF_TIMEOUT in the logs.

Tests are green locally.

@dasch 