### PR TITLE
Implement Consumer Group API

### DIFF
--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -59,6 +59,12 @@ module Kafka
   class OffsetMetadataTooLarge < ProtocolError
   end
 
+  class GroupCoordinatorNotAvailable < ProtocolError
+  end
+
+  class NotCoordinatorForGroup < ProtocolError
+  end
+
   # For a request which attempts to access an invalid topic (e.g. one which has
   # an illegal name), or if an attempt is made to write to an internal topic
   # (such as the consumer offsets topic).
@@ -87,6 +93,15 @@ module Kafka
 
   # Raised if a replica is expected on a broker, but is not. Can be safely ignored.
   class ReplicaNotAvailable < ProtocolError
+  end
+
+  class UnknownMemberId < ProtocolError
+  end
+
+  class IllegalGeneration < ProtocolError
+  end
+
+  class InvalidSessionTimeout < ProtocolError
   end
 
   # Raised when there's a network connection error.

--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -64,5 +64,47 @@ module Kafka
 
       @connection.send_request(request)
     end
+
+    def fetch_offsets(**options)
+      request = Protocol::OffsetFetchRequest.new(**options)
+
+      @connection.send_request(request)
+    end
+
+    def commit_offsets(**options)
+      request = Protocol::OffsetCommitRequest.new(**options)
+
+      @connection.send_request(request)
+    end
+
+    def join_group(**options)
+      request = Protocol::JoinGroupRequest.new(**options)
+
+      @connection.send_request(request)
+    end
+
+    def sync_group(**options)
+      request = Protocol::SyncGroupRequest.new(**options)
+
+      @connection.send_request(request)
+    end
+
+    def leave_group(**options)
+      request = Protocol::LeaveGroupRequest.new(**options)
+
+      @connection.send_request(request)
+    end
+
+    def find_group_coordinator(**options)
+      request = Protocol::GroupCoordinatorRequest.new(**options)
+
+      @connection.send_request(request)
+    end
+
+    def heartbeat(**options)
+      request = Protocol::HeartbeatRequest.new(**options)
+
+      @connection.send_request(request)
+    end
   end
 end

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -1,5 +1,6 @@
 require "kafka/cluster"
 require "kafka/producer"
+require "kafka/consumer"
 require "kafka/async_producer"
 require "kafka/fetched_message"
 require "kafka/fetch_operation"
@@ -60,6 +61,14 @@ module Kafka
         delivery_interval: delivery_interval,
         delivery_threshold: delivery_threshold,
         max_queue_size: max_queue_size,
+      )
+    end
+
+    def consumer(**options)
+      Consumer.new(
+        cluster: @cluster,
+        logger: @logger,
+        **options,
       )
     end
 

