### PR TITLE
Rename Producer#send_messages to #deliver_messages

### DIFF
--- a/examples/simple-producer.rb
+++ b/examples/simple-producer.rb
@@ -30,11 +30,11 @@ begin
     producer.produce(line, topic: topic)
 
     # Send messages for every 10 lines.
-    producer.send_messages if index % 10 == 0
+    producer.deliver_messages if index % 10 == 0
   end
 ensure
   # Make sure to send any remaining messages.
-  producer.send_messages
+  producer.deliver_messages
 
   producer.shutdown
 end

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -23,10 +23,10 @@ module Kafka
   #
   # ## Buffering
   #
-  # The producer buffers pending messages until {#send_messages} is called. Note that there is
+  # The producer buffers pending messages until {#deliver_messages} is called. Note that there is
   # a maximum buffer size (default is 1,000 messages) and writing messages after the
   # buffer has reached this size will result in a BufferOverflow exception. Make sure
-  # to periodically call {#send_messages} or set `max_buffer_size` to an appropriate value.
+  # to periodically call {#deliver_messages} or set `max_buffer_size` to an appropriate value.
   #
   # Buffering messages and sending them in batches greatly improves performance, so
   # try to avoid sending messages after every write. The tradeoff between throughput and
@@ -73,11 +73,11 @@ module Kafka
   #         producer.produce(line, topic: topic)
   #
   #         # Send messages for every 10 lines.
-  #         producer.send_messages if index % 10 == 0
+  #         producer.deliver_messages if index % 10 == 0
   #       end
   #     ensure
   #       # Make sure to send any remaining messages.
-  #       producer.send_messages
+  #       producer.deliver_messages
   #
   #       producer.shutdown
   #     end
@@ -123,7 +123,7 @@ module Kafka
     end
 
     # Produces a message to the specified topic. Note that messages are buffered in
-    # the producer until {#send_messages} is called.
+    # the producer until {#deliver_messages} is called.
     #
     # ## Partitioning
     #
@@ -176,7 +176,7 @@ module Kafka
     #
     # @raise [FailedToSendMessages] if not all messages could be successfully sent.
     # @return [nil]
-    def send_messages
+    def deliver_messages
       attempt = 0
 
       # Make sure we get metadata for this topic.

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -22,7 +22,7 @@ describe "Producer API", functional: true do
     producer.produce(value1, key: "x", topic: "test-messages", partition: 0)
     producer.produce(value2, key: "y", topic: "test-messages", partition: 1)
 
-    producer.send_messages
+    producer.deliver_messages
 
     message1 = kafka.fetch_messages(topic: "test-messages", partition: 0, offset: :earliest).last
     message2 = kafka.fetch_messages(topic: "test-messages", partition: 1, offset: :earliest).last
@@ -35,21 +35,21 @@ describe "Producer API", functional: true do
     producer.produce("hello1", key: "x", topic: "test-messages", partition_key: "xk")
     producer.produce("hello2", key: "y", topic: "test-messages", partition_key: "yk")
 
-    producer.send_messages
+    producer.deliver_messages
   end
 
   example "having the producer assign partitions based on message keys" do
     producer.produce("hello1", key: "x", topic: "test-messages")
     producer.produce("hello2", key: "y", topic: "test-messages")
 
-    producer.send_messages
+    producer.deliver_messages
   end
 
   example "omitting message keys entirely" do
     producer.produce("hello1", topic: "test-messages")
     producer.produce("hello2", topic: "test-messages")
 
-    producer.send_messages
+    producer.deliver_messages
   end
 
   example "writing to a an explicit partition of a topic that doesn't yet exist" do
@@ -57,7 +57,7 @@ describe "Producer API", functional: true do
 
     producer = kafka.get_producer(max_retries: 10, retry_backoff: 1)
     producer.produce("hello", topic: topic, partition: 0)
-    producer.send_messages
+    producer.deliver_messages
 
     expect(producer.buffer_size).to eq 0
 
