### PR TITLE
Allow fetching messages from a specific partition

### DIFF
--- a/examples/simple-consumer.rb
+++ b/examples/simple-consumer.rb
@@ -1,0 +1,48 @@
+# Consumes lines from a Kafka partition and writes them to STDOUT.
+#
+# You need to define the environment variable KAFKA_BROKERS for this
+# to work, e.g.
+#
+#     export KAFKA_BROKERS=localhost:9092
+#
+
+$LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
+
+require "kafka"
+
+# We don't want log output to clutter the console. Replace `StringIO.new`
+# with e.g. `$stderr` if you want to see what's happening under the hood.
+logger = Logger.new(StringIO.new)
+
+brokers = ENV.fetch("KAFKA_BROKERS").split(",")
+
+# Make sure to create this topic in your Kafka cluster or configure the
+# cluster to auto-create topics.
+topic = "text"
+
+kafka = Kafka.new(
+  seed_brokers: brokers,
+  client_id: "simple-consumer",
+  socket_timeout: 20,
+  logger: logger,
+)
+
+begin
+  offset = :latest
+  partition = 0
+
+  loop do
+    messages = kafka.fetch_messages(
+      topic: topic,
+      partition: partition,
+      offset: offset
+    )
+
+    messages.each do |message|
+      puts message.value
+      offset = message.offset + 1
+    end
+  end
+ensure
+  kafka.close
+end

--- a/examples/simple-producer.rb
+++ b/examples/simple-producer.rb
@@ -1,4 +1,10 @@
 # Reads lines from STDIN, writing them to Kafka.
+#
+# You need to define the environment variable KAFKA_BROKERS for this
+# to work, e.g.
+#
+#     export KAFKA_BROKERS=localhost:9092
+#
 
 $LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
 
@@ -9,7 +15,7 @@ brokers = ENV.fetch("KAFKA_BROKERS").split(",")
 
 # Make sure to create this topic in your Kafka cluster or configure the
 # cluster to auto-create topics.
