### PR TITLE
Allow specifying buffer limits in terms of byte size

### DIFF
--- a/lib/kafka/pending_message.rb
+++ b/lib/kafka/pending_message.rb
@@ -2,12 +2,16 @@ module Kafka
   class PendingMessage
     attr_reader :value, :key, :topic, :partition, :partition_key
 
+    attr_reader :bytesize
+
     def initialize(value:, key:, topic:, partition:, partition_key:)
       @key = key
       @value = value
       @topic = topic
       @partition = partition
       @partition_key = partition_key
+
+      @bytesize = key.to_s.bytesize + value.to_s.bytesize
     end
   end
 end

--- a/lib/kafka/pending_message_queue.rb
+++ b/lib/kafka/pending_message_queue.rb
@@ -1,0 +1,43 @@
+module Kafka
+
+  # A pending message queue holds messages that have not yet been assigned to
+  # a partition. It's designed to only remove messages once they've been
+  # successfully handled.
+  class PendingMessageQueue
+    attr_reader :size, :bytesize
+
+    def initialize
+      @messages = []
+      @size = 0
+      @bytesize = 0
+    end
+
+    def write(message)
+      @messages << message
+      @size += 1
+      @bytesize += message.bytesize
+    end
+
+    def empty?
+      @messages.empty?
+    end
+
+    # Yields each message in the queue to the provided block, removing the
+    # message after the block has processed it. If the block raises an
+    # exception, the message will be retained in the queue.
+    #
+    # @yieldparam [PendingMessage] message
+    # @return [nil]
+    def dequeue_each(&block)
+      until @messages.empty?
+        message = @messages.first
+
+        yield message
+
+        @size -= 1
+        @bytesize -= message.bytesize
+        @messages.shift
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/message.rb
+++ b/lib/kafka/protocol/message.rb
@@ -18,11 +18,15 @@ module Kafka
 
       attr_reader :key, :value, :attributes, :offset
 
+      attr_reader :bytesize
+
       def initialize(value:, key: nil, attributes: 0, offset: -1)
         @key = key
         @value = value
         @attributes = attributes
         @offset = offset
+
+        @bytesize = @key.to_s.bytesize + @value.to_s.bytesize
       end
 
       def encode(encoder)


### PR DESCRIPTION
Since buffer size limits are mainly in place in order to avoid unbounded memory growth, defining the limits in terms of memory size makes sense. However, this does introduce some complexity – this is an attempt to see if it's worth the trouble.