### PR TITLE
Don't raise topic/partition errors when fetching metadata

### DIFF
--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -27,22 +27,7 @@ module Kafka
       request = Protocol::TopicMetadataRequest.new(**options)
       response_class = Protocol::MetadataResponse
 
-      response = @connection.send_request(request, response_class)
-
-      response.topics.each do |topic|
-        Protocol.handle_error(topic.topic_error_code)
-
-        topic.partitions.each do |partition|
-          begin
-            Protocol.handle_error(partition.partition_error_code)
-          rescue ReplicaNotAvailable
-            # This error can be safely ignored per the protocol specification.
-            @logger.warn "Replica not available for #{topic.topic_name}/#{partition.partition_id}"
-          end
-        end
-      end
-
-      response
+      @connection.send_request(request, response_class)
     end
 
     def produce(**options)

--- a/spec/broker_pool_spec.rb
+++ b/spec/broker_pool_spec.rb
@@ -1,0 +1,73 @@
+describe Kafka::BrokerPool do
+  describe "#get_leader" do
+    let(:broker) { double(:broker) }
+
+    let(:pool) {
+      Kafka::BrokerPool.new(
+        seed_brokers: ["test1:9092"],
+        client_id: "test",
+        logger: Logger.new(LOG),
+      )
+    }
+
+    before do
+      allow(Kafka::Broker).to receive(:connect) { broker }
+      allow(broker).to receive(:disconnect)
+    end
+
+    it "raises LeaderNotAvailable if there's no leader for the partition" do
+      metadata = Kafka::Protocol::MetadataResponse.new(
+        brokers: [
+          Kafka::Protocol::MetadataResponse::BrokerInfo.new(
+            node_id: 42,
+            host: "test1",
+            port: 9092,
+          )
+        ],
+        topics: [
+          Kafka::Protocol::MetadataResponse::TopicMetadata.new(
+            topic_name: "greetings",
+            partitions: [
+              Kafka::Protocol::MetadataResponse::PartitionMetadata.new(
+                partition_id: 42,
+                leader: 2,
+                partition_error_code: 5, # <-- this is the important bit.
+              )
+            ]
+          )
+        ],
+      )
+
+      allow(broker).to receive(:fetch_metadata) { metadata }
+
+      expect {
+        pool.get_leader("greetings", 42)
+      }.to raise_error Kafka::LeaderNotAvailable
+    end
+
+    it "raises InvalidTopic if the topic is invalid" do
+      metadata = Kafka::Protocol::MetadataResponse.new(
+        brokers: [
+          Kafka::Protocol::MetadataResponse::BrokerInfo.new(
+            node_id: 42,
+            host: "test1",
+            port: 9092,
+          )
+        ],
+        topics: [
+          Kafka::Protocol::MetadataResponse::TopicMetadata.new(
+            topic_name: "greetings",
+            topic_error_code: 17, # <-- this is the important bit.
+            partitions: []
+          )
+        ],
+      )
+
+      allow(broker).to receive(:fetch_metadata) { metadata }
+
+      expect {
+        pool.get_leader("greetings", 42)
+      }.to raise_error Kafka::InvalidTopic
+    end
+  end
+end


### PR DESCRIPTION
There's no need to raise an error unless the client actually tries to use the topic/partition.

Fixes #55.