@@ -71,7 +71,7 @@ describe "Producer API", functional: true do
 
     producer = kafka.get_producer(max_retries: 10, retry_backoff: 1)
     producer.produce("hello", topic: topic)
-    producer.send_messages
+    producer.deliver_messages
 
     expect(producer.buffer_size).to eq 0
 
@@ -91,7 +91,7 @@ describe "Producer API", functional: true do
       producer.produce("hello1", key: "x", topic: "test-messages", partition: 1)
       producer.produce("hello1", key: "x", topic: "test-messages", partition: 2)
 
-      producer.send_messages
+      producer.deliver_messages
     ensure
       KAFKA_CLUSTER.start_kafka_broker(0)
     end

--- a/spec/fuzz/producer_spec.rb
+++ b/spec/fuzz/producer_spec.rb
@@ -42,7 +42,7 @@ describe "Producing a lot of messages with an unreliable cluster", fuzz: true do
       producer.produce("message#{i}", key: i.to_s, topic: "fuzz")
 
       if i % publish_interval == 0
-        producer.send_messages
+        producer.deliver_messages
       end
     end
   end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -74,17 +74,17 @@ describe Kafka::Producer do
 
       # Only when we try to send the messages to Kafka do we experience the issue.
       expect {
-        producer.send_messages
+        producer.deliver_messages
       }.to raise_exception(Kafka::Error)
     end
   end
 
-  describe "#send_messages" do
+  describe "#deliver_messages" do
     it "sends messages to the leader of the partition being written to" do
       producer.produce("hello1", key: "greeting1", topic: "greetings", partition: 0)
       producer.produce("hello2", key: "greeting2", topic: "greetings", partition: 1)
 
-      producer.send_messages
+      producer.deliver_messages
 
       expect(broker1.messages).to eq ["hello1"]
       expect(broker2.messages).to eq ["hello2"]
@@ -95,7 +95,7 @@ describe Kafka::Producer do
 
       producer.produce("hello1", topic: "greetings", partition: 0)
 
-      expect { producer.send_messages }.to raise_error(Kafka::FailedToSendMessages)
+      expect { producer.deliver_messages }.to raise_error(Kafka::FailedToSendMessages)
 
       # The producer was not able to write the message, but it's still buffered.
       expect(producer.buffer_size).to eq 1
@@ -103,7 +103,7 @@ describe Kafka::Producer do
       # Clear the error.
       broker1.mark_partition_with_error(topic: "greetings", partition: 0, error_code: 0)
 
-      producer.send_messages
+      producer.deliver_messages
 
       expect(producer.buffer_size).to eq 0
     end
@@ -113,7 +113,7 @@ describe Kafka::Producer do
 
       producer.produce("hello1", topic: "greetings", partition: 0)
 
-      expect { producer.send_messages }.to raise_error(Kafka::FailedToSendMessages)
+      expect { producer.deliver_messages }.to raise_error(Kafka::FailedToSendMessages)
 
       # The producer was not able to write the message, but it's still buffered.
       expect(producer.buffer_size).to eq 1
@@ -121,7 +121,7 @@ describe Kafka::Producer do
       # Clear the error.
       allow(cluster).to receive(:get_leader) { broker1 }
 
-      producer.send_messages
+      producer.deliver_messages
 
       expect(producer.buffer_size).to eq 0
     end
@@ -136,7 +136,7 @@ describe Kafka::Producer do
       )
 
       producer.produce("hello1", topic: "greetings", partition: 0)
-      producer.send_messages
+      producer.deliver_messages
 
       # The producer was not able to write the message, but it's still buffered.
       expect(producer.buffer_size).to eq 0


### PR DESCRIPTION
I feel that "send" doesn't capture what's happening: the producer may "send" multiple requests, but it's all part of a single attempt at "delivering" the buffered messages.

This is a breaking API change, but at this point in ruby-kafka's development I'm not too worried about that. I want to have a nice API once we reach 1.0.

I'm also thinking about renaming `Producer#produce`, although I'm not sure what would be better. I'm afraid people will think `#produce` actually delivers the message...