### PR TITLE
Handle flaky network conditions

### DIFF
--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -102,7 +102,7 @@ module Kafka
           end
         end
       end
-    rescue Errno::EPIPE, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+    rescue Errno::EPIPE, Errno::ECONNRESET, Errno::ETIMEDOUT, EOFError => e
       @logger.error "Connection error: #{e}"
 
       close

--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -38,7 +38,15 @@ module Kafka
 
       @logger.info "Opening connection to #{@host}:#{@port} with client id #{@client_id}..."
 
-      @socket = SocketWithTimeout.new(@host, @port, timeout: @connect_timeout)
+      connect
+    end
+
+    def to_s
+      "#{@host}:#{@port}"
+    end
+
+    def connect
+      @socket = SocketWithTimeout.new(@host, @port, connect_timeout: @connect_timeout, timeout: @socket_timeout)
 
       @encoder = Kafka::Protocol::Encoder.new(@socket)
       @decoder = Kafka::Protocol::Decoder.new(@socket)
@@ -46,20 +54,23 @@ module Kafka
       # Correlation id is initialized to zero and bumped for each request.
       @correlation_id = 0
     rescue Errno::ETIMEDOUT => e
-      @logger.error "Timed out while trying to connect to #{host}:#{port}: #{e}"
+      @logger.error "Timed out while trying to connect to #{self}: #{e}"
       raise ConnectionError, e
     rescue SocketError, Errno::ECONNREFUSED => e
-      @logger.error "Failed to connect to #{host}:#{port}: #{e}"
+      @logger.error "Failed to connect to #{self}: #{e}"
       raise ConnectionError, e
     end
 
-    def to_s
-      "#{@host}:#{@port}"
+    def connected?
+      !@socket.nil?
     end
 
     def close
       @logger.debug "Closing socket to #{to_s}"
-      @socket.close
+
+      @socket.close if @socket
+
+      @socket = nil
     end
 
     # Sends a request over the connection.
@@ -70,6 +81,8 @@ module Kafka
     #
     # @return [Object] the response that was decoded by `response_class`.
     def request(api_key, request, response_class)
+      connect unless connected?
+
       write_request(api_key, request)
 
       unless response_class.nil?
@@ -89,6 +102,12 @@ module Kafka
           end
         end
       end
+    rescue Errno::EPIPE, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+      @logger.error "Connection error: #{e}"
+
+      close
+
+      raise ConnectionError, "Connection error: #{e}"
     end
 
     private
@@ -117,7 +136,7 @@ module Kafka
       nil
     rescue Errno::ETIMEDOUT
       @logger.error "Timed out while writing request #{@correlation_id}"
-      raise ConnectionError
+      raise
     end
 
     # Reads a response from the connection.
@@ -142,7 +161,7 @@ module Kafka
       return correlation_id, response
     rescue Errno::ETIMEDOUT
       @logger.error "Timed out while waiting for response #{@correlation_id}"
-      raise ConnectionError
+      raise
     end
   end
 end

--- a/lib/kafka/protocol/decoder.rb
+++ b/lib/kafka/protocol/decoder.rb
@@ -85,7 +85,7 @@ module Kafka
       #
       # @return [String]
       def read(number_of_bytes)
-        @io.read(number_of_bytes)
+        @io.read(number_of_bytes) or raise EOFError
       end
     end
   end

--- a/spec/socket_with_timeout_spec.rb
+++ b/spec/socket_with_timeout_spec.rb
@@ -9,7 +9,7 @@ describe Kafka::SocketWithTimeout, ".open" do
     start = Time.now
 
     expect {
-      Kafka::SocketWithTimeout.new(host, port, timeout: timeout)
+      Kafka::SocketWithTimeout.new(host, port, connect_timeout: timeout, timeout: 1)
     }.to raise_exception(Errno::ETIMEDOUT)
 
     finish = Time.now
@@ -26,12 +26,12 @@ describe Kafka::SocketWithTimeout, ".open" do
       timeout = 0.1
       allowed_time = timeout + 0.1
 
-      socket = Kafka::SocketWithTimeout.new(host, port, timeout: 1)
+      socket = Kafka::SocketWithTimeout.new(host, port, connect_timeout: 1, timeout: timeout)
 
       start = Time.now
 
       expect {
-        socket.read(4, timeout: timeout)
+        socket.read(4)
       }.to raise_exception(Errno::ETIMEDOUT)
 
       finish = Time.now


### PR DESCRIPTION
We ran into an issue in our staging environment where network connection errors caused `Errno::EPIPE` to be raised from `Socket#read`. This was not handled gracefully, and the error propagated up through the stack.

This PR contains a few fixes:

* Before, socket timeouts were not being properly set. This was discovered during testing.
* Sockets can no longer get into a bad state. Rather, if they raise an exception they're closed and discarded, and a new one will be opened the next time a connection is used.
* Gracefully handle unexpectedly reaching the end of a buffer when reading a response.