### PR TITLE
Let the request class define the response class

### DIFF
--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -31,9 +31,8 @@ module Kafka
     # @return [Kafka::Protocol::MetadataResponse]
     def fetch_metadata(**options)
       request = Protocol::TopicMetadataRequest.new(**options)
-      response_class = Protocol::MetadataResponse
 
-      @connection.send_request(request, response_class)
+      @connection.send_request(request)
     end
 
     # Fetches messages from a specified topic and partition.
@@ -42,9 +41,8 @@ module Kafka
     # @return [Kafka::Protocol::FetchResponse]
     def fetch_messages(**options)
       request = Protocol::FetchRequest.new(**options)
-      response_class = Protocol::FetchResponse
 
-      @connection.send_request(request, response_class)
+      @connection.send_request(request)
     end
 
     # Lists the offset of the specified topics and partitions.
@@ -53,9 +51,8 @@ module Kafka
     # @return [Kafka::Protocol::ListOffsetResponse]
     def list_offsets(**options)
       request = Protocol::ListOffsetRequest.new(**options)
-      response_class = Protocol::ListOffsetResponse
 
-      @connection.send_request(request, response_class)
+      @connection.send_request(request)
     end
 
     # Produces a set of messages to the broker.
@@ -64,9 +61,8 @@ module Kafka
     # @return [Kafka::Protocol::ProduceResponse]
     def produce(**options)
       request = Protocol::ProduceRequest.new(**options)
-      response_class = request.requires_acks? ? Protocol::ProduceResponse : nil
 
-      @connection.send_request(request, response_class)
+      @connection.send_request(request)
     end
   end
 end

--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -68,11 +68,11 @@ module Kafka
 
     # Sends a request over the connection.
     #
-    # @param request [#encode] the request that should be encoded and written.
-    # @param response_class [#decode] an object that can decode the response.
+    # @param request [#encode, #response_class] the request that should be
+    #   encoded and written.
     #
-    # @return [Object] the response that was decoded by `response_class`.
-    def send_request(request, response_class)
+    # @return [Object] the response.
+    def send_request(request)
       # Default notification payload.
       notification = {
         api: Protocol.api_name(request.api_key),
@@ -86,6 +86,8 @@ module Kafka
         @correlation_id += 1
 
         write_request(request, notification)
+
+        response_class = request.response_class
         wait_for_response(response_class, notification) unless response_class.nil?
       end
     rescue Errno::EPIPE, Errno::ECONNRESET, Errno::ETIMEDOUT, EOFError => e

--- a/lib/kafka/protocol/fetch_request.rb
+++ b/lib/kafka/protocol/fetch_request.rb
@@ -30,6 +30,10 @@ module Kafka
         1
       end
 
+      def response_class
+        Protocol::FetchResponse
+      end
+
       def encode(encoder)
         encoder.write_int32(@replica_id)
         encoder.write_int32(@max_wait_time)

--- a/lib/kafka/protocol/list_offset_request.rb
+++ b/lib/kafka/protocol/list_offset_request.rb
@@ -23,6 +23,10 @@ module Kafka
         2
       end
 
+      def response_class
+        Protocol::ListOffsetResponse
+      end
+
       def encode(encoder)
         encoder.write_int32(@replica_id)
 

--- a/lib/kafka/protocol/produce_request.rb
+++ b/lib/kafka/protocol/produce_request.rb
@@ -40,6 +40,10 @@ module Kafka
         0
       end
 
+      def response_class
+        requires_acks? ? Protocol::ProduceResponse : nil
+      end
+
       # Whether this request requires any acknowledgements at all. If no acknowledgements
       # are required, the server will not send back a response at all.
       #

--- a/lib/kafka/protocol/topic_metadata_request.rb
+++ b/lib/kafka/protocol/topic_metadata_request.rb
@@ -13,6 +13,10 @@ module Kafka
         3
       end
 
+      def response_class
+        Protocol::MetadataResponse
+      end
+
       def encode(encoder)
         encoder.write_array(@topics) {|topic| encoder.write_string(topic) }
       end

--- a/spec/broker_spec.rb
+++ b/spec/broker_spec.rb
@@ -14,7 +14,7 @@ describe Kafka::Broker do
       @mocked_response = response
     end
 
-    def send_request(request, response_decoder)
+    def send_request(request)
       @mocked_response
     end
   end


### PR DESCRIPTION
Currently, Broker is responsible for orchestrating requests by combining a request class and a response class for a given logical API call. Sometimes a response isn't expected (e.g. for produce API calls with `required_acks=0`) and this case must be handled.

It makes more sense to me to have the individual request classes handle these decisions. Broker is now just an easier-to-use wrapper around the concrete request classes. 