### PR TITLE
Introduce Cluster, limit the responsibility of BrokerPool

### DIFF
--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -1,0 +1,38 @@
+require "kafka/broker"
+
+module Kafka
+  class BrokerPool
+    def initialize(client_id:, connect_timeout: nil, socket_timeout: nil, logger:)
+      @client_id = client_id
+      @connect_timeout = connect_timeout
+      @socket_timeout = socket_timeout
+      @logger = logger
+      @brokers = {}
+    end
+
+    def connect(host, port, node_id: nil)
+      return @brokers.fetch(node_id) if @brokers.key?(node_id)
+
+      broker = Broker.connect(
+        host: host,
+        port: port,
+        node_id: node_id,
+        client_id: @client_id,
+        connect_timeout: @connect_timeout,
+        socket_timeout: @socket_timeout,
+        logger: @logger,
+      )
+
+      @brokers[node_id] = broker unless node_id.nil?
+
+      broker
+    end
+
+    def close
+      @brokers.each do |id, broker|
+        @logger.info "Disconnecting broker #{id}"
+        broker.disconnect
+      end
+    end
+  end
+end

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -1,4 +1,4 @@
-require "kafka/broker_pool"
+require "kafka/cluster"
 require "kafka/producer"
 require "kafka/fetched_message"
 require "kafka/fetch_operation"
@@ -18,16 +18,16 @@ module Kafka
     # @param logger [Logger]
     #
     # @param connect_timeout [Integer, nil] the timeout setting for connecting
-    #   to brokers. See {BrokerPool#initialize}.
+    #   to brokers. See {Cluster#initialize}.
     #
     # @param socket_timeout [Integer, nil] the timeout setting for socket
-    #   connections. See {BrokerPool#initialize}.
+    #   connections. See {Cluster#initialize}.
     #
     # @return [Client]
     def initialize(seed_brokers:, client_id: DEFAULT_CLIENT_ID, logger: DEFAULT_LOGGER, connect_timeout: nil, socket_timeout: nil)
       @logger = logger
 
