### PR TITLE
Allow buffering messages even when Kafka is unavailable

### DIFF
--- a/lib/kafka/message_buffer.rb
+++ b/lib/kafka/message_buffer.rb
@@ -1,3 +1,5 @@
+require "kafka/protocol/message"
+
 module Kafka
 
   # Buffers messages for specific topics/partitions.
@@ -11,8 +13,9 @@ module Kafka
       @size = 0
     end
 
-    def write(message, topic:, partition:)
+    def write(value:, key:, topic:, partition:)
       @size += 1
+      message = Protocol::Message.new(key: key, value: value)
       buffer_for(topic, partition) << message
     end
 

--- a/lib/kafka/pending_message.rb
+++ b/lib/kafka/pending_message.rb
@@ -1,0 +1,13 @@
+module Kafka
+  class PendingMessage
+    attr_reader :value, :key, :topic, :partition, :partition_key
+
+    def initialize(value:, key:, topic:, partition:, partition_key:)
+      @key = key
+      @value = value
+      @topic = topic
+      @partition = partition
+      @partition_key = partition_key
+    end
+  end
+end

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -1,7 +1,7 @@
 require "kafka/partitioner"
 require "kafka/message_buffer"
-require "kafka/protocol/message"
 require "kafka/produce_operation"
+require "kafka/pending_message"
 
 module Kafka
 
@@ -115,7 +115,12 @@ module Kafka
       @max_retries = max_retries
       @retry_backoff = retry_backoff
       @max_buffer_size = max_buffer_size
+
+      # A buffer organized by topic/partition.
       @buffer = MessageBuffer.new
+
+      # Messages added by `#produce` but not yet assigned a partition.
+      @pending_messages = []
     end
 
     # Produces a message to the specified topic. Note that messages are buffered in
@@ -152,21 +157,15 @@ module Kafka
         raise BufferOverflow, "Max buffer size #{@max_buffer_size} exceeded"
       end
 
-      # Make sure we get metadata for this topic.
-      @broker_pool.add_target_topic(topic)
+      @pending_messages << PendingMessage.new(
+        value: value,
+        key: key,
+        topic: topic,
+        partition: partition,
+        partition_key: partition_key,
+      )
 
-      if partition.nil?
-        # If no explicit partition key is specified we use the message key instead.
-        partition_key ||= key
-        partitioner = Partitioner.new(@broker_pool.partitions_for(topic))
-        partition = partitioner.partition_for_key(partition_key)
-      end
-
-      message = Protocol::Message.new(key: key, value: value)
-
-      @buffer.write(message, topic: topic, partition: partition)
-
-      partition
+      nil
     end
 
     # Sends all buffered messages to the Kafka brokers.
@@ -181,6 +180,10 @@ module Kafka
     def send_messages
       attempt = 0
 
+      # Make sure we get metadata for this topic.
+      target_topics = @pending_messages.map(&:topic).uniq
+      @broker_pool.add_target_topics(target_topics)
+
       operation = ProduceOperation.new(
         broker_pool: @broker_pool,
         buffer: @buffer,
@@ -193,9 +196,10 @@ module Kafka
         @logger.info "Sending #{@buffer.size} messages"
 
         attempt += 1
+        assign_partitions!
         operation.execute
 
-        if @buffer.empty?
+        if @pending_messages.empty? && @buffer.empty?
           @logger.info "Successfully sent all messages"
           break
         elsif attempt <= @max_retries
@@ -227,7 +231,7 @@ module Kafka
     #
     # @return [Integer] buffer size.
     def buffer_size
-      @buffer.size
+      @pending_messages.size + @buffer.size
     end
 
     # Closes all connections to the brokers.
@@ -235,6 +239,30 @@ module Kafka
     # @return [nil]
     def shutdown
       @broker_pool.shutdown
+    end
+
+    private
+
+    def assign_partitions!
+      @pending_messages.each do |message|
+        partition = message.partition
+
+        if partition.nil?
+          # If no explicit partition key is specified we use the message key instead.
+          partition_key = message.partition_key || message.key
+          partitioner = Partitioner.new(@broker_pool.partitions_for(message.topic))
+          partition = partitioner.partition_for_key(partition_key)
+        end
+
+        @buffer.write(
+          value: message.value,
+          key: message.key,
+          topic: message.topic,
+          partition: partition,
+        )
+      end
+
+      @pending_messages.clear
     end
   end
 end

--- a/lib/kafka/protocol/metadata_response.rb
+++ b/lib/kafka/protocol/metadata_response.rb
@@ -131,6 +131,8 @@ module Kafka
           raise UnknownTopicOrPartition, "unknown topic #{topic_name}"
         end
 
+        Protocol.handle_error(topic.topic_error_code)
+
         topic.partitions
       end
 


### PR DESCRIPTION
Until now, `Producer#produce` has required access to the cluster metadata in order to determine the partition that a given message should be assigned to. In the case of Kafka being unavailable, this would have blocked clients from buffering messages, as the metadata request would fail. Furthermore, since ffc1a34 the metadata has been invalidated the first time `#produce` is called with a topic not seen by the Producer instance before. This would mean a thundering herd of metadata requests when e.g. a cluster of web application processes are restarted. By postponing the metadata request until we're ready to send all the messages, we'll be able to do a single request containing *all* the topics.

This is done by adding a separate first-stage buffer to Producer. This is a flat list of pending messages that have not yet been assigned a partition. When sending messages, we first get the set of topics referenced by these messages and make sure there's metadata for them, possibly re-fetching the metadata. Then we use the metadata to assign each message to a partition and copy the messages into the MessageBuffer. From there it's business as usual.