### PR TITLE
Allow automatically creating topics when fetching messages

### DIFF
--- a/lib/kafka/fetch_operation.rb
+++ b/lib/kafka/fetch_operation.rb
@@ -39,6 +39,8 @@ module Kafka
     end
 
     def execute
+      @broker_pool.add_target_topics(@topics.keys)
+
       topics_by_broker = {}
 
       @topics.each do |topic, partitions|
@@ -78,6 +80,10 @@ module Kafka
           }
         }
       }
+    rescue Kafka::LeaderNotAvailable
+      @broker_pool.mark_as_stale!
+
+      raise
     end
 
     private

--- a/spec/functional/fetch_spec.rb
+++ b/spec/functional/fetch_spec.rb
@@ -1,0 +1,37 @@
+describe "Fetch API", functional: true do
+  let(:logger) { Logger.new(LOG) }
+  let(:kafka) { Kafka.new(seed_brokers: KAFKA_BROKERS, client_id: "test", logger: logger) }
+
+  before do
+    require "test_cluster"
+  end
+
+  after do
+    kafka.close
+  end
+
+  example "fetching from a non-existing topic when auto-create is enabled" do
+    topic = "rand#{rand(1000)}"
+    attempt = 1
+    messages = nil
+
+    begin
+      messages = kafka.fetch_messages(
+        topic: topic,
+        partition: 0,
+        offset: 0,
+        max_wait_time: 0.1
+      )
+    rescue Kafka::LeaderNotAvailable
+      if attempt < 10
+        attempt += 1
+        sleep 0.1
+        retry
+      else
+        raise "timed out"
+      end
+    end
+
+    expect(messages).to eq []
+  end
+end

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -1,6 +1,5 @@
 describe "Producer API", functional: true do
-  let(:logger) { Logger.new(log) }
-  let(:log) { LOG }
+  let(:logger) { Logger.new(LOG) }
   let(:kafka) { Kafka.new(seed_brokers: KAFKA_BROKERS, client_id: "test", logger: logger) }
   let(:producer) { kafka.get_producer(max_retries: 1, retry_backoff: 0) }
 


### PR DESCRIPTION
By adding the target topic to the broker pool, subsequent metadata requests will ensure that the topic is created.

Fixes #71.