### PR TITLE
Implement an async producer

### DIFF
--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -1,0 +1,181 @@
+require "thread"
+
+module Kafka
+
+  # A Kafka producer that does all its work in the background so as to not block
+  # the calling thread. Calls to {#deliver_messages} are asynchronous and return
+  # immediately.
+  #
+  # In addition to this property it's possible to define automatic delivery
+  # policies. These allow placing an upper bound on the number of buffered
+  # messages and the time between message deliveries.
+  #
+  # * If `delivery_threshold` is set to a value _n_ higher than zero, the producer
+  #   will automatically deliver its messages once its buffer size reaches _n_.
+  # * If `delivery_interval` is set to a value _n_ higher than zero, the producer
+  #   will automatically deliver its messages every _n_ seconds.
+  #
+  # By default, automatic delivery is disabled and you'll have to call
+  # {#deliver_messages} manually.
+  #
+  # The calling thread communicates with the background thread doing the actual
+  # work using a thread safe queue. While the background thread is busy delivering
+  # messages, new messages will be buffered in the queue. In order to avoid
+  # the queue growing uncontrollably in cases where the background thread gets
+  # stuck or can't follow the pace of the calling thread, there's a maximum
+  # number of messages that is allowed to be buffered. You can configure this
+  # value by setting `max_queue_size`.
+  #
+  # ## Example
+  #
+  #     producer = kafka.async_producer(
+  #       # Keep at most 1.000 messages in the buffer before delivering:
+  #       delivery_threshold: 1000,
+  #
+  #       # Deliver messages every 30 seconds:
+  #       delivery_interval: 30,
+  #     )
+  #
+  #     # There's no need to manually call #deliver_messages, it will happen
+  #     # automatically in the background.
+  #     producer.produce("hello", topic: "greetings")
+  #
+  #     # Remember to shut down the producer when you're done with it.
+  #     producer.shutdown
+  #
+  class AsyncProducer
+
+    # Initializes a new AsyncProducer.
+    #
+    # @param sync_producer [Kafka::Producer] the synchronous producer that should
+    #   be used in the background.
+    # @param max_queue_size [Integer] the maximum number of messages allowed in
+    #   the queue.
+    # @param delivery_threshold [Integer] if greater than zero, the number of
+    #   buffered messages that will automatically trigger a delivery.
+    # @param delivery_interval [Integer] if greater than zero, the number of
+    #   seconds between automatic message deliveries.
+    #
+    def initialize(sync_producer:, max_queue_size: 1000, delivery_threshold: 0, delivery_interval: 0)
+      raise ArgumentError unless max_queue_size > 0
+      raise ArgumentError unless delivery_threshold >= 0
+      raise ArgumentError unless delivery_interval >= 0
+
+      @queue = Queue.new
+      @max_queue_size = max_queue_size
+
+      @worker_thread = Thread.new do
+        worker = Worker.new(
+          queue: @queue,
+          producer: sync_producer,
+          delivery_threshold: delivery_threshold,
+        )
+
+        worker.run
+      end
+
+      @worker_thread.abort_on_exception = true
+
+      if delivery_interval > 0
+        Thread.new do
+          Timer.new(queue: @queue, interval: delivery_interval).run
+        end
+      end
+    end
+
+    # Produces a message to the specified topic.
+    #
+    # @see Kafka::Producer#produce
+    # @param (see Kafka::Producer#produce)
+    # @raise [BufferOverflow] if the message queue is full.
+    # @return [nil]
+    def produce(*args)
+      raise BufferOverflow if @queue.size >= @max_queue_size
+      @queue << [:produce, args]
+
+      nil
+    end
+
+    # Asynchronously delivers the buffered messages. This method will return
+    # immediately and the actual work will be done in the background.
+    #
+    # @see Kafka::Producer#deliver_messages
+    # @return [nil]
+    def deliver_messages
+      @queue << [:deliver_messages, nil]
+
+      nil
+    end
+
+    # Shuts down the producer, releasing the network resources used. This
+    # method will block until the buffered messages have been delivered.
+    #
+    # @see Kafka::Producer#shutdown
+    # @return [nil]
+    def shutdown
+      @queue << [:shutdown, nil]
+      @worker_thread.join
+
+      nil
+    end
+
+    class Timer
+      def initialize(interval:, queue:)
+        @queue = queue
+        @interval = interval
+      end
+
+      def run
+        loop do
+          sleep(@interval)
+          @queue << [:deliver_messages, nil]
+        end
+      end
+    end
+
+    class Worker
+      def initialize(queue:, producer:, delivery_threshold:)
+        @queue = queue
+        @producer = producer
+        @delivery_threshold = delivery_threshold
+      end
+
+      def run
+        loop do
+          operation, payload = @queue.pop
+
+          case operation
+          when :produce
+            @producer.produce(*payload)
+            deliver_messages if threshold_reached?
+          when :deliver_messages
+            deliver_messages
+          when :shutdown
+            # Deliver any pending messages first.
+            deliver_messages
+
+            # Stop the run loop.
+            break
+          else
+            raise "Unknown operation #{operation.inspect}"
+          end
+        end
+      ensure
+        @producer.shutdown
+      end
+
+      private
+
+      def deliver_messages
+        @producer.deliver_messages
+      rescue FailedToSendMessages
+        # Delivery failed.
+      end
+
+      def threshold_reached?
+        @delivery_threshold > 0 &&
+          @producer.buffer_size >= @delivery_threshold
+      end
+    end
+  end
+end

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -1,5 +1,6 @@
 require "kafka/cluster"
 require "kafka/producer"
