### PR TITLE
Consolidate metadata refresh policy

### DIFF
--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -8,12 +8,6 @@ module Kafka
   # partitions to the current leader for those partitions.
   class BrokerPool
 
-    # The number of times to try to connect to a broker before giving up.
-    MAX_CONNECTION_ATTEMPTS = 3
-
-    # The backoff period between connection retries, in seconds.
-    RETRY_BACKOFF_TIMEOUT = 5
-
     # Initializes a broker pool with a set of seed brokers.
     #
     # The pool will try to fetch cluster metadata from one of the brokers.
@@ -27,19 +21,52 @@ module Kafka
       @socket_timeout = socket_timeout
       @brokers = {}
       @seed_brokers = seed_brokers
-
-      refresh
+      @cluster_info = nil
     end
 
-    # Refreshes the cluster metadata.
+    def mark_as_stale!
+      @cluster_info = nil
+    end
+
+    # Finds the broker acting as the leader of the given topic and partition.
+    #
+    # @param topic [String]
+    # @param partition [Integer]
+    # @return [Integer] the broker id.
+    def get_leader_id(topic, partition)
+      cluster_info.find_leader_id(topic, partition)
+    end
+
+    def get_broker(broker_id)
+      @brokers[broker_id] ||= connect_to_broker(broker_id)
+    end
+
+    def partitions_for(topic)
+      cluster_info.partitions_for(topic)
+    end
+
+    def shutdown
+      @brokers.each do |id, broker|
+        @logger.info "Disconnecting broker #{id}"
+        broker.disconnect
+      end
+    end
+
+    private
+
+    def cluster_info
+      @cluster_info ||= fetch_cluster_info
+    end
+
+    # Fetches the cluster metadata.
     #
     # This is used to update the partition leadership information, among other things.
     # The methods will go through each node listed in +seed_brokers+, connecting to the
     # first one that is available. This node will be queried for the cluster metadata.
     #
     # @raise [ConnectionError] if none of the nodes in +seed_brokers+ are available.
-    # @return [nil]
-    def refresh
+    # @return [Protocol::MetadataResponse] the cluster metadata.
+    def fetch_cluster_info
       @seed_brokers.each do |node|
         @logger.info "Trying to initialize broker pool from node #{node}"
 
@@ -54,11 +81,11 @@ module Kafka
             logger: @logger,
           )
 
-          @cluster_info = broker.fetch_metadata
+          cluster_info = broker.fetch_metadata
 
-          @logger.info "Initialized broker pool with brokers: #{@cluster_info.brokers.inspect}"
+          @logger.info "Initialized broker pool with brokers: #{cluster_info.brokers.inspect}"
 
-          return
+          return cluster_info
         rescue Error => e
           @logger.error "Failed to fetch metadata from #{node}: #{e}"
         end
@@ -67,63 +94,8 @@ module Kafka
       raise ConnectionError, "Could not connect to any of the seed brokers: #{@seed_brokers.inspect}"
     end
 
-    # Finds the broker acting as the leader of the given topic and partition and connects to it.
-    #
-    # Note that this call may take a considerable amount of time, since the cached cluster
-    # metadata may be out of date. In that case, the cluster needs to be re-discovered. This
-    # can happen when a broker becomes unavailable, which would trigger a leader election for
-    # the partitions previously owned by that broker. Since this can take some time, this method
-    # will retry up to +MAX_CONNECTION_ATTEMPTS+ times, waiting +RETRY_BACKOFF_TIMEOUT+ seconds
-    # between each attempt.
-    #
-    # @param topic [String]
-    # @param partition [Integer]
-    # @raise [ConnectionError] if it was not possible to connect to the leader.
-    # @return [Broker] the broker that's currently acting as leader of the partition.
-    def get_leader(topic, partition)
-      attempt = 0
-
-      begin
-        leader_id = @cluster_info.find_leader_id(topic, partition)
-        broker_for_id(leader_id)
-      rescue ConnectionError => e
-        @logger.error "Failed to connect to leader for topic `#{topic}`, partition #{partition}"
-
-        if attempt < MAX_CONNECTION_ATTEMPTS
-          attempt += 1
-
-          @logger.info "Rediscovering cluster and retrying in #{RETRY_BACKOFF_TIMEOUT} second(s)"
-
-          sleep RETRY_BACKOFF_TIMEOUT
-          refresh
-          retry
-        else
-          @logger.error "Giving up trying to find leader for topic `#{topic}`, partition #{partition}"
-
-          raise e
-        end
-      end
-    end
-
-    def partitions_for(topic)
-      @cluster_info.partitions_for(topic)
-    end
-
-    def shutdown
-      @brokers.each do |id, broker|
-        @logger.info "Disconnecting broker #{id}"
-        broker.disconnect
-      end
-    end
-
-    private
-
-    def broker_for_id(broker_id)
-      @brokers[broker_id] ||= connect_to_broker(broker_id)
-    end
-
     def connect_to_broker(broker_id)
-      broker_info = @cluster_info.find_broker(broker_id)
+      broker_info = cluster_info.find_broker(broker_id)
 
       Broker.connect(
         host: broker_info.host,

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -217,8 +217,10 @@ module Kafka
           @logger.error "Unknown topic or partition #{topic}/#{partition}"
         rescue Kafka::LeaderNotAvailable
           @logger.error "Leader currently not available for #{topic}/#{partition}"
+          @broker_pool.mark_as_stale!
         rescue Kafka::NotLeaderForPartition
           @logger.error "Broker not currently leader for #{topic}/#{partition}"
+          @broker_pool.mark_as_stale!
         rescue Kafka::RequestTimedOut
           @logger.error "Timed out while writing to #{topic}/#{partition}"
         rescue Kafka::NotEnoughReplicas

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -42,7 +42,7 @@ describe "Producer API", type: :functional do
 
   example "handle a broker going down after the initial discovery" do
     begin
-      producer
+      producer = kafka.get_producer(max_retries: 3, retry_backoff: 5)
 
       KAFKA_CLUSTER.kill_kafka_broker(0)
 

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -14,6 +14,8 @@ describe Kafka::Producer do
   }
 
   before do
+    allow(broker_pool).to receive(:mark_as_stale!)
+
     allow(broker_pool).to receive(:get_leader_id).with("greetings", 0) { 1 }
     allow(broker_pool).to receive(:get_leader_id).with("greetings", 1) { 2 }
 


### PR DESCRIPTION
Rather than having BrokerPool handle connection retries we should consolidate that logic in Producer in order to avoid nested retry loops. Furthermore, by moving connection error handling into the existing Producer retry loop we can more intelligently control when to refresh the cluster metadata. This is now done when some response errors are encountered, as well.