### PR TITLE
Avoid a barrage of metadata requests on errors

### DIFF
--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -30,6 +30,7 @@ module Kafka
       @brokers = {}
       @seed_brokers = seed_brokers
       @cluster_info = nil
+      @stale = true
 
       # This is the set of topics we need metadata for. If empty, metadata for
       # all topics will be fetched.
@@ -49,12 +50,16 @@ module Kafka
     end
 
     def mark_as_stale!
-      @cluster_info = nil
+      @stale = true
     end
 
     def refresh_metadata!
-      mark_as_stale!
+      @cluster_info = nil
       cluster_info
+    end
+
+    def refresh_metadata_if_necessary!
+      refresh_metadata! if @stale
     end
 
     # Finds the broker acting as the leader of the given topic and partition.
@@ -119,6 +124,8 @@ module Kafka
           )
 
           cluster_info = broker.fetch_metadata(topics: @target_topics)
+
+          @stale = false
 
           @logger.info "Discovered cluster metadata; nodes: #{cluster_info.brokers.join(', ')}"
 

--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -137,7 +137,7 @@ module Kafka
         end
       end
 
-      raise ConnectionError, "Could not connect to any of the seed brokers: #{@seed_brokers.inspect}"
+      raise ConnectionError, "Could not connect to any of the seed brokers: #{@seed_brokers.join(', ')}"
     end
 
     def connect_to_broker(broker_id)

--- a/lib/kafka/fetch_operation.rb
+++ b/lib/kafka/fetch_operation.rb
@@ -40,6 +40,7 @@ module Kafka
 
     def execute
       @broker_pool.add_target_topics(@topics.keys)
+      @broker_pool.refresh_metadata_if_necessary!
 
       topics_by_broker = {}
 
@@ -80,7 +81,7 @@ module Kafka
           }
         }
       }
-    rescue Kafka::LeaderNotAvailable
+    rescue Kafka::LeaderNotAvailable, Kafka::NotLeaderForPartition
       @broker_pool.mark_as_stale!
 
       raise

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -194,6 +194,9 @@ module Kafka
 
       loop do
         attempt += 1
+
+        @broker_pool.refresh_metadata_if_necessary!
+
         assign_partitions!
         operation.execute
 

--- a/spec/broker_pool_spec.rb
+++ b/spec/broker_pool_spec.rb
@@ -69,5 +69,19 @@ describe Kafka::BrokerPool do
         pool.get_leader("greetings", 42)
       }.to raise_error Kafka::InvalidTopic
     end
+
+    it "raises ConnectionError if unable to connect to any of the seed brokers" do
+      pool = Kafka::BrokerPool.new(
+        seed_brokers: ["not-there:9092", "not-here:9092"],
+        client_id: "test",
+        logger: Logger.new(LOG),
+      )
+
+      allow(Kafka::Broker).to receive(:connect).and_raise(Kafka::ConnectionError)
+
+      expect {
+        pool.get_leader("greetings", 42)
+      }.to raise_exception(Kafka::ConnectionError)
+    end
   end
 end

--- a/spec/functional/fetch_spec.rb
+++ b/spec/functional/fetch_spec.rb
@@ -22,7 +22,7 @@ describe "Fetch API", functional: true do
         offset: 0,
         max_wait_time: 0.1
       )
-    rescue Kafka::LeaderNotAvailable
+    rescue Kafka::LeaderNotAvailable, Kafka::NotLeaderForPartition
       if attempt < 10
         attempt += 1
         sleep 0.1

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -17,6 +17,7 @@ describe Kafka::Producer do
 
   before do
     allow(broker_pool).to receive(:mark_as_stale!)
+    allow(broker_pool).to receive(:refresh_metadata_if_necessary!)
     allow(broker_pool).to receive(:add_target_topics)
 
     allow(broker_pool).to receive(:get_leader).with("greetings", 0) { broker1 }


### PR DESCRIPTION
Previously, `BrokerPool#mark_as_stale!` would cause the cached metadata to be removed, but each subsequent call for metadata info (such as leader lookups) would cause a metadata request. In order to avoid this situation, the metadata is kept in the cache even though it's stale. This makes sense because the metadata is not either completely accurate or completely inaccurate -- it can be accurate for some partitions but not others. Therefore we get as much work done as possible with the existing metadata and only do a refresh when we start a new retry.