### PR TITLE
SSL connection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Although parts of this library work with Kafka 0.8 – specifically, the Produce
   2. [Consuming Messages from Kafka](#consuming-messages-from-kafka)
 3. [Logging](#logging)
 4. [Understanding Timeouts](#understanding-timeouts)
-5. [Development](#development)
-6. [Roadmap](#roadmap)
+5. [SSL](#ssl)
+6. [Development](#development)
+7. [Roadmap](#roadmap)
 
 ## Installation
 
@@ -306,6 +307,33 @@ When sending many messages, it's likely that the client needs to send some messa
     n * (connect_timeout + socket_timeout + retry_backoff) * max_retries
 
 Make sure your application can survive being blocked for so long.
+
+### SSL
+
+Kafka 0.9+ supports SSL for authentication and authorization. There are two possible modes of operation:
+
+#### You have a 0.9 broker with SSL setup and only want to encrypt traffic to it:
+
+In this case you just need to pass `ssl: true` to `Kafka.new`. You don't need an SSL context.
+
+```ruby
+kafka = Kafka.new(ssl: true, ...)
+```
+
+#### You have a 0.9 broker with SSL setup and want to use client certificates and Kafka's authentication mechanism:
+
+In this case you need to pass `ssl: true`, and an `ssl_context` setup with the client certificate you want to use:
+
+```ruby
+ssl_context = OpenSSL::SSL::SSLContext.new
+ssl_context.set_params(
+  cert: OpenSSL::X509::Certificate.new(YOUR_CLIENT_CERTIFICATE),
+  key: OpenSSL::PKey::RSA.new(YOUR_CLIENT_CERTIFICATE_KEY),
+)
+kafka = Kafka.new(ssl: true, ssl_context: ssl_context ...)
+```
+
+Without these options, ssl support is disabled, and ruby-kafka will throw exceptions when trying to connect to an SSL socket.
 
 ## Development
 

--- a/examples/ssl-producer.rb
+++ b/examples/ssl-producer.rb
@@ -1,0 +1,42 @@
+# Reads lines from STDIN, writing them to Kafka.
+
+$LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
+
+require "kafka"
+
+logger = Logger.new($stderr)
+brokers = ENV.fetch("KAFKA_BROKERS").split(",")
+
+# Make sure to create this topic in your Kafka cluster or configure the
+# cluster to auto-create topics.
+topic = "page-visits"
+
+ssl_context = OpenSSL::SSL::SSLContext.new
+ssl_context.set_params(
+  cert: OpenSSL::X509::Certificate.new(ENV.fetch("KAFKA_CLIENT_CERT")),
+  key: OpenSSL::PKey::RSA.new(ENV.fetch("KAFKA_CLIENT_CERT_KEY")),
+)
+
+kafka = Kafka.new(
+  seed_brokers: brokers,
+  client_id: "ssl-producer",
+  logger: logger,
+  ssl: true,
+  ssl_context: ssl_context,
+)
+
+producer = kafka.producer
+
+begin
+  $stdin.each_with_index do |line, index|
+    producer.produce(line, topic: topic)
+
+    # Send messages for every 10 lines.
+    producer.deliver_messages if index % 10 == 0
+  end
+ensure
+  # Make sure to send any remaining messages.
+  producer.deliver_messages
+
+  producer.shutdown
+end

--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -2,12 +2,14 @@ require "kafka/broker"
 
 module Kafka
   class BrokerPool
-    def initialize(client_id:, connect_timeout: nil, socket_timeout: nil, logger:)
+    def initialize(client_id:, connect_timeout: nil, socket_timeout: nil, logger:, ssl: nil, ssl_context: nil)
       @client_id = client_id
       @connect_timeout = connect_timeout
       @socket_timeout = socket_timeout
       @logger = logger
       @brokers = {}
+      @ssl = ssl
+      @ssl_context = ssl_context
     end
 
     def connect(host, port, node_id: nil)
@@ -21,6 +23,8 @@ module Kafka
         connect_timeout: @connect_timeout,
         socket_timeout: @socket_timeout,
         logger: @logger,
+        ssl: @ssl,
+        ssl_context: @ssl_context,
       )
 
       @brokers[node_id] = broker unless node_id.nil?

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -24,7 +24,7 @@ module Kafka
     #   connections. See {BrokerPool#initialize}.
     #
     # @return [Client]
-    def initialize(seed_brokers:, client_id: "ruby-kafka", logger: nil, connect_timeout: nil, socket_timeout: nil)
+    def initialize(seed_brokers:, client_id: "ruby-kafka", logger: nil, connect_timeout: nil, socket_timeout: nil, ssl: nil, ssl_context: nil)
       @logger = logger || Logger.new("/dev/null")
 
       broker_pool = BrokerPool.new(
@@ -32,6 +32,8 @@ module Kafka
         connect_timeout: connect_timeout,
         socket_timeout: socket_timeout,
         logger: logger,
+        ssl: ssl,
+        ssl_context: ssl_context,
       )
 
       @cluster = Cluster.new(

--- a/lib/kafka/ssl_socket_with_timeout.rb
+++ b/lib/kafka/ssl_socket_with_timeout.rb
@@ -1,0 +1,158 @@
+require "socket"
+
+module Kafka
+
+  # Opens sockets in a non-blocking fashion, ensuring that we're not stalling
+  # for long periods of time.
+  #
+  # It's possible to set timeouts for connecting to the server, for reading data,
+  # and for writing data. Whenever a timeout is exceeded, Errno::ETIMEDOUT is
+  # raised.
+  #
+  class SSLSocketWithTimeout
+
+    # Opens a socket.
+    #
+    # @param host [String]
+    # @param port [Integer]
+    # @param connect_timeout [Integer] the connection timeout, in seconds.
+    # @param timeout [Integer] the read and write timeout, in seconds.
+    # @param ssl_context [OpenSSL::SSL::SSLContext] which SSLContext the ssl connection should use
+    # @raise [Errno::ETIMEDOUT] if the timeout is exceeded.
+    def initialize(host, port, connect_timeout: nil, timeout: nil, ssl_context: nil)
+      addr = Socket.getaddrinfo(host, nil)
+      sockaddr = Socket.pack_sockaddr_in(port, addr[0][3])
+
+      @timeout = timeout
+
+      @tcp_socket = Socket.new(Socket.const_get(addr[0][0]), Socket::SOCK_STREAM, 0)
+      @tcp_socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+
+      # first initiate the TCP socket
+      begin
+        # Initiate the socket connection in the background. If it doesn't fail 
+        # immediately it will raise an IO::WaitWritable (Errno::EINPROGRESS) 
+        # indicating the connection is in progress.
+        @tcp_socket.connect_nonblock(sockaddr)
+      rescue IO::WaitWritable
+        # IO.select will block until the socket is writable or the timeout
+        # is exceeded, whichever comes first.
+        unless IO.select(nil, [@tcp_socket], nil, connect_timeout)
+          # IO.select returns nil when the socket is not ready before timeout 
+          # seconds have elapsed
+          @tcp_socket.close
+          raise Errno::ETIMEDOUT
+        end
+
+        begin
+          # Verify there is now a good connection.
+          @tcp_socket.connect_nonblock(sockaddr)
+        rescue Errno::EISCONN
+          # The socket is connected, we're good!
+        end
+      end
+
+      # once that's connected, we can start initiating the ssl socket
+      if ssl_context
+        @ssl_socket = OpenSSL::SSL::SSLSocket.new(@tcp_socket, ssl_context)
+      else
+        @ssl_socket = OpenSSL::SSL::SSLSocket.new(@tcp_socket)
+      end
+
+      begin
+        # Initiate the socket connection in the background. If it doesn't fail 
+        # immediately it will raise an IO::WaitWritable (Errno::EINPROGRESS) 
+        # indicating the connection is in progress.
+        # Unlike waiting for a tcp socket to connect, you can't time out ssl socket
+        # connections during the connect phase properly, because IO.select only partially works.
+        # Instead, you have to retry.
+        @ssl_socket.connect_nonblock
+      rescue Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitReadable
+        IO.select([@ssl_socket])
+        retry
+      rescue IO::WaitWritable
+        IO.select(nil, [@ssl_socket])
+        retry
+      end
+    end
+
+    # Reads bytes from the socket, possible with a timeout.
+    #
+    # @param num_bytes [Integer] the number of bytes to read.
+    # @raise [Errno::ETIMEDOUT] if the timeout is exceeded.
+    # @return [String] the data that was read from the socket.
+    def read(num_bytes)
+      buffer = ''
+      until buffer.length >= num_bytes
+        begin
+          # unlike plain tcp sockets, ssl sockets don't support IO.select
+          # properly.
+          # Instead, timeouts happen on a per read basis, and we have to
+          # catch exceptions from read_nonblock, and gradually build up
+          # our read buffer.
+          buffer << @ssl_socket.read_nonblock(num_bytes - buffer.length)
+        rescue IO::WaitReadable
+          unless IO.select([@ssl_socket], nil, nil, @timeout)
+            raise Errno::ETIMEDOUT
+          end
+          retry
+        rescue IO::WaitWritable
+          unless IO.select(nil, [@ssl_socket], nil, @timeout)
+            raise Errno::ETIMEDOUT
+          end
+          retry
+        end
+      end
+      buffer
+    end
+
+    # Writes bytes to the socket, possible with a timeout.
+    #
+    # @param bytes [String] the data that should be written to the socket.
+    # @raise [Errno::ETIMEDOUT] if the timeout is exceeded.
+    # @return [Integer] the number of bytes written.
+    def write(bytes)
+      loop do
+        written = 0
+        begin
+          # unlike plain tcp sockets, ssl sockets don't support IO.select
+          # properly.
+          # Instead, timeouts happen on a per write basis, and we have to
+          # catch exceptions from write_nonblock, and gradually build up
+          # our write buffer.
+          written += @ssl_socket.write_nonblock(bytes)
+        rescue Errno::EFAULT => error
+            raise error
+        rescue OpenSSL::SSL::SSLError, Errno::EAGAIN, Errno::EWOULDBLOCK, IO::WaitWritable => error
+          if error.is_a?(OpenSSL::SSL::SSLError) && error.message == 'write would block'
+            if IO.select(nil, [@ssl_socket], nil, @timeout)
+              retry
+            else
+              raise Errno::ETIMEDOUT
+            end
+          else
+            raise error
+          end
+        end
+
+        # Fast, common case.
+        break if written == bytes.size
+
+        # This takes advantage of the fact that most ruby implementations
+        # have Copy-On-Write strings. Thusly why requesting a subrange
+        # of data, we actually don't copy data because the new string
+        # simply references a subrange of the original.
+        bytes = bytes[written, bytes.size]
+      end
+    end
+
+    def close
+      @tcp_socket.close
+      @ssl_socket.close
+    end
+
+    def set_encoding(encoding)
+      @tcp_socket.set_encoding(encoding)
+    end
+  end
+end

--- a/spec/ssl_socket_with_timeout_spec.rb
+++ b/spec/ssl_socket_with_timeout_spec.rb
@@ -1,0 +1,19 @@
+describe Kafka::SSLSocketWithTimeout, ".open" do
+  it "times out if the server doesn't accept the connection within the timeout" do
+    host = "10.255.255.1" # this address is non-routable!
+    port = 4444
+
+    timeout = 0.1
+    allowed_time = timeout + 0.1
+
+    start = Time.now
+
+    expect {
+      Kafka::SSLSocketWithTimeout.new(host, port, connect_timeout: timeout, timeout: 1)
+    }.to raise_exception(Errno::ETIMEDOUT)
+
+    finish = Time.now
+
+    expect(finish - start).to be < allowed_time
+  end
+end


### PR DESCRIPTION
This lets this client support ssl connections. I was relatively unsure of how to add tests for this, but have a staging environment setup with SSL support, so I've tested a number of failure scenarios and such.

This implements https://github.com/zendesk/ruby-kafka/issues/100.

Ruby SSL socket support is a nightmare, and actually impossible to use to do timeouts "correctly". I've left a lot of comments in the SSLSocketWithTimeout class to that effect.