### PR TITLE
Allow specifying the offset commit policy as a threshold

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -83,8 +83,11 @@ module Kafka
     #   hasn't contacted the Kafka cluster, it will be kicked out of the group.
     # @param offset_commit_interval [Integer] the interval between offset commits,
     #   in seconds.
+    # @param offset_commit_threshold [Integer] the number of messages that can be
+    #   processed before their offsets are committed. If zero, offset commits are
+    #   not triggered by message processing.
     # @return [Consumer]
-    def consumer(group_id:, session_timeout: 30, offset_commit_interval: 10)
+    def consumer(group_id:, session_timeout: 30, offset_commit_interval: 10, offset_commit_threshold: 0)
       group = ConsumerGroup.new(
         cluster: @cluster,
         logger: @logger,
@@ -96,6 +99,7 @@ module Kafka
         group: group,
         logger: @logger,
         commit_interval: offset_commit_interval,
+        commit_threshold: offset_commit_threshold,
       )
 
       Consumer.new(

--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -1,10 +1,12 @@
 module Kafka
   class OffsetManager
-    def initialize(group:, logger:, commit_interval: 10)
+    def initialize(group:, logger:, commit_interval:, commit_threshold:)
       @group = group
       @logger = logger
       @commit_interval = commit_interval
+      @commit_threshold = commit_threshold
 
+      @uncommitted_offsets = 0
       @processed_offsets = {}
       @default_offsets = {}
       @committed_offsets = nil
@@ -16,6 +18,7 @@ module Kafka
     end
 
     def mark_as_processed(topic, partition, offset)
+      @uncommitted_offsets += 1
       @processed_offsets[topic] ||= {}
       @processed_offsets[topic][partition] = offset + 1
     end
@@ -32,19 +35,24 @@ module Kafka
 
     def commit_offsets
       unless @processed_offsets.empty?
-        @logger.info "Committing offsets"
+        @logger.info "Committing offsets for #{@uncommitted_offsets} messages"
+
         @group.commit_offsets(@processed_offsets)
+
         @last_commit = Time.now
+        @processed_offsets.clear
+        @uncommitted_offsets = 0
       end
     end
 
     def commit_offsets_if_necessary
-      if seconds_since_last_commit >= @commit_interval
+      if seconds_since_last_commit >= @commit_interval || commit_threshold_reached?
         commit_offsets
       end
     end
 
     def clear_offsets
+      @uncommitted_offsets = 0
       @processed_offsets.clear
       @committed_offsets = nil
     end
@@ -58,6 +66,10 @@ module Kafka
     def committed_offset_for(topic, partition)
       @committed_offsets ||= @group.fetch_offsets
       @committed_offsets.offset_for(topic, partition)
+    end
+
+    def commit_threshold_reached?
+      @commit_threshold != 0 && @uncommitted_offsets >= @commit_threshold
     end
   end
 end


### PR DESCRIPTION
The threshold represents the number of messages that can be processed before an offset commit is required, thus putting an upper bound on duplicate message processing in case a consumer dies.