### PR TITLE
Makes the Partitioner configurable(no documentation yet)

### DIFF
--- a/lib/kafka/default_partitioner.rb
+++ b/lib/kafka/default_partitioner.rb
@@ -3,7 +3,7 @@ require "zlib"
 module Kafka
 
   # Assigns partitions to messages.
-  class Partitioner
+  class DefaultPartitioner
 
     # Assigns a partition number based on a key.
     #

--- a/spec/partitioner_spec.rb
+++ b/spec/partitioner_spec.rb
@@ -1,5 +1,5 @@
-describe Kafka::Partitioner, "#partition_for_key" do
-  let(:partitioner) { Kafka::Partitioner }
+describe Kafka::DefaultPartitioner, "#partition_for_key" do
+  let(:partitioner) { Kafka::DefaultPartitioner }
 
   it "deterministically returns a partition number for a given key and number of partitions" do
     partition = partitioner.partition_for_key(3, "yolo")


### PR DESCRIPTION
Not all Kafka clients have the same default partitioning logic (librdkafka and the Java client had different defaults last time I checked). This means that you need to be able to use a custom partitioner if you care about message order and have multiple clients producing to the same topic.

This pull request allows you to specify a custom Partitioner in calls to Client#get_producer. If one is not specified it continues to use the standard Partitioner (now rename DefaultPartitioner). If you like this approach let me know and I'll update the pull request with documentation.

It _is_ possible to keep the custom partitioner logic out of ruby-kafka, and instead have gem users handle this themselves, but to me it feels like a natural part of the Producer.