--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -126,6 +126,7 @@ module Kafka
 
       message = Kafka::Protocol::RequestMessage.new(
         api_key: request.api_key,
+        api_version: request.respond_to?(:api_version) ? request.api_version : 0,
         correlation_id: @correlation_id,
         client_id: @client_id,
         request: request,

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -1,0 +1,91 @@
+require "kafka/consumer_group"
+require "kafka/fetch_operation"
+
+module Kafka
+  class Consumer
+    def initialize(cluster:, logger:, group_id:)
+      @cluster = cluster
+      @logger = logger
+      @group_id = group_id
+
+      @group = ConsumerGroup.new(
+        cluster: cluster,
+        logger: logger,
+        group_id: group_id,
+      )
+
+      @offsets = {}
+      @default_offset = :earliest
+    end
+
+    def subscribe(topic)
+      @group.subscribe(topic)
+    end
+
+    def each_message(&block)
+      while true
+        batch = fetch_batch
+
+        batch.each do |message|
+          yield message
+
+          @offsets[message.topic] ||= {}
+          @offsets[message.topic][message.partition] = message.offset + 1
+        end
+
+        commit_offsets
+      end
+    end
+
+    def fetch_batch
+      @group.join unless @group.member?
+
+      @logger.debug "Fetching a batch of messages"
+
+      assigned_partitions = @group.assigned_partitions
+
+      # Make sure we're not kicked out of the group.
+      @group.heartbeat
+
+      raise "No partitions assigned!" if assigned_partitions.empty?
+
+      operation = FetchOperation.new(
+        cluster: @cluster,
+        logger: @logger,
+        min_bytes: 1,
+        max_wait_time: 5,
+      )
+
+      offset_response = @group.fetch_offsets
+
+      assigned_partitions.each do |topic, partitions|
+        partitions.each do |partition|
+          offset = @offsets.fetch(topic, {}).fetch(partition) {
+            offset_response.offset_for(topic, partition)
+          }
+
+          offset = @default_offset if offset < 0
+
+          @logger.debug "Fetching from #{topic}/#{partition} starting at offset #{offset}"
+
+          operation.fetch_from_partition(topic, partition, offset: offset)
+        end
+      end
+
+      messages = operation.execute
+
+      @logger.debug "Fetched #{messages.count} messages"
+
+      messages
+    end
+
+    def commit_offsets
+      @logger.debug "Committing offsets"
+      @group.commit_offsets(@offsets)
+    end
+
+    def shutdown
+      @group.leave
+    end
+  end
+end

--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -1,0 +1,170 @@
+require "set"
+require "kafka/protocol/member_assignment"
+
+module Kafka
+  class ConsumerGroup
+    attr_reader :assigned_partitions
+
+    def initialize(cluster:, logger:, group_id:)
+      @cluster = cluster
+      @logger = logger
+      @group_id = group_id
+      @session_timeout = 30
+      @member_id = ""
+      @generation_id = nil
+      @members = {}
+      @topics = Set.new
+      @assigned_partitions = {}
+    end
+
+    def subscribe(topic)
+      @topics.add(topic)
+      @cluster.add_target_topics([topic])
+    end
+
+    def member?
+      !@generation_id.nil?
+    end
+
+    def join
+      join_group
+      synchronize
+    rescue NotCoordinatorForGroup
+      @coordinator = nil
+      retry
+    rescue ConnectionError => e
+      @logger.error "Connection error (#{e}), retrying..."
+      @coordinator = nil
+      retry
+    end
+
+    def leave
+      @logger.info "[#{@member_id}] Leaving group `#{@group_id}`"
+      coordinator.leave_group(group_id: @group_id, member_id: @member_id)
+    end
+
+    def fetch_offsets
+      coordinator.fetch_offsets(
+        group_id: @group_id,
+        topics: @assigned_partitions,
+      )
+    end
+
+    def commit_offsets(offsets)
+      response = coordinator.commit_offsets(
+        group_id: @group_id,
+        member_id: @member_id,
+        generation_id: @generation_id,
+        offsets: offsets,
+      )
+
+      response.topics.each do |topic, partitions|
+        partitions.each do |partition, error_code|
+          Protocol.handle_error(error_code)
+        end
+      end
+    rescue UnknownMemberId
+      @logger.error "Kicked out of group; rejoining"
+      join
+      retry
+    rescue IllegalGeneration
+      @logger.error "Illegal generation #{@generation_id}; rejoining group"
+      join
+      retry
+    end
+
+    def heartbeat
+      @logger.info "[#{@member_id}] Sending heartbeat..."
+
+      response = coordinator.heartbeat(
+        group_id: @group_id,
+        generation_id: @generation_id,
+        member_id: @member_id,
+      )
+
+      Protocol.handle_error(response.error_code)
+    end
+
+    private
+
+    def join_group
+      @logger.info "Joining group `#{@group_id}`"
+
+      response = coordinator.join_group(
+        group_id: @group_id,
+        session_timeout: @session_timeout,
+        member_id: @member_id,
+      )
+
+      Protocol.handle_error(response.error_code)
+
+      @generation_id = response.generation_id
+      @member_id = response.member_id
+      @leader_id = response.leader_id
+      @members = response.members
+
+      @logger.info "[#{@member_id}] Joined group `#{@group_id}` with member id `#{@member_id}`"
+      @logger.info "[#{@member_id}] Leader for group `#{@group_id}` is `#{response.leader_id}`"
+    rescue UnknownMemberId
+      @member_id = nil
+
+      retry
+    end
+
+    def group_leader?
+      @member_id == @leader_id
+    end
+
+    def synchronize
+      @logger.info "[#{@member_id}] Synchronizing group"
+
+      group_assignment = {}
+
+      if group_leader?
+        @logger.info "[#{@member_id}] Chosen as leader of group `#{@group_id}`"
+
+        member_ids = @members.keys
+
+        member_ids.each do |member_id|
+          group_assignment[member_id] = Protocol::MemberAssignment.new
+        end
+
+        @topics.each do |topic|
+          partitions = @cluster.partitions_for(topic).map(&:partition_id)
+          partitions_per_member = partitions.group_by {|partition_id|
+            partition_id % member_ids.count
+          }.values
+
+          member_ids.zip(partitions_per_member).each do |member_id, member_partitions|
+            group_assignment[member_id].assign(topic, member_partitions)
+          end
+        end
+      end
+
+      response = coordinator.sync_group(
+        group_id: @group_id,
+        generation_id: @generation_id,
+        member_id: @member_id,
+        group_assignment: group_assignment,
+      )
+
+      Protocol.handle_error(response.error_code)
+
+      response.member_assignment.topics.each do |topic, assigned_partitions|
+        @logger.info "[#{@member_id}] Partitions assigned for `#{topic}`: #{assigned_partitions.join(', ')}"
+      end
+
+      @assigned_partitions.replace(response.member_assignment.topics)
+    end
+
+    def coordinator
+      @coordinator ||= @cluster.get_group_coordinator(group_id: @group_id)
+    rescue GroupCoordinatorNotAvailable
+      @logger.error "Group coordinator not available for group `#{@group_id}`"
+
+      sleep 1
+
+      retry
+    end
+  end
+end

--- a/lib/kafka/fetch_operation.rb
+++ b/lib/kafka/fetch_operation.rb
@@ -16,7 +16,7 @@ module Kafka
   #     operation.execute
   #
   class FetchOperation
-    def initialize(cluster:, logger:, min_bytes:, max_wait_time:)
+    def initialize(cluster:, logger:, min_bytes: 1, max_wait_time: 5)
       @cluster = cluster
       @logger = logger
       @min_bytes = min_bytes
@@ -24,7 +24,7 @@ module Kafka
       @topics = {}
     end
 
-    def fetch_from_partition(topic, partition, offset:, max_bytes:)
+    def fetch_from_partition(topic, partition, offset: :latest, max_bytes: 1048576)
       if offset == :earliest
         offset = -2
       elsif offset == :latest

--- a/lib/kafka/protocol.rb
+++ b/lib/kafka/protocol.rb
@@ -8,6 +8,13 @@ module Kafka
       1 => :fetch,
       2 => :list_offset,
       3 => :topic_metadata,
+      8 => :offset_commit,
+      9 => :offset_fetch,
+      10 => :group_coordinator,
+      11 => :join_group,
+      12 => :heartbeat,
+      13 => :leave_group,
+      14 => :sync_group,
     }
 
     ERRORS = {
@@ -23,11 +30,16 @@ module Kafka
       9 => ReplicaNotAvailable,
       10 => MessageSizeTooLarge,
       12 => OffsetMetadataTooLarge,
+      15 => GroupCoordinatorNotAvailable,
+      16 => NotCoordinatorForGroup,
       17 => InvalidTopic,
       18 => RecordListTooLarge,
       19 => NotEnoughReplicas,
       20 => NotEnoughReplicasAfterAppend,
       21 => InvalidRequiredAcks,
+      22 => IllegalGeneration,
+      25 => UnknownMemberId,
+      26 => InvalidSessionTimeout,
     }
 
     def self.handle_error(error_code)
