### PR TITLE
Automatically commit offsets at fixed intervals

### DIFF
--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -31,13 +31,15 @@ module Kafka
     end
 
     def commit_offsets
-      @logger.info "Committing offsets"
-      @group.commit_offsets(@processed_offsets)
-      @last_commit = Time.now
+      unless @processed_offsets.empty?
+        @logger.info "Committing offsets"
+        @group.commit_offsets(@processed_offsets)
+        @last_commit = Time.now
+      end
     end
 
     def commit_offsets_if_necessary
-      if Time.now - @last_commit >= @commit_interval
+      if seconds_since_last_commit >= @commit_interval
         commit_offsets
       end
     end
@@ -48,6 +50,10 @@ module Kafka
     end
 
     private
+
+    def seconds_since_last_commit
+      Time.now - @last_commit
+    end
 
     def committed_offset_for(topic, partition)
       @committed_offsets ||= @group.fetch_offsets

--- a/spec/fuzz/consumer_group_spec.rb
+++ b/spec/fuzz/consumer_group_spec.rb
@@ -1,6 +1,6 @@
 describe "Consumer groups", fuzz: true do
   let(:logger) { Logger.new(LOG) }
-  let(:num_messages) { 100_000 }
+  let(:num_messages) { 10_000 }
   let(:num_partitions) { 30 }
   let(:num_consumers) { 10 }
   let(:topic) { "fuzz-consumer-group" }
@@ -56,6 +56,7 @@ describe "Consumer groups", fuzz: true do
           size = num_messages - missing_messages.size
           puts "===> Received #{size} messages" if size % 100 == 0
         else
+          puts "===> Duplicate message #{message} received"
           duplicate_messages.add(message)
         end
       end
@@ -76,7 +77,7 @@ describe "Consumer groups", fuzz: true do
           connect_timeout: 20,
         )
 
-        consumer = kafka.consumer(group_id: "fuzz", session_timeout: 10)
+        consumer = kafka.consumer(group_id: "fuzz", session_timeout: 30)
         consumer.subscribe(topic)
 
         consumer.each_message do |message|


### PR DESCRIPTION
Automatically commits offsets every ten seconds. Another PR will make this configurable and probably add the option of expressing the commit frequency in terms of the number of messages processed.

Also fixed an issue that caused lots of duplicate processing: when an error code from the cluster caused a group re-join, we didn't reset the current message loop. Now such errors propagate to the loop, causing it to break and re-start with a new batch.