### PR TITLE
Use low-lever socket timeouts

### DIFF
--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -1,5 +1,5 @@
-require "socket"
 require "stringio"
+require "kafka/socket_with_timeout"
 require "kafka/protocol/request_message"
 require "kafka/protocol/encoder"
 require "kafka/protocol/decoder"
@@ -38,7 +38,7 @@ module Kafka
 
       @logger.info "Opening connection to #{@host}:#{@port} with client id #{@client_id}..."
 
-      @socket = Socket.tcp(host, port, connect_timeout: @connect_timeout)
+      @socket = SocketWithTimeout.open(@host, @port, timeout: @connect_timeout)
 
       @encoder = Kafka::Protocol::Encoder.new(@socket)
       @decoder = Kafka::Protocol::Decoder.new(@socket)

--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -38,7 +38,7 @@ module Kafka
 
       @logger.info "Opening connection to #{@host}:#{@port} with client id #{@client_id}..."
 
-      @socket = SocketWithTimeout.open(@host, @port, timeout: @connect_timeout)
+      @socket = SocketWithTimeout.new(@host, @port, timeout: @connect_timeout)
 
       @encoder = Kafka::Protocol::Encoder.new(@socket)
       @decoder = Kafka::Protocol::Decoder.new(@socket)
@@ -112,14 +112,12 @@ module Kafka
 
       data = Kafka::Protocol::Encoder.encode_with(message)
 
-      unless IO.select(nil, [@socket], nil, @socket_timeout)
-        @logger.error "Timed out while writing request #{@correlation_id}"
-        raise ConnectionError
-      end
-
       @encoder.write_bytes(data)
 
       nil
+    rescue Errno::ETIMEDOUT
+      @logger.error "Timed out while writing request #{@correlation_id}"
+      raise ConnectionError
     end
 
     # Reads a response from the connection.
@@ -130,11 +128,6 @@ module Kafka
     # @return [nil]
     def read_response(response_class)
       @logger.debug "Waiting for response #{@correlation_id} from #{to_s}"
-
-      unless IO.select([@socket], nil, nil, @socket_timeout)
-        @logger.error "Timed out while waiting for response #{@correlation_id}"
-        raise ConnectionError
-      end
 
       bytes = @decoder.bytes
 
@@ -147,6 +140,9 @@ module Kafka
       @logger.debug "Received response #{correlation_id} from #{to_s}"
 
       return correlation_id, response
+    rescue Errno::ETIMEDOUT
+      @logger.error "Timed out while waiting for response #{@correlation_id}"
+      raise ConnectionError
     end
   end
 end

--- a/lib/kafka/socket_with_timeout.rb
+++ b/lib/kafka/socket_with_timeout.rb
@@ -4,7 +4,7 @@ module Kafka
 
   # Opens sockets in a non-blocking fashion, ensuring that we're not stalling
   # for long periods of time waiting for a connection to open.
-  module SocketWithTimeout
+  class SocketWithTimeout
 
     # Opens a socket.
     #
@@ -12,37 +12,59 @@ module Kafka
     # @param port [Integer]
     # @param timeout [Integer] the connection timeout, in seconds.
     # @return [TCPSocket] the open socket.
-    def self.open(host, port, timeout: nil)
+    def initialize(host, port, timeout: nil)
       addr = Socket.getaddrinfo(host, nil)
       sockaddr = Socket.pack_sockaddr_in(port, addr[0][3])
 
-      socket = Socket.new(Socket.const_get(addr[0][0]), Socket::SOCK_STREAM, 0)
-      socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+      @socket = Socket.new(Socket.const_get(addr[0][0]), Socket::SOCK_STREAM, 0)
+      @socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
 
       begin
         # Initiate the socket connection in the background. If it doesn't fail 
         # immediately it will raise an IO::WaitWritable (Errno::EINPROGRESS) 
         # indicating the connection is in progress.
-        socket.connect_nonblock(sockaddr)
+        @socket.connect_nonblock(sockaddr)
       rescue IO::WaitWritable
         # IO.select will block until the socket is writable or the timeout
         # is exceeded, whichever comes first.
-        unless IO.select(nil, [socket], nil, timeout)
+        unless IO.select(nil, [@socket], nil, timeout)
           # IO.select returns nil when the socket is not ready before timeout 
           # seconds have elapsed
-          socket.close
+          @socket.close
           raise Errno::ETIMEDOUT
         end
 
         begin
           # Verify there is now a good connection.
-          socket.connect_nonblock(sockaddr)
+          @socket.connect_nonblock(sockaddr)
         rescue Errno::EISCONN
           # The socket is connected, we're good!
         end
       end