@@ -54,3 +66,17 @@ require "kafka/protocol/fetch_request"
 require "kafka/protocol/fetch_response"
 require "kafka/protocol/list_offset_request"
 require "kafka/protocol/list_offset_response"
+require "kafka/protocol/group_coordinator_request"
+require "kafka/protocol/group_coordinator_response"
+require "kafka/protocol/join_group_request"
+require "kafka/protocol/join_group_response"
+require "kafka/protocol/sync_group_request"
+require "kafka/protocol/sync_group_response"
+require "kafka/protocol/leave_group_request"
+require "kafka/protocol/leave_group_response"
+require "kafka/protocol/heartbeat_request"
+require "kafka/protocol/heartbeat_response"
+require "kafka/protocol/offset_fetch_request"
+require "kafka/protocol/offset_fetch_response"
+require "kafka/protocol/offset_commit_request"
+require "kafka/protocol/offset_commit_response"

--- a/lib/kafka/protocol/consumer_group_protocol.rb
+++ b/lib/kafka/protocol/consumer_group_protocol.rb
@@ -1,0 +1,17 @@
+module Kafka
+  module Protocol
+    class ConsumerGroupProtocol
+      def initialize(version: 0, topics:, user_data: nil)
+        @version = version
+        @topics = topics
+        @user_data = user_data
+      end
+
+      def encode(encoder)
+        encoder.write_int16(@version)
+        encoder.write_array(@topics) {|topic| encoder.write_string(topic) }
+        encoder.write_bytes(@user_data)
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/group_coordinator_request.rb
+++ b/lib/kafka/protocol/group_coordinator_request.rb
@@ -1,0 +1,21 @@
+module Kafka
+  module Protocol
+    class GroupCoordinatorRequest
+      def initialize(group_id:)
+        @group_id = group_id
+      end
+
+      def api_key
+        10
+      end
+
+      def encode(encoder)
+        encoder.write_string(@group_id)
+      end
+
+      def response_class
+        GroupCoordinatorResponse
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/group_coordinator_response.rb
+++ b/lib/kafka/protocol/group_coordinator_response.rb
@@ -1,0 +1,25 @@
+module Kafka
+  module Protocol
+    class GroupCoordinatorResponse
+      attr_reader :error_code
+
+      attr_reader :coordinator_id, :coordinator_host, :coordinator_port
+
+      def initialize(error_code:, coordinator_id:, coordinator_host:, coordinator_port:)
+        @error_code = error_code
+        @coordinator_id = coordinator_id
+        @coordinator_host = coordinator_host
+        @coordinator_port = coordinator_port
+      end
+
+      def self.decode(decoder)
+        new(
+          error_code: decoder.int16,
+          coordinator_id: decoder.int32,
+          coordinator_host: decoder.string,
+          coordinator_port: decoder.int32,
+        )
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/group_protocol.rb
+++ b/lib/kafka/protocol/group_protocol.rb
@@ -1,0 +1,10 @@
+module Kafka
+  module Protocol
+    class ConsumerGroupProtocol
+      def initialize(name:, metadata:)
+        @name = name
+        @metadata = metadata
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/heartbeat_request.rb
+++ b/lib/kafka/protocol/heartbeat_request.rb
@@ -1,0 +1,25 @@
+module Kafka
+  module Protocol
+    class HeartbeatRequest
+      def initialize(group_id:, generation_id:, member_id:)
+        @group_id = group_id
+        @generation_id = generation_id
+        @member_id = member_id
+      end
+
+      def api_key
+        12
+      end
+
+      def response_class
+        HeartbeatResponse
+      end
+
+      def encode(encoder)
+        encoder.write_string(@group_id)
+        encoder.write_int32(@generation_id)
+        encoder.write_string(@member_id)
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/heartbeat_response.rb
+++ b/lib/kafka/protocol/heartbeat_response.rb
@@ -1,0 +1,15 @@
+module Kafka
+  module Protocol
+    class HeartbeatResponse
+      attr_reader :error_code
+
+      def initialize(error_code:)
+        @error_code = error_code
+      end
+
+      def self.decode(decoder)
+        new(error_code: decoder.int16)
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/join_group_request.rb
+++ b/lib/kafka/protocol/join_group_request.rb
@@ -1,0 +1,39 @@
+require "kafka/protocol/consumer_group_protocol"
+
+module Kafka
+  module Protocol
+    class JoinGroupRequest
+      PROTOCOL_TYPE = "consumer"
+
+      def initialize(group_id:, session_timeout:, member_id:, topics: [])
+        @group_id = group_id
+        @session_timeout = session_timeout * 1000 # Kafka wants ms.
+        @member_id = member_id || ""
+        @protocol_type = PROTOCOL_TYPE
+        @group_protocols = {
+          "standard" => ConsumerGroupProtocol.new(topics: ["test-messages"]),
+        }
+      end
+
+      def api_key
+        11
+      end
+
+      def response_class
+        JoinGroupResponse
+      end
+
+      def encode(encoder)
+        encoder.write_string(@group_id)
+        encoder.write_int32(@session_timeout)
+        encoder.write_string(@member_id)
+        encoder.write_string(@protocol_type)
+
+        encoder.write_array(@group_protocols) do |name, metadata|
+          encoder.write_string(name)
+          encoder.write_bytes(Encoder.encode_with(metadata))
+        end
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/join_group_response.rb
+++ b/lib/kafka/protocol/join_group_response.rb
@@ -1,0 +1,31 @@
+module Kafka
+  module Protocol
+    class JoinGroupResponse
+      attr_reader :error_code
+
+      attr_reader :generation_id, :group_protocol
+
+      attr_reader :leader_id, :member_id, :members
+
+      def initialize(error_code:, generation_id:, group_protocol:, leader_id:, member_id:, members:)
+        @error_code = error_code
+        @generation_id = generation_id
+        @group_protocol = group_protocol
+        @leader_id = leader_id
+        @member_id = member_id
+        @members = members
+      end
+
+      def self.decode(decoder)
+        new(
+          error_code: decoder.int16,
+          generation_id: decoder.int32,
+          group_protocol: decoder.string,
+          leader_id: decoder.string,
+          member_id: decoder.string,
+          members: Hash[decoder.array { [decoder.string, decoder.bytes] }],
+        )
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/leave_group_request.rb
+++ b/lib/kafka/protocol/leave_group_request.rb
@@ -1,0 +1,23 @@
+module Kafka
+  module Protocol
+    class LeaveGroupRequest
+      def initialize(group_id:, member_id:)
+        @group_id = group_id
+        @member_id = member_id
+      end
+
+      def api_key
+        13
+      end
+
+      def response_class
+        LeaveGroupResponse
+      end
+
+      def encode(encoder)
+        encoder.write_string(@group_id)
+        encoder.write_string(@member_id)
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/leave_group_response.rb
+++ b/lib/kafka/protocol/leave_group_response.rb
@@ -1,0 +1,15 @@
+module Kafka
+  module Protocol
+    class LeaveGroupResponse
+      attr_reader :error_code
+
+      def initialize(error_code:)
+        @error_code = error_code
+      end
+
+      def self.decode(decoder)
+        new(error_code: decoder.int16)
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/member_assignment.rb
+++ b/lib/kafka/protocol/member_assignment.rb
@@ -1,0 +1,40 @@
+module Kafka
+  module Protocol
+    class MemberAssignment
+      attr_reader :topics
+
+      def initialize(version: 0, topics: {}, user_data: nil)
+        @version = version
+        @topics = topics
+        @user_data = user_data
+      end
+
+      def assign(topic, partitions)
+        @topics[topic] ||= []
+        @topics[topic].concat(partitions)
+      end
+
+      def encode(encoder)
+        encoder.write_int16(@version)
+
+        encoder.write_array(@topics) do |topic, partitions|
+          encoder.write_string(topic)
+
+          encoder.write_array(partitions) do |partition|
+            encoder.write_int32(partition)
+          end
+        end
+
+        encoder.write_bytes(@user_data)
+      end
+
+      def self.decode(decoder)
+        new(
+          version: decoder.int16,
+          topics: Hash[decoder.array { [decoder.string, decoder.array { decoder.int32 }] }],
+          user_data: decoder.bytes,
+        )
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/offset_commit_request.rb
+++ b/lib/kafka/protocol/offset_commit_request.rb
@@ -1,0 +1,42 @@
+module Kafka
+  module Protocol
+    class OffsetCommitRequest
+      def api_key
+        8
+      end
+
+      def api_version
+        2
+      end
+
+      def response_class
+        OffsetCommitResponse
+      end
+
+      def initialize(group_id:, generation_id:, member_id:, retention_time: 0, offsets:)
+        @group_id = group_id
+        @generation_id = generation_id
+        @member_id = member_id
+        @retention_time = retention_time
+        @offsets = offsets
+      end
+
+      def encode(encoder)
+        encoder.write_string(@group_id)
+        encoder.write_int32(@generation_id)
+        encoder.write_string(@member_id)
+        encoder.write_int64(@retention_time)
+
+        encoder.write_array(@offsets) do |topic, partitions|
+          encoder.write_string(topic)
+
+          encoder.write_array(partitions) do |partition, offset|
+            encoder.write_int32(partition)
+            encoder.write_int64(offset)
+            encoder.write_string(nil) # metadata
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/offset_commit_response.rb
+++ b/lib/kafka/protocol/offset_commit_response.rb
@@ -1,0 +1,27 @@
+module Kafka
+  module Protocol
+    class OffsetCommitResponse
+      attr_reader :topics
+
+      def initialize(topics:)
+        @topics = topics
+      end
+
+      def self.decode(decoder)
+        topics = decoder.array {
+          topic = decoder.string
+          partitions = decoder.array {
+            partition = decoder.int32
+            error_code = decoder.int16
+
+            [partition, error_code]
+          }
+
+          [topic, Hash[partitions]]
+        }
+
+        new(topics: Hash[topics])
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/offset_fetch_request.rb
+++ b/lib/kafka/protocol/offset_fetch_request.rb
@@ -1,0 +1,34 @@
+module Kafka
+  module Protocol
+    class OffsetFetchRequest
+      def initialize(group_id:, topics:)
+        @group_id = group_id
+        @topics = topics
+      end
+
+      def api_key
+        9
+      end
+
+      def api_version
+        1
+      end
+
+      def response_class
+        OffsetFetchResponse
+      end
+
+      def encode(encoder)
+        encoder.write_string(@group_id)
+
+        encoder.write_array(@topics) do |topic, partitions|
+          encoder.write_string(topic)
+
+          encoder.write_array(partitions) do |partition|
+            encoder.write_int32(partition)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/offset_fetch_response.rb
+++ b/lib/kafka/protocol/offset_fetch_response.rb
@@ -1,0 +1,51 @@
+module Kafka
+  module Protocol
+    class OffsetFetchResponse
+      class PartitionOffsetInfo
+        attr_reader :offset, :metadata, :error_code
+
+        def initialize(offset:, metadata:, error_code:)
+          @offset = offset
+          @metadata = metadata
+          @error_code = error_code
+        end
+      end
+
+      attr_reader :topics
+
+      def initialize(topics:)
+        @topics = topics
+      end
+
+      def offset_for(topic, partition)
+        offset_info = topics.fetch(topic).fetch(partition)
+
+        Protocol.handle_error(offset_info.error_code)
+
+        offset_info.offset
+      end
+
+      def self.decode(decoder)
+        topics = decoder.array {
+          topic = decoder.string
+
+          partitions = decoder.array {
+            partition = decoder.int32
+
+            info = PartitionOffsetInfo.new(
+              offset: decoder.int64,
+              metadata: decoder.string,
+              error_code: decoder.int16,
+            )
+
+            [partition, info]
+          }
+
+          [topic, Hash[partitions]]
+        }
+
+        new(topics: Hash[topics])
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/sync_group_request.rb
+++ b/lib/kafka/protocol/sync_group_request.rb
@@ -1,0 +1,31 @@
+module Kafka
+  module Protocol
+    class SyncGroupRequest
+      def initialize(group_id:, generation_id:, member_id:, group_assignment: {})
+        @group_id = group_id
+        @generation_id = generation_id
+        @member_id = member_id
+        @group_assignment = group_assignment
+      end
+
+      def api_key
+        14
+      end
+
+      def response_class
+        SyncGroupResponse
+      end
+
+      def encode(encoder)
+        encoder.write_string(@group_id)
+        encoder.write_int32(@generation_id)
+        encoder.write_string(@member_id)
+
+        encoder.write_array(@group_assignment) do |member_id, member_assignment|
+          encoder.write_string(member_id)
+          encoder.write_bytes(Encoder.encode_with(member_assignment))
+        end
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/sync_group_response.rb
+++ b/lib/kafka/protocol/sync_group_response.rb
@@ -1,0 +1,21 @@
+require "kafka/protocol/member_assignment"
+
+module Kafka
+  module Protocol
+    class SyncGroupResponse
+      attr_reader :error_code, :member_assignment
+
+      def initialize(error_code:, member_assignment:)
+        @error_code = error_code
+        @member_assignment = member_assignment
+      end
+
+      def self.decode(decoder)
+        new(
+          error_code: decoder.int16,
+          member_assignment: MemberAssignment.decode(Decoder.from_string(decoder.bytes)),
+        )
+      end
+    end
+  end
+end

