### PR TITLE
Fix automatic topic creation

### DIFF
--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -37,10 +37,10 @@ module Kafka
     end
 
     def add_target_topics(topics)
-      new_topics = @target_topics.difference(topics)
+      new_topics = Set.new(topics) - @target_topics
 
       unless new_topics.empty?
-        @logger.info "New topics added to target list: #{new_topics.join(', ')}"
+        @logger.info "New topics added to target list: #{new_topics.to_a.join(', ')}"
 
         @target_topics.merge(new_topics)
 
@@ -105,7 +105,7 @@ module Kafka
     # @return [Protocol::MetadataResponse] the cluster metadata.
     def fetch_cluster_info
       @seed_brokers.each do |node|
-        @logger.info "Trying to initialize broker pool from node #{node}"
+        @logger.info "Fetching cluster metadata from #{node}"
 
         begin
           host, port = node.split(":", 2)

--- a/lib/kafka/partitioner.rb
+++ b/lib/kafka/partitioner.rb
@@ -5,6 +5,8 @@ module Kafka
   # Assigns partitions to messages.
   class Partitioner
     def initialize(partitions)
+      raise ArgumentError if partitions.empty?
+
       @partitions = partitions
     end
 

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -193,7 +193,7 @@ module Kafka
       )
 
       loop do
-        @logger.info "Sending #{@buffer.size} messages"
+        @logger.info "Sending #{buffer_size} messages"
 
         attempt += 1
         assign_partitions!

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -53,6 +53,18 @@ describe "Producer API", functional: true do
     producer.send_messages
   end
 
+  example "writing to a topic that doesn't yet exist" do
+    topic = "topic#{rand(1000)}"
+
+    producer = kafka.get_producer(max_retries: 10, retry_backoff: 1)
+    producer.produce("hello", topic: topic, partition: 0)
+    producer.send_messages
+
+    messages = kafka.fetch_messages(topic: topic, partition: 0, offset: 0)
+
+    expect(messages.last.value).to eq "hello"
+  end
+
   example "handle a broker going down after the initial discovery" do
     begin
       producer = kafka.get_producer(max_retries: 3, retry_backoff: 5)


### PR DESCRIPTION
An error in `add_target_topics` caused new topics to not be added to the target list. Furthermore, the LeaderNotAvailable exception raised when attempting to send messages to a newly created topic was not being handled.

Should fix #62 for real this time.