+    end
 
-      socket
+    def read(num_bytes, timeout: nil)
+      unless IO.select([@socket], nil, nil, timeout)
+        raise Errno::ETIMEDOUT
+      end
+
+      @socket.read(num_bytes)
+    end
+
+    def write(bytes, timeout: nil)
+      unless IO.select(nil, [@socket], nil, timeout)
+        raise Errno::ETIMEDOUT
+      end
+
+      @socket.write(bytes)
+    end
+
+    def close
+      @socket.close
+    end
+
+    def set_encoding(encoding)
+      @socket.set_encoding(encoding)
     end
   end
 end

--- a/lib/kafka/socket_with_timeout.rb
+++ b/lib/kafka/socket_with_timeout.rb
@@ -1,0 +1,48 @@
+require "socket"
+
+module Kafka
+
+  # Opens sockets in a non-blocking fashion, ensuring that we're not stalling
+  # for long periods of time waiting for a connection to open.
+  module SocketWithTimeout
+
+    # Opens a socket.
+    #
+    # @param host [String]
+    # @param port [Integer]
+    # @param timeout [Integer] the connection timeout, in seconds.
+    # @return [TCPSocket] the open socket.
+    def self.open(host, port, timeout: nil)
+      addr = Socket.getaddrinfo(host, nil)
+      sockaddr = Socket.pack_sockaddr_in(port, addr[0][3])
+
+      socket = Socket.new(Socket.const_get(addr[0][0]), Socket::SOCK_STREAM, 0)
+      socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+
+      begin
+        # Initiate the socket connection in the background. If it doesn't fail 
+        # immediately it will raise an IO::WaitWritable (Errno::EINPROGRESS) 
+        # indicating the connection is in progress.
+        socket.connect_nonblock(sockaddr)
+      rescue IO::WaitWritable
+        # IO.select will block until the socket is writable or the timeout
+        # is exceeded, whichever comes first.
+        unless IO.select(nil, [socket], nil, timeout)
+          # IO.select returns nil when the socket is not ready before timeout 
+          # seconds have elapsed
+          socket.close
+          raise Errno::ETIMEDOUT
+        end
+
+        begin
+          # Verify there is now a good connection.
+          socket.connect_nonblock(sockaddr)
+        rescue Errno::EISCONN
+          # The socket is connected, we're good!
+        end
+      end
+
+      socket
+    end
+  end
+end

--- a/spec/socket_with_timeout_spec.rb
+++ b/spec/socket_with_timeout_spec.rb
@@ -1,0 +1,19 @@
+describe Kafka::SocketWithTimeout, ".open" do
+  it "times out if the server doesn't accept the connection within the timeout" do
+    host = "10.255.255.1" # this address is non-routable!
+    port = 4444
+
+    timeout = 0.1
+    allowed_time = timeout + 0.1
+
+    start = Time.now
+
+    expect {
+      Kafka::SocketWithTimeout.open(host, port, timeout: timeout)
+    }.to raise_exception(Errno::ETIMEDOUT)
+
+    finish = Time.now
+
+    expect(finish - start).to be < allowed_time
+  end
+end

--- a/spec/socket_with_timeout_spec.rb
+++ b/spec/socket_with_timeout_spec.rb
@@ -9,11 +9,34 @@ describe Kafka::SocketWithTimeout, ".open" do
     start = Time.now
 
     expect {
-      Kafka::SocketWithTimeout.open(host, port, timeout: timeout)
+      Kafka::SocketWithTimeout.new(host, port, timeout: timeout)
     }.to raise_exception(Errno::ETIMEDOUT)
 
     finish = Time.now
 
     expect(finish - start).to be < allowed_time
+  end
+
+  describe "#read" do
+    it "times out after the specified amount of time" do
+      host = "localhost"
+      server = TCPServer.new(host, 0)
+      port = server.addr[1]
+
+      timeout = 0.1
+      allowed_time = timeout + 0.1
+
+      socket = Kafka::SocketWithTimeout.new(host, port, timeout: 1)
+
+      start = Time.now
+
+      expect {
+        socket.read(4, timeout: timeout)
+      }.to raise_exception(Errno::ETIMEDOUT)
+
+      finish = Time.now
+
+      expect(finish - start).to be < allowed_time
+    end
   end
 end


### PR DESCRIPTION
`Socket.tcp` with a connection timeout value yields horrible performance. Replacing it with a non-blocking socket and `IO.select` improves latency by an order of magnitude.

In addition to this, network timeout related code is now centralized in SocketWithTimeout.