--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -1,0 +1,62 @@
+describe "Producer API", functional: true do
+  let(:logger) { Logger.new(LOG) }
+
+  before do
+    require "test_cluster"
+  end
+
+  example "joining a consumer group" do
+    num_partitions = 15
+    sent_messages = 1_000
+
+    KAFKA_CLUSTER.create_topic("topic-with-consumers", num_partitions: num_partitions, num_replicas: 1)
+
+    Thread.new do
+      kafka = Kafka.new(seed_brokers: KAFKA_BROKERS, client_id: "test")
+      producer = kafka.producer
+
+      1.upto(sent_messages) do |i|
+        producer.produce("hello", topic: "topic-with-consumers", partition_key: i.to_s)
+
+        if i % 100 == 0
+          producer.deliver_messages 
+          sleep 1
+        end
+      end
+
+      (0...num_partitions).each do |i|
+        # Send a tombstone to each partition.
+        producer.produce(nil, topic: "topic-with-consumers", partition: i)
+      end
+
+      producer.deliver_messages
+    end
+
+    threads = 2.times.map do |thread_id|
+      t = Thread.new do
+        received_messages = 0
+
+        kafka = Kafka.new(seed_brokers: KAFKA_BROKERS, client_id: "test", logger: logger)
+        consumer = kafka.consumer(group_id: "test")
+        consumer.subscribe("topic-with-consumers")
+
+        consumer.each_message do |message|
+          break if message.value.nil?
+          received_messages += 1
+        end
+
+        consumer.shutdown
+
+        received_messages
+      end
+
+      t.abort_on_exception = true
+
+      t
+    end
+
+    received_messages = threads.map(&:value).inject(0, &:+)
+
+    expect(received_messages).to eq sent_messages
+  end
+end


### PR DESCRIPTION
This is still very _very_ alpha level.

The consumer group API is very generic and therefore somewhat hard to grok. It's basically a general-purpose coordination API, with the consumer group API being a sub-protocol. The clients themselves are responsible for assigning partitions among themselves; one is selected as the leader for a specific generation and sends a list of member -> partitions assignments to the Kafka broker. This allows the clients to control assignment policies, but also makes it a bit more upfront work.

###### Tasks

- [x] Ensure heartbeats are sent periodically.
- [x] ~~Figure out a threading model that isn't too difficult to work with.~~ screw that, let's just keep everything synchronous for now.
- [x] Handle rebalances.
- [x] Fetch and commit offsets.