### PR TITLE
Make message keys optional

### DIFF
--- a/lib/kafka/partitioner.rb
+++ b/lib/kafka/partitioner.rb
@@ -1,13 +1,28 @@
 require "zlib"
 
 module Kafka
+
+  # Assigns partitions to messages.
   class Partitioner
     def initialize(partitions)
       @partitions = partitions
     end
 
+    # Assigns a partition number based on a key.
+    #
+    # If the key is nil, then a random partition is selected. Otherwise, a digest
+    # of the key is used to deterministically find a partition. As long as the
+    # number of partitions doesn't change, the same key will always be assigned
+    # to the same partition.
+    #
+    # @param key [String, nil] the key to base the partition assignment on, or nil.
+    # @return [Integer] the partition number.
     def partition_for_key(key)
-      Zlib.crc32(key) % @partitions.count
+      if key.nil?
+        rand(@partitions.count)
+      else
+        Zlib.crc32(key) % @partitions.count
+      end
     end
   end
 end

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -22,13 +22,20 @@ module Kafka
     # == Partitioning
     #
     # There are several options for specifying the partition that the message should
-    # be written to. The simplest option is to not specify a partition or partition
-    # key, in which case the message key will be used to select one of the available
-    # partitions. You can also specify the `partition` parameter yourself. This
-    # requires you to know which partitions are available, however. Oftentimes the
-    # best option is to specify the `partition_key` parameter: messages with the
-    # same partition key will always be assigned to the same partition, as long as
-    # the number of partitions doesn't change.
+    # be written to.
+    #
+    # The simplest option is to not specify a message key, partition key, or
+    # partition number, in which case the message will be assigned a partition at
+    # random.
+    #
+    # You can also specify the `partition` parameter yourself. This requires you to
+    # know which partitions are available, however. Oftentimes the best option is
+    # to specify the `partition_key` parameter: messages with the same partition
+    # key will always be assigned to the same partition, as long as the number of
+    # partitions doesn't change. You can also omit the partition key and specify
+    # a message key instead. The message key is part of the message payload, and
+    # so can carry semantic value--whether you want to have the message key double
+    # as a partition key is up to you.
     #
     # @param value [String] the message data.
     # @param key [String] the message key.
@@ -37,7 +44,7 @@ module Kafka
     # @param partition_key [String] the key that should be used to assign a partition.
     #
     # @return [nil]
-    def write(value, key:, topic:, partition: nil, partition_key: nil)
+    def write(value, key: nil, topic:, partition: nil, partition_key: nil)
       if partition.nil?
         # If no explicit partition key is specified we use the message key instead.
         partition_key ||= key

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -31,6 +31,13 @@ describe "Producer API" do
     producer.flush
   end
 
+  example "omitting message keys entirely" do
+    producer.write("hello1", topic: "test-messages")
+    producer.write("hello2", topic: "test-messages")
+
+    producer.flush
+  end
+
   example "handle a broker going down after the initial discovery" do
     begin
       producer

--- a/spec/partitioner_spec.rb
+++ b/spec/partitioner_spec.rb
@@ -1,0 +1,13 @@
+describe Kafka::Partitioner, "#partition_for_key" do
+  let(:partitioner) { Kafka::Partitioner.new([0, 1, 2]) }
+
+  it "deterministically returns a partition number for a given key and number of partitions" do
+    partition = partitioner.partition_for_key("yolo")
+    expect(partition).to eq 0
+  end
+
+  it "randomly picks a partition if the key is nil" do
+    partitions = 30.times.map { partitioner.partition_for_key(nil) }
+    expect(partitions.uniq).to contain_exactly(0, 1, 2)
+  end
+end


### PR DESCRIPTION
If a message key is not passed, and there's no explicit partition or partition key specified either, the partition is picked at random.