### PR TITLE
Allow specifying a compression threshold

### DIFF
--- a/lib/kafka/produce_operation.rb
+++ b/lib/kafka/produce_operation.rb
@@ -25,12 +25,13 @@ module Kafka
   # * `sent_message_count` – the number of messages that were successfully sent.
   #
   class ProduceOperation
-    def initialize(cluster:, buffer:, compression_codec:, required_acks:, ack_timeout:, logger:)
+    def initialize(cluster:, buffer:, compression_codec:, compression_threshold:, required_acks:, ack_timeout:, logger:)
       @cluster = cluster
       @buffer = buffer
       @required_acks = required_acks
       @ack_timeout = ack_timeout
       @compression_codec = compression_codec
+      @compression_threshold = compression_threshold
       @logger = logger
     end
 
@@ -77,7 +78,12 @@ module Kafka
           messages_for_topics = {}
 
           message_buffer.each do |topic, partition, messages|
-            message_set = Protocol::MessageSet.new(messages: messages, compression_codec: @compression_codec)
+            message_set = Protocol::MessageSet.new(
+              messages: messages,
+              compression_codec: @compression_codec,
+              compression_threshold: @compression_threshold,
+            )
+
             messages_for_topics[topic] ||= {}
             messages_for_topics[topic][partition] = message_set
           end

--- a/lib/kafka/protocol/message_set.rb
+++ b/lib/kafka/protocol/message_set.rb
@@ -3,9 +3,14 @@ module Kafka
     class MessageSet
       attr_reader :messages
 
-      def initialize(messages: [], compression_codec: nil)
+      def initialize(messages: [], compression_codec: nil, compression_threshold: 1)
         @messages = messages
         @compression_codec = compression_codec
+        @compression_threshold = compression_threshold
+      end
+
+      def size
+        @messages.size
       end
 
       def ==(other)
@@ -13,10 +18,10 @@ module Kafka
       end
 
       def encode(encoder)
-        if @compression_codec.nil?
-          encode_without_compression(encoder)
-        else
+        if compress?
           encode_with_compression(encoder)
+        else
+          encode_without_compression(encoder)
         end
       end
 
@@ -38,6 +43,10 @@ module Kafka
       end
 
       private
+
+      def compress?
+        !@compression_codec.nil? && size >= @compression_threshold
+      end
 
       def encode_with_compression(encoder)
         codec = @compression_codec

--- a/spec/protocol/message_set_spec.rb
+++ b/spec/protocol/message_set_spec.rb
@@ -15,4 +15,26 @@ describe Kafka::Protocol::MessageSet do
 
     expect(decoded_message_set.messages.map(&:value)).to eq ["hello1", "hello2"]
   end
+
+  it "only compresses the messages if there are at least the configured threshold" do
+    message1 = Kafka::Protocol::Message.new(value: "hello1" * 100)
+    message2 = Kafka::Protocol::Message.new(value: "hello2" * 100)
+
+    compressed_message_set = Kafka::Protocol::MessageSet.new(
+      messages: [message1, message2],
+      compression_codec: Kafka::SnappyCodec.new,
+      compression_threshold: 2, # <-- only requires two messages for compression.
+    )
+
+    uncompressed_message_set = Kafka::Protocol::MessageSet.new(
+      messages: [message1, message2],
+      compression_codec: Kafka::SnappyCodec.new,
+      compression_threshold: 3, # <-- requires three messages for compression.
+    )
+
+    compressed_data = Kafka::Protocol::Encoder.encode_with(compressed_message_set)
+    uncompressed_data = Kafka::Protocol::Encoder.encode_with(uncompressed_message_set)
+
+    expect(compressed_data.bytesize).to be < uncompressed_data.bytesize
+  end
 end


### PR DESCRIPTION
In our use case we have a single producer that writes to dozens of topics, with an uneven throughput distribution. This means that it would make sense to enable compression for some topics and not others. On the other hand, our writes sometimes spike on some topics.

Rather than decide up front which topics should have compression enabled and which should not, this API would allow the user to set a threshold defined in terms of the number of messages buffered for a single partition. Only if the threshold is reached are the messages compressed.