-      @broker_pool = BrokerPool.new(
+      @cluster = Cluster.new(
         seed_brokers: seed_brokers,
         client_id: client_id,
         logger: logger,
@@ -43,7 +43,7 @@ module Kafka
     # @see Producer#initialize
     # @return [Kafka::Producer] the Kafka producer.
     def get_producer(**options)
-      Producer.new(broker_pool: @broker_pool, logger: @logger, **options)
+      Producer.new(cluster: @cluster, logger: @logger, **options)
     end
 
     # Fetches a batch of messages from a single partition. Note that it's possible
@@ -109,7 +109,7 @@ module Kafka
     # @return [Array<Kafka::FetchedMessage>] the messages returned from the broker.
     def fetch_messages(topic:, partition:, offset: :latest, max_wait_time: 5, min_bytes: 1, max_bytes: 1048576)
       operation = FetchOperation.new(
-        broker_pool: @broker_pool,
+        cluster: @cluster,
         logger: @logger,
         min_bytes: min_bytes,
         max_wait_time: max_wait_time,
@@ -124,11 +124,11 @@ module Kafka
     #
     # @return [Array<String>] the list of topic names.
     def topics
-      @broker_pool.topics
+      @cluster.topics
     end
 
     def close
-      @broker_pool.shutdown
+      @cluster.shutdown
     end
   end
 end

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -27,12 +27,17 @@ module Kafka
     def initialize(seed_brokers:, client_id: DEFAULT_CLIENT_ID, logger: DEFAULT_LOGGER, connect_timeout: nil, socket_timeout: nil)
       @logger = logger
 
-      @cluster = Cluster.new(
-        seed_brokers: seed_brokers,
+      broker_pool = BrokerPool.new(
         client_id: client_id,
-        logger: logger,
         connect_timeout: connect_timeout,
         socket_timeout: socket_timeout,
+        logger: logger,
+      )
+
+      @cluster = Cluster.new(
+        seed_brokers: seed_brokers,
+        broker_pool: broker_pool,
+        logger: logger,
       )
     end
 

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -18,10 +18,10 @@ module Kafka
     # @param logger [Logger]
     #
     # @param connect_timeout [Integer, nil] the timeout setting for connecting
-    #   to brokers. See {Cluster#initialize}.
+    #   to brokers. See {BrokerPool#initialize}.
     #
     # @param socket_timeout [Integer, nil] the timeout setting for socket
-    #   connections. See {Cluster#initialize}.
+    #   connections. See {BrokerPool#initialize}.
     #
     # @return [Client]
     def initialize(seed_brokers:, client_id: DEFAULT_CLIENT_ID, logger: DEFAULT_LOGGER, connect_timeout: nil, socket_timeout: nil)
@@ -128,7 +128,7 @@ module Kafka
     end
 
     def close
-      @cluster.shutdown
+      @cluster.disconnect
     end
   end
 end

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -14,26 +14,18 @@ module Kafka
     # The cluster will try to fetch cluster metadata from one of the brokers.
     #
     # @param seed_brokers [Array<String>]
-    # @param client_id [String]
+    # @param broker_pool [Kafka::BrokerPool]
     # @param logger [Logger]
-    # @param connect_timeout [Integer, nil] see {Connection#initialize}.
-    # @param socket_timeout [Integer, nil] see {Connection#initialize}.
-    def initialize(seed_brokers:, client_id:, logger:, connect_timeout: nil, socket_timeout: nil)
+    def initialize(seed_brokers:, broker_pool:, logger:)
       if seed_brokers.empty?
         raise ArgumentError, "At least one seed broker must be configured"
       end
 
       @logger = logger
       @seed_brokers = seed_brokers
+      @broker_pool = broker_pool
       @cluster_info = nil
       @stale = true
-
-      @broker_pool = BrokerPool.new(
-        client_id: client_id,
-        connect_timeout: connect_timeout,
-        socket_timeout: socket_timeout,
-        logger: logger,
-      )
 
       # This is the set of topics we need metadata for. If empty, metadata for
       # all topics will be fetched.

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -3,15 +3,15 @@ require "kafka/broker"
 
 module Kafka
 
-  # A broker pool represents the set of brokers in a cluster. It needs to be initialized
-  # with a non-empty list of seed brokers. The first seed broker that the pool can connect
-  # to will be asked for the cluster metadata, which allows the pool to map topic
+  # A broker cluster represents the set of brokers in a cluster. It needs to be initialized
+  # with a non-empty list of seed brokers. The first seed broker that the cluster can connect
+  # to will be asked for the cluster metadata, which allows the cluster to map topic
   # partitions to the current leader for those partitions.
-  class BrokerPool
+  class Cluster
 
-    # Initializes a broker pool with a set of seed brokers.
+    # Initializes a broker cluster with a set of seed brokers.
     #
-    # The pool will try to fetch cluster metadata from one of the brokers.
+    # The cluster will try to fetch cluster metadata from one of the brokers.
     #
     # @param seed_brokers [Array<String>]
     # @param client_id [String]

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -1,15 +1,15 @@
 require "set"
-require "kafka/broker"
+require "kafka/broker_pool"
 
 module Kafka
 
-  # A broker cluster represents the set of brokers in a cluster. It needs to be initialized
+  # A cluster represents the state of a Kafka cluster. It needs to be initialized
   # with a non-empty list of seed brokers. The first seed broker that the cluster can connect
   # to will be asked for the cluster metadata, which allows the cluster to map topic
   # partitions to the current leader for those partitions.
   class Cluster
 
-    # Initializes a broker cluster with a set of seed brokers.
+    # Initializes a Cluster with a set of seed brokers.
     #
     # The cluster will try to fetch cluster metadata from one of the brokers.
     #
@@ -23,14 +23,17 @@ module Kafka
         raise ArgumentError, "At least one seed broker must be configured"
       end
 
-      @client_id = client_id
       @logger = logger
-      @connect_timeout = connect_timeout
-      @socket_timeout = socket_timeout
-      @brokers = {}
       @seed_brokers = seed_brokers
       @cluster_info = nil
       @stale = true
+
+      @broker_pool = BrokerPool.new(
+        client_id: client_id,
+        connect_timeout: connect_timeout,
+        socket_timeout: socket_timeout,
+        logger: logger,
+      )
 
       # This is the set of topics we need metadata for. If empty, metadata for
       # all topics will be fetched.
@@ -68,7 +71,7 @@ module Kafka
     # @param partition [Integer]
     # @return [Broker] the broker that's currently leader.
     def get_leader(topic, partition)
-      get_broker(get_leader_id(topic, partition))
+      connect_to_broker(get_leader_id(topic, partition))
     end
 
     def partitions_for(topic)
@@ -79,21 +82,14 @@ module Kafka
       cluster_info.topics.map(&:topic_name)
     end
 
-    def shutdown
-      @brokers.each do |id, broker|
-        @logger.info "Disconnecting broker #{id}"
-        broker.disconnect
-      end
+    def disconnect
+      @broker_pool.close
     end
 
     private
 
     def get_leader_id(topic, partition)
       cluster_info.find_leader_id(topic, partition)
-    end
-
-    def get_broker(broker_id)
-      @brokers[broker_id] ||= connect_to_broker(broker_id)
     end
 
     def cluster_info
@@ -115,14 +111,7 @@ module Kafka
         begin
           host, port = node.split(":", 2)
 
-          broker = Broker.connect(
-            host: host,
-            port: port.to_i,
-            client_id: @client_id,
-            socket_timeout: @socket_timeout,
-            logger: @logger,
-          )
-
+          broker = @broker_pool.connect(host, port.to_i)
           cluster_info = broker.fetch_metadata(topics: @target_topics)
 
           @stale = false
@@ -141,17 +130,9 @@ module Kafka
     end
 
     def connect_to_broker(broker_id)
-      broker_info = cluster_info.find_broker(broker_id)
+      info = cluster_info.find_broker(broker_id)
 
-      Broker.connect(
-        host: broker_info.host,
-        port: broker_info.port,
-        node_id: broker_info.node_id,
-        client_id: @client_id,
-        connect_timeout: @connect_timeout,
-        socket_timeout: @socket_timeout,
-        logger: @logger,
-      )
+      @broker_pool.connect(info.host, info.port, node_id: info.node_id)
     end
   end
 end

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -236,7 +236,7 @@ module Kafka
     #
     # @return [nil]
     def shutdown
-      @cluster.shutdown
+      @cluster.disconnect
     end
 
     private

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -1,17 +1,18 @@
 describe Kafka::Cluster do
   describe "#get_leader" do
     let(:broker) { double(:broker) }
+    let(:broker_pool) { double(:broker_pool) }
 
     let(:cluster) {
       Kafka::Cluster.new(
         seed_brokers: ["test1:9092"],
-        client_id: "test",
+        broker_pool: broker_pool,
         logger: Logger.new(LOG),
       )
     }
 
     before do
-      allow(Kafka::Broker).to receive(:connect) { broker }
+      allow(broker_pool).to receive(:connect) { broker }
       allow(broker).to receive(:disconnect)
     end
 
@@ -73,11 +74,11 @@ describe Kafka::Cluster do
     it "raises ConnectionError if unable to connect to any of the seed brokers" do
       cluster = Kafka::Cluster.new(
         seed_brokers: ["not-there:9092", "not-here:9092"],
-        client_id: "test",
+        broker_pool: broker_pool,
         logger: Logger.new(LOG),
       )
 
-      allow(Kafka::Broker).to receive(:connect).and_raise(Kafka::ConnectionError)
+      allow(broker_pool).to receive(:connect).and_raise(Kafka::ConnectionError)
 
       expect {
         cluster.get_leader("greetings", 42)

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -1,9 +1,9 @@
-describe Kafka::BrokerPool do
+describe Kafka::Cluster do
   describe "#get_leader" do
     let(:broker) { double(:broker) }
 
-    let(:pool) {
-      Kafka::BrokerPool.new(
+    let(:cluster) {
+      Kafka::Cluster.new(
         seed_brokers: ["test1:9092"],
         client_id: "test",
         logger: Logger.new(LOG),
@@ -41,7 +41,7 @@ describe Kafka::BrokerPool do
       allow(broker).to receive(:fetch_metadata) { metadata }
 
       expect {
-        pool.get_leader("greetings", 42)
+        cluster.get_leader("greetings", 42)
       }.to raise_error Kafka::LeaderNotAvailable
     end
 
@@ -66,12 +66,12 @@ describe Kafka::BrokerPool do
       allow(broker).to receive(:fetch_metadata) { metadata }
 
       expect {
-        pool.get_leader("greetings", 42)
+        cluster.get_leader("greetings", 42)
       }.to raise_error Kafka::InvalidTopic
     end
 
     it "raises ConnectionError if unable to connect to any of the seed brokers" do
-      pool = Kafka::BrokerPool.new(
+      cluster = Kafka::Cluster.new(
         seed_brokers: ["not-there:9092", "not-here:9092"],
         client_id: "test",
         logger: Logger.new(LOG),
@@ -80,7 +80,7 @@ describe Kafka::BrokerPool do
       allow(Kafka::Broker).to receive(:connect).and_raise(Kafka::ConnectionError)
 
       expect {
-        pool.get_leader("greetings", 42)
+        cluster.get_leader("greetings", 42)
       }.to raise_exception(Kafka::ConnectionError)
     end
   end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -4,11 +4,11 @@ describe Kafka::Producer do
   let(:logger) { Logger.new(LOG) }
   let(:broker1) { FakeBroker.new }
   let(:broker2) { FakeBroker.new }
-  let(:broker_pool) { double(:broker_pool) }
+  let(:cluster) { double(:cluster) }
 
   let(:producer) {
     Kafka::Producer.new(
-      broker_pool: broker_pool,
+      cluster: cluster,
       logger: logger,
       max_retries: 2,
       retry_backoff: 0,
@@ -16,17 +16,17 @@ describe Kafka::Producer do
   }
 
   before do
-    allow(broker_pool).to receive(:mark_as_stale!)
-    allow(broker_pool).to receive(:refresh_metadata_if_necessary!)
-    allow(broker_pool).to receive(:add_target_topics)
+    allow(cluster).to receive(:mark_as_stale!)
+    allow(cluster).to receive(:refresh_metadata_if_necessary!)
+    allow(cluster).to receive(:add_target_topics)
 
-    allow(broker_pool).to receive(:get_leader).with("greetings", 0) { broker1 }
-    allow(broker_pool).to receive(:get_leader).with("greetings", 1) { broker2 }
+    allow(cluster).to receive(:get_leader).with("greetings", 0) { broker1 }
+    allow(cluster).to receive(:get_leader).with("greetings", 1) { broker2 }
   end
 
   describe "#produce" do
     before do
-      allow(broker_pool).to receive(:partitions_for).with("greetings") { [0, 1, 2, 3] }
+      allow(cluster).to receive(:partitions_for).with("greetings") { [0, 1, 2, 3] }
     end
 
     it "writes the message to the buffer" do
@@ -49,7 +49,7 @@ describe Kafka::Producer do
 
     it "raises BufferOverflow if the max buffer size is exceeded" do
       producer = Kafka::Producer.new(
-        broker_pool: broker_pool,
+        cluster: cluster,
         logger: logger,
         max_buffer_size: 2, # <-- this is the important bit.
       )
@@ -109,7 +109,7 @@ describe Kafka::Producer do
     end
 
     it "handles when there's a connection error when fetching topic metadata" do
-      allow(broker_pool).to receive(:get_leader).and_raise(Kafka::ConnectionError)
+      allow(cluster).to receive(:get_leader).and_raise(Kafka::ConnectionError)
 
       producer.produce("hello1", topic: "greetings", partition: 0)
 
@@ -119,7 +119,7 @@ describe Kafka::Producer do
       expect(producer.buffer_size).to eq 1
 
       # Clear the error.
-      allow(broker_pool).to receive(:get_leader) { broker1 }
+      allow(cluster).to receive(:get_leader) { broker1 }
 
       producer.send_messages
 
@@ -128,7 +128,7 @@ describe Kafka::Producer do
 
     it "clears the buffer after sending messages if no acknowledgements are required" do
       producer = Kafka::Producer.new(
-        broker_pool: broker_pool,
+        cluster: cluster,
         logger: logger,
         required_acks: 0, # <-- this is the important bit.
         max_retries: 2,


### PR DESCRIPTION
Extracts the cluster-specific parts of BrokerPool to Cluster, leaving only broker pool handling.