-topic = "random-messages"
+topic = "text"
 
 kafka = Kafka.new(
   seed_brokers: brokers,

--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -30,6 +30,20 @@ module Kafka
       @connection.send_request(request, response_class)
     end
 
+    def fetch_messages(**options)
+      request = Protocol::FetchRequest.new(**options)
+      response_class = Protocol::FetchResponse
+
+      @connection.send_request(request, response_class)
+    end
+
+    def list_offsets(**options)
+      request = Protocol::ListOffsetRequest.new(**options)
+      response_class = Protocol::ListOffsetResponse
+
+      @connection.send_request(request, response_class)
+    end
+
     def produce(**options)
       request = Protocol::ProduceRequest.new(**options)
       response_class = request.requires_acks? ? Protocol::ProduceResponse : nil

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -1,5 +1,6 @@
 require "kafka/broker_pool"
 require "kafka/producer"
+require "kafka/fetched_message"
 
 module Kafka
   class Client
@@ -38,9 +39,107 @@ module Kafka
     # `options` are passed to {Producer#initialize}.
     #
     # @see Producer#initialize
-    # @return [Producer] the Kafka producer.
+    # @return [Kafka::Producer] the Kafka producer.
     def get_producer(**options)
       Producer.new(broker_pool: @broker_pool, logger: @logger, **options)
+    end
+
+    # Fetches a batch of messages from a single partition. Note that it's possible
+    # to get back empty batches.
+    #
+    # The starting point for the fetch can be configured with the `:offset` argument.
+    # If you pass a number, the fetch will start at that offset. However, there are
+    # two special Symbol values that can be passed instead:
+    #
+    # * `:earliest` — the first offset in the partition.
+    # * `:latest` — the next offset that will be written to, effectively making the
+    #   call block until there is a new message in the partition.
+    #
+    # The Kafka protocol specifies the numeric values of these two options: -2 and -1,
+    # respectively. You can also pass in these numbers directly.
+    #
+    # ## Example
+    #
+    # When enumerating the messages in a partition, you typically fetch batches
+    # sequentially.
+    #
+    #     offset = :earliest
+    #
+    #     loop do
+    #       messages = kafka.fetch_messages(
+    #         topic: "my-topic",
+    #         partition: 42,
+    #         offset: offset,
+    #       )
+    #
+    #       messages.each do |message|
+    #         puts message.offset, message.key, message.value
+    #
+    #         # Set the next offset that should be read to be the subsequent
+    #         # offset.
+    #         offset = message.offset + 1
+    #       end
+    #     end
+    #
+    # See a working example in `examples/simple-consumer.rb`.
+    #
+    # @note This API is still alpha level. Don't try to use it in production.
+    #
+    # @param topic [String] the topic that messages should be fetched from.
+    #
+    # @param partition [Integer] the partition that messages should be fetched from.
+    #
+    # @param offset [Integer, Symbol] the offset to start reading from. Default is
+    #   the latest offset.
+    #
+    # @param max_wait_time [Integer] the maximum amount of time to wait before
+    #   the server responds.
+    #
+    # @param min_bytes [Integer] the minimum number of bytes to wait for. If set to
+    #   zero, the broker will respond immediately, but the response may be empty.
+    #   The default is 1 byte, which means that the broker will respond as soon as
+    #   a message is written to the partition.
+    #
+    # @param max_bytes [Integer] the maximum number of bytes to include in the
+    #   response message set. Default is 1 MB. You need to set this higher if you
+    #   expect messages to be larger than this.
+    #
+    # @return [Array<Kafka::FetchedMessage>] the messages returned from the broker.
+    def fetch_messages(topic:, partition:, offset: :latest, max_wait_time: 10, min_bytes: 1, max_bytes: 1048576)
+      broker = @broker_pool.get_leader(topic, partition)
+
+      offset = resolve_offset(topic, partition, offset, broker)
+
+      options = {
+        max_wait_time: max_wait_time * 1000, # Kafka expects ms, not secs
+        min_bytes: min_bytes,
+        topics: {
+          topic => {
+            partition => {
+              fetch_offset: offset,
+              max_bytes: max_bytes,
+            }
+          }
+        }
+      }
+
+      response = broker.fetch_messages(**options)
+
+      response.topics.map {|fetched_topic|
+        fetched_topic.partitions.map {|fetched_partition|
+          Protocol.handle_error(fetched_partition.error_code)
+
+          fetched_partition.messages.map {|offset, message|
+            FetchedMessage.new(
+              value: message.value,
+              key: message.key,
+              topic: fetched_topic.name,
+              partition: fetched_partition.partition,
+              offset: offset,
+            )
+          }
+        }
+      }.flatten
     end
 
     # Lists all topics in the cluster.
@@ -52,6 +151,37 @@ module Kafka
 
     def close
       @broker_pool.shutdown
+    end
+
+    private
+
+    def resolve_offset(topic, partition, logical_offset, broker)
+      if logical_offset == :earliest
+        offset = -2
+      elsif logical_offset == :latest
+        offset = -1
+      else
+        offset = logical_offset
+      end
+
+      # Positive offsets don't need resolving.
+      return offset if offset > 0
+
+      @logger.debug "Resolving offset `#{logical_offset}` for #{topic}/#{partition}..."
+
+      response = broker.list_offsets(
+        topics: {
+          topic => [
+            { partition: partition, time: offset, max_offsets: 1 }
+          ]
+        }
+      )
+
+      resolved_offset = response.offset_for(topic, partition)
+
+      @logger.debug "Offset `#{logical_offset}` for #{topic}/#{partition} is #{resolved_offset.inspect}"
+
+      resolved_offset || 0
     end
   end
 end

--- a/lib/kafka/fetched_message.rb
+++ b/lib/kafka/fetched_message.rb
@@ -1,0 +1,27 @@
+module Kafka
+  class FetchedMessage
+
+    # @return [String] the value of the message.
+    attr_reader :value
+
+    # @return [String] the key of the message.
+    attr_reader :key
+    
+    # @return [String] the name of the topic that the message was written to.
+    attr_reader :topic
+    
+    # @return [Integer] the partition number that the message was written to.
+    attr_reader :partition
+    
+    # @return [Integer] the offset of the message in the partition.
+    attr_reader :offset
+
+    def initialize(value:, key:, topic:, partition:, offset:)
+      @value = value
+      @key = key
+      @topic = topic
+      @partition = partition
+      @offset = offset
+    end
+  end
+end

--- a/lib/kafka/protocol.rb
+++ b/lib/kafka/protocol.rb
@@ -1,7 +1,12 @@
 module Kafka
   module Protocol
+    # The replica id of non-brokers is always -1.
+    REPLICA_ID = -1
+
     APIS = {
       0 => :produce,
+      1 => :fetch,
+      2 => :list_offset,
       3 => :topic_metadata,
     }
 
@@ -45,3 +50,7 @@ require "kafka/protocol/topic_metadata_request"
 require "kafka/protocol/metadata_response"
 require "kafka/protocol/produce_request"
 require "kafka/protocol/produce_response"
+require "kafka/protocol/fetch_request"
+require "kafka/protocol/fetch_response"
+require "kafka/protocol/list_offset_request"
+require "kafka/protocol/list_offset_response"

--- a/lib/kafka/protocol/decoder.rb
+++ b/lib/kafka/protocol/decoder.rb
@@ -5,12 +5,19 @@ module Kafka
     # from it. The Kafka protocol is not self-describing, so a client must call
     # these methods in just the right order for things to work.
     class Decoder
+      def self.from_string(str)
+        new(StringIO.new(str))
+      end
 
       # Initializes a new decoder.
       #
       # @param io [IO] an object that acts as an IO.
       def initialize(io)
         @io = io
+      end
+
+      def eof?
+        @io.eof?
       end
 
       # Decodes an 8-bit integer from the IO object.

--- a/lib/kafka/protocol/fetch_request.rb
+++ b/lib/kafka/protocol/fetch_request.rb
@@ -1,0 +1,49 @@
+module Kafka
+  module Protocol
+
+    # A request to fetch messages from a given partition.
+    #
+    # ## API Specification
+    #
+    #     FetchRequest => ReplicaId MaxWaitTime MinBytes [TopicName [Partition FetchOffset MaxBytes]]
+    #       ReplicaId => int32
+    #       MaxWaitTime => int32
+    #       MinBytes => int32
+    #       TopicName => string
+    #       Partition => int32
+    #       FetchOffset => int64
+    #       MaxBytes => int32
+    #
+    class FetchRequest
+      def initialize(max_wait_time:, min_bytes:, topics:)
+        @replica_id = REPLICA_ID
+        @max_wait_time = max_wait_time
+        @min_bytes = min_bytes
+        @topics = topics
+      end
+
+      def api_key
+        1
+      end
+
+      def encode(encoder)
+        encoder.write_int32(@replica_id)
+        encoder.write_int32(@max_wait_time)
+        encoder.write_int32(@min_bytes)
+
+        encoder.write_array(@topics) do |topic, partitions|
+          encoder.write_string(topic)
+
+          encoder.write_array(partitions) do |partition, config|
+            fetch_offset = config.fetch(:fetch_offset)
+            max_bytes = config.fetch(:max_bytes)
+
+            encoder.write_int32(partition)
+            encoder.write_int64(fetch_offset)
+            encoder.write_int32(max_bytes)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/fetch_response.rb
+++ b/lib/kafka/protocol/fetch_response.rb
@@ -1,0 +1,75 @@
+require "kafka/protocol/message_set"
+
+module Kafka
+  module Protocol
+
+    # A response to a fetch request.
+    #
+    # ## API Specification
+    #
+    #     FetchResponse => [TopicName [Partition ErrorCode HighwaterMarkOffset MessageSetSize MessageSet]]
+    #       TopicName => string
+    #       Partition => int32
+    #       ErrorCode => int16
+    #       HighwaterMarkOffset => int64
+    #       MessageSetSize => int32
+    #
+    class FetchResponse
+      class FetchedPartition
+        attr_reader :partition, :error_code
+        attr_reader :highwater_mark_offset, :messages
+
+        def initialize(partition:, error_code:, highwater_mark_offset:, messages:)
+          @partition = partition
+          @error_code = error_code
+          @highwater_mark_offset = highwater_mark_offset
+          @messages = messages
+        end
+      end
+
+      class FetchedTopic
+        attr_reader :name, :partitions
+
+        def initialize(name:, partitions:)
+          @name = name
+          @partitions = partitions
+        end
+      end
+
+      attr_reader :topics
+
+      def initialize(topics: [])
+        @topics = topics
+      end
+
+      def self.decode(decoder)
+        topics = decoder.array do
+          topic_name = decoder.string
+
+          partitions = decoder.array do
+            partition = decoder.int32
+            error_code = decoder.int16
+            highwater_mark_offset = decoder.int64
+
+            message_set_decoder = Decoder.from_string(decoder.bytes)
+            message_set = MessageSet.decode(message_set_decoder)
+
+            FetchedPartition.new(
+              partition: partition,
+              error_code: error_code,
+              highwater_mark_offset: highwater_mark_offset,
+              messages: message_set.messages,
+            )
+          end
+
+          FetchedTopic.new(
+            name: topic_name,
+            partitions: partitions,
+          )
+        end
+
+        new(topics: topics)
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/list_offset_request.rb
+++ b/lib/kafka/protocol/list_offset_request.rb
@@ -1,0 +1,39 @@
+module Kafka
+  module Protocol
+    # A request to list the available offsets for a set of topics/partitions.
+    #
+    # ## API Specification
+    #
+    #     OffsetRequest => ReplicaId [TopicName [Partition Time MaxNumberOfOffsets]]
+    #       ReplicaId => int32
+    #       TopicName => string
+    #       Partition => int32
+    #       Time => int64
+    #       MaxNumberOfOffsets => int32
+    #
+    class ListOffsetRequest
+      def initialize(topics:)
+        @replica_id = REPLICA_ID
+        @topics = topics
+      end
+
+      def api_key
+        2
+      end
+
+      def encode(encoder)
+        encoder.write_int32(@replica_id)
+
+        encoder.write_array(@topics) do |topic, partitions|
+          encoder.write_string(topic)
+
+          encoder.write_array(partitions) do |partition|
+            encoder.write_int32(partition.fetch(:partition))
+            encoder.write_int64(partition.fetch(:time))
+            encoder.write_int32(partition.fetch(:max_offsets))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/list_offset_response.rb
+++ b/lib/kafka/protocol/list_offset_response.rb
@@ -1,0 +1,74 @@
+module Kafka
+  module Protocol
+
+    # A response to a list offset request.
+    #
+    # ## API Specification
+    #
+    #     OffsetResponse => [TopicName [PartitionOffsets]]
+    #       PartitionOffsets => Partition ErrorCode [Offset]
+    #       Partition => int32
+    #       ErrorCode => int16
+    #       Offset => int64
+    #
+    class ListOffsetResponse
+      class TopicOffsetInfo
+        attr_reader :name, :partition_offsets
+
+        def initialize(name:, partition_offsets:)
+          @name = name
+          @partition_offsets = partition_offsets
+        end
+      end
+
+      class PartitionOffsetInfo
+        attr_reader :partition, :error_code, :offsets
+
+        def initialize(partition:, error_code:, offsets:)
+          @partition = partition
+          @error_code = error_code
+          @offsets = offsets
+        end
+      end
+
+      attr_reader :topics
+
+      def initialize(topics:)
+        @topics = topics
+      end
+
+      def offset_for(topic, partition)
+        topic_info = @topics.find {|t| t.name == topic }
+
+        partition_info = topic_info
+          .partition_offsets
+          .find {|p| p.partition == partition }
+
+        Protocol.handle_error(partition_info.error_code)
+
+        partition_info.offsets.first
+      end
+
+      def self.decode(decoder)
+        topics = decoder.array do
+          name = decoder.string
+
+          partition_offsets = decoder.array do
+            PartitionOffsetInfo.new(
+              partition: decoder.int32,
+              error_code: decoder.int16,
+              offsets: decoder.array { decoder.int64 },
+            )
+          end
+
+          TopicOffsetInfo.new(
+            name: name,
+            partition_offsets: partition_offsets
+          )
+        end
+
+        new(topics: topics)
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/message.rb
+++ b/lib/kafka/protocol/message.rb
@@ -36,6 +36,21 @@ module Kafka
         @key == other.key && @value == other.value && @attributes == other.attributes
       end
 
+      def self.decode(decoder)
+        crc = decoder.int32
+        magic_byte = decoder.int8
+
+        unless magic_byte == MAGIC_BYTE
+          raise Kafka::Error, "Invalid magic byte: #{magic_byte}"
+        end
+
+        attributes = decoder.int8
+        key = decoder.bytes
+        value = decoder.bytes
+
+        new(key: key, value: value, attributes: attributes)
+      end
+
       private
 
       def encode_without_crc

--- a/lib/kafka/protocol/message_set.rb
+++ b/lib/kafka/protocol/message_set.rb
@@ -1,0 +1,25 @@
+module Kafka
+  module Protocol
+    class MessageSet
+      attr_reader :messages
+
+      def initialize(messages:)
+        @messages = messages
+      end
+
+      def self.decode(decoder)
+        fetched_messages = []
+
+        until decoder.eof?
+          offset = decoder.int64
+          message_decoder = Decoder.from_string(decoder.bytes)
+          message = Message.decode(message_decoder)
+
+          fetched_messages << [offset, message]
+        end
+
+        new(messages: fetched_messages)
+      end
+    end
+  end
+end

--- a/spec/broker_spec.rb
+++ b/spec/broker_spec.rb
@@ -64,4 +64,20 @@ describe Kafka::Broker do
       expect(response).to be_nil
     end
   end
+
+  describe "#fetch_messages" do
+    it "fetches messages from the specified topic/partition" do
+      response = Kafka::Protocol::ProduceResponse.new
+
+      connection.mock_response(response)
+
+      actual_response = broker.fetch_messages(
+        max_wait_time: 0,
+        min_bytes: 0,
+        topics: {}
+      )
+
+      expect(actual_response.topics).to eq []
+    end
+  end
 end

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -17,10 +17,19 @@ describe "Producer API", functional: true do
   end
 
   example "writing messages using the buffered producer" do
-    producer.produce("hello1", key: "x", topic: "test-messages", partition: 0)
-    producer.produce("hello2", key: "y", topic: "test-messages", partition: 1)
+    value1 = rand(10_000).to_s
+    value2 = rand(10_000).to_s
+
+    producer.produce(value1, key: "x", topic: "test-messages", partition: 0)
+    producer.produce(value2, key: "y", topic: "test-messages", partition: 1)
 
     producer.send_messages
+
+    message1 = kafka.fetch_messages(topic: "test-messages", partition: 0, offset: :earliest).last
+    message2 = kafka.fetch_messages(topic: "test-messages", partition: 1, offset: :earliest).last
+
+    expect(message1.value).to eq value1
+    expect(message2.value).to eq value2
   end
 
   example "having the producer assign partitions based on partition keys" do


### PR DESCRIPTION
Implements #47.

Fetches a batch of messages from a specified partition.

###### To Do

- [x] Resolve magic offset names `:earliest` and `:latest` using the [Offset API](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-OffsetAPI(AKAListOffset)).