### PR TITLE
Implement error handling and retry logic

### DIFF
--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -13,6 +13,9 @@ module Kafka
   NotLeaderForPartition = Class.new(Error)
   RequestTimedOut = Class.new(Error)
 
+  # Raised when a producer buffer has reached its maximum size.
+  BufferOverflow = Class.new(Error)
+
   # Raised if not all messages could be sent by a producer.
   FailedToSendMessages = Class.new(Error)
 

--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -13,6 +13,9 @@ module Kafka
   NotLeaderForPartition = Class.new(Error)
   RequestTimedOut = Class.new(Error)
 
+  # Raised if not all messages could be sent by a producer.
+  FailedToSendMessages = Class.new(Error)
+
   # Raised if a replica is expected on a broker, but is not. Can be safely ignored.
   ReplicaNotAvailable = Class.new(Error)
 

--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -60,7 +60,7 @@ module Kafka
 
           return
         rescue Error => e
-          @logger.error "Failed to fetch metadata from broker #{broker}: #{e}"
+          @logger.error "Failed to fetch metadata from #{node}: #{e}"
         end
       end
 

--- a/lib/kafka/message_buffer.rb
+++ b/lib/kafka/message_buffer.rb
@@ -20,6 +20,14 @@ module Kafka
       @buffer
     end
 
+    def size
+      @buffer.values.inject(0) {|sum, messages| messages.values.flatten.size + sum }
+    end
+
+    def empty?
+      @buffer.empty?
+    end
+
     def each
       @buffer.each do |topic, messages_for_topic|
         messages_for_topic.each do |partition, messages_for_partition|

--- a/lib/kafka/message_buffer.rb
+++ b/lib/kafka/message_buffer.rb
@@ -36,6 +36,20 @@ module Kafka
       end
     end
 
+    # Clears buffered messages for the given topic and partition.
+    #
+    # @param topic [String] the name of the topic.
+    # @param partition [Integer] the partition id.
+    #
+    # @return [nil]
+    def clear_messages(topic:, partition:)
+      @buffer[topic].delete(partition)
+      @buffer.delete(topic) if @buffer[topic].empty?
+    end
+
+    # Clears messages across all topics and partitions.
+    #
+    # @return [nil]
     def clear
       @buffer = {}
     end

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -131,7 +131,11 @@ module Kafka
         @buffer.clear
       end
 
-      nil
+      unless @buffer.empty?
+        partitions = @buffer.map {|topic, partition, _| "#{topic}/#{partition}" }.join(", ")
+
+        raise FailedToSendMessages, "Failed to send messages to #{partitions}"
+      end
     end
 
     # Returns the number of messages currently held in the buffer.

--- a/lib/kafka/protocol/produce_response.rb
+++ b/lib/kafka/protocol/produce_response.rb
@@ -26,6 +26,14 @@ module Kafka
         @topics = topics
       end
 
+      def each_partition
+        @topics.each do |topic_info|
+          topic_info.partitions.each do |partition_info|
+            yield topic_info, partition_info
+          end
+        end
+      end
+
       def self.decode(decoder)
         topics = decoder.array do
           topic = decoder.string

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -2,7 +2,7 @@ describe "Producer API", type: :functional do
   let(:logger) { Logger.new(log) }
   let(:log) { LOG }
   let(:kafka) { Kafka.new(seed_brokers: KAFKA_BROKERS, client_id: "test", logger: logger) }
-  let(:producer) { kafka.get_producer }
+  let(:producer) { kafka.get_producer(max_retries: 1, retry_backoff: 0) }
 
   before do
     require "test_cluster"
@@ -46,6 +46,7 @@ describe "Producer API", type: :functional do
 
       KAFKA_CLUSTER.kill_kafka_broker(0)
 
+      # Write to all partitions so that we'll be sure to hit the broker.
       producer.write("hello1", key: "x", topic: "test-messages", partition: 0)
       producer.write("hello1", key: "x", topic: "test-messages", partition: 1)
       producer.write("hello1", key: "x", topic: "test-messages", partition: 2)

--- a/spec/message_buffer_spec.rb
+++ b/spec/message_buffer_spec.rb
@@ -1,0 +1,11 @@
+describe Kafka::MessageBuffer do
+  describe "#size" do
+    it "returns the number of messages in the buffer" do
+      buffer = Kafka::MessageBuffer.new
+      buffer.concat(["a", "b", "c"], topic: "foo", partition: 3)
+      buffer.concat(["a", "b", "c"], topic: "bar", partition: 1)
+
+      expect(buffer.size).to eq 6
+    end
+  end
+end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -122,7 +122,8 @@ describe Kafka::Producer do
       allow(broker_pool).to receive(:get_leader).with("greetings", 0) { broker }
 
       producer.write("hello1", topic: "greetings", partition: 0)
-      producer.flush
+
+      expect { producer.flush }.to raise_error(Kafka::FailedToSendMessages)
 
       # The producer was not able to write the message, but it's still buffered.
       expect(producer.buffer_size).to eq 1

--- a/spec/test_cluster.rb
+++ b/spec/test_cluster.rb
@@ -92,7 +92,7 @@ class TestCluster
       "--zookeeper zk",
     ]
 
-    puts "creating topic #{topic}..."
+    puts "Creating topic #{topic}..."
     out, err, status = @kafka.exec(command)
 
     raise "Command failed: #{out}" if status != 0


### PR DESCRIPTION
See the code documentation for a description of the design. If you have questions, I'd like to answer them in the docs rather than here :-)

I'd like to get some feedback on the design of the error handling. Specifically the way the buffer is used. In the current design, calling `flush` would never fail with an exception – rather, a bunch of errors would be logged and the buffer would retain all messages that could not be written. Alternatively, `flush` could raise an exception if any messages are left in the buffer after all attempts have been exhausted, but I'm not sure what the value of that would be. For us at least, it would be better to just keep running.

I'll have to implement a max buffer size, though, so eventually the client code would run into trouble. But with sufficient logging, I feel that that's the right way to go: make sure there's some time for the cluster to heal in case of availability issues.