+require "kafka/async_producer"
 require "kafka/fetched_message"
 require "kafka/fetch_operation"
 
@@ -49,6 +50,17 @@ module Kafka
     # @return [Kafka::Producer] the Kafka producer.
     def producer(**options)
       Producer.new(cluster: @cluster, logger: @logger, **options)
+    end
+
+    def async_producer(delivery_interval: 0, delivery_threshold: 0, max_queue_size: 1000, **options)
+      sync_producer = producer(**options)
+
+      AsyncProducer.new(
+        sync_producer: sync_producer,
+        delivery_interval: delivery_interval,
+        delivery_threshold: delivery_threshold,
+        max_queue_size: max_queue_size,
+      )
     end
 
     # Fetches a batch of messages from a single partition. Note that it's possible

--- a/spec/async_producer_spec.rb
+++ b/spec/async_producer_spec.rb
@@ -1,0 +1,55 @@
+class FakeSyncProducer
+  def initialize(mutex)
+    @mutex = mutex
+  end
+
+  def produce(*args)
+    @mutex.lock
+  end
+
+  def deliver_messages
+  end
+
+  def shutdown
+  end
+end
+
+describe Kafka::AsyncProducer do
+  describe "#produce" do
+    it "raises BufferOverflow if the queue exceeds the defined max size" do
+      # The sync producer will be blocked trying to grab the mutex.
+      mutex = Mutex.new
+      mutex.lock
+
+      sync_producer = FakeSyncProducer.new(mutex)
+
+      producer = Kafka::AsyncProducer.new(
+        sync_producer: sync_producer,
+        max_queue_size: 2,
+      )
+
+      expect {
+        3.times do
+          producer.produce("hello", topic: "greetings")
+        end
+      }.to raise_exception(Kafka::BufferOverflow)
+    end
+  end
+
+  describe "#deliver_messages" do
+    it "handles when the sync producer fails to deliver messages" do
+      sync_producer = double(:sync_producer, shutdown: nil, produce: nil)
+
+      producer = Kafka::AsyncProducer.new(
+        sync_producer: sync_producer,
+      )
+
+      producer.produce("hello", topic: "greetings")
+
+      allow(sync_producer).to receive(:deliver_messages).and_raise(Kafka::FailedToSendMessages)
+
+      producer.deliver_messages
+      producer.shutdown
+    end
+  end
+end

--- a/spec/functional/async_producer_spec.rb
+++ b/spec/functional/async_producer_spec.rb
@@ -1,0 +1,75 @@
+describe "Producer API", functional: true do
+  let(:logger) { Logger.new(LOG) }
+  let(:kafka) { Kafka.new(seed_brokers: KAFKA_BROKERS, client_id: "test", logger: logger) }
+  let(:producer) { kafka.async_producer(max_retries: 1, retry_backoff: 0) }
+
+  before do
+    require "test_cluster"
+  end
+
+  after do
+    producer.shutdown
+  end
+
+  example "writing messages using async producer" do
+    value1 = rand(10_000).to_s
+    value2 = rand(10_000).to_s
+
+    producer.produce(value1, key: "x", topic: "test-messages", partition: 0)
+    producer.produce(value2, key: "y", topic: "test-messages", partition: 1)
+
+    producer.deliver_messages
+
+    # Wait for everything to be delivered.
+    producer.shutdown
+
+    message1 = kafka.fetch_messages(topic: "test-messages", partition: 0, offset: :earliest).last
+    message2 = kafka.fetch_messages(topic: "test-messages", partition: 1, offset: :earliest).last
+
+    expect(message1.value).to eq value1
+    expect(message2.value).to eq value2
+  end
+
+  example "automatically delivering messages with a fixed time interval" do
+    producer = kafka.async_producer(delivery_interval: 0.1)
+
+    value = rand(10_000).to_s
+    producer.produce(value, topic: "test-messages", partition: 0)
+
+    sleep 0.2
+
+    messages = kafka.fetch_messages(
+      topic: "test-messages",
+      partition: 0,
+      offset: 0,
+      max_wait_time: 0.1,
+    )
+
+    expect(messages.last.value).to eq value
+
+    producer.shutdown
+  end
+
+  example "automatically delivering messages when a buffer threshold is reached" do
+    producer = kafka.async_producer(delivery_threshold: 5)
+
+    values = 5.times.map { rand(10_000).to_s }
+
+    values.each do |value|
+      producer.produce(value, topic: "test-messages", partition: 0)
+    end
+
+    sleep 0.2
+
+    messages = kafka.fetch_messages(
+      topic: "test-messages",
+      partition: 0,
+      offset: 0,
+      max_wait_time: 0,
+    )
+
+    expect(messages.last(5).map(&:value)).to eq values
+
+    producer.shutdown
+  end
+end

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -11,10 +11,6 @@ describe "Producer API", functional: true do
     producer.shutdown
   end
 
-  example "listing all topics in the cluster" do
-    expect(kafka.topics).to include "test-messages"
-  end
-
   example "writing messages using the buffered producer" do
     value1 = rand(10_000).to_s
     value2 = rand(10_000).to_s


### PR DESCRIPTION
Adds an async producer with options for automatic delivery:

* at a fixed time interval; and
* when the producer buffer reaches a configured threshold.

###### Tasks

- [x] Make sure there's a bound on the number of messages in the queue.
- [ ] Should we allow blocking on `#produce` if the queue is full?
- [ ] Ensure there are no races with the shared broker pool.

Closes #10.