### PR TITLE
cleaner SSL interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,26 +344,31 @@ Kafka 0.9+ supports SSL for authentication and authorization. There are two poss
 
 #### You have a 0.9 broker with SSL setup and only want to encrypt traffic to it:
 
-In this case you just need to pass `ssl: true` to `Kafka.new`. You don't need an SSL context.
+In this case you just need to pass `ssl_ca_cert: ` to `Kafka.new`:
 
 ```ruby
-kafka = Kafka.new(ssl: true, ...)
+kafka = Kafka.new(
+          ssl_ca_cert: File.read('my_ca_cert.pem'),
+          ...
+        )
 ```
+
+You need the CA cert to prevent against MITM attacks.
 
 #### You have a 0.9 broker with SSL setup and want to use client certificates and Kafka's authentication mechanism:
 
-In this case you need to pass `ssl: true`, and an `ssl_context` setup with the client certificate you want to use:
+In this case you need to pass `ssl_ca_cert:`, `ssl_client_cert:` and `ssl_client_cert_key:` to `Kafka.new`:
 
 ```ruby
-ssl_context = OpenSSL::SSL::SSLContext.new
-ssl_context.set_params(
-  cert: OpenSSL::X509::Certificate.new(YOUR_CLIENT_CERTIFICATE),
-  key: OpenSSL::PKey::RSA.new(YOUR_CLIENT_CERTIFICATE_KEY),
-)
-kafka = Kafka.new(ssl: true, ssl_context: ssl_context ...)
+kafka = Kafka.new(
+          ssl_ca_cert: File.read('my_ca_cert.pem'),
+          ssl_client_cert: File.read('my_client_cert.pem'),
+          ssl_client_cert_key: File.read('my_client_cert_key.pem'),
+          ...
+        )
 ```
 
-Without these options, ssl support is disabled, and ruby-kafka will throw exceptions when trying to connect to an SSL socket.
+Without any SSL options, SSL support is disabled, and `ruby-kafka` will throw exceptions when trying to connect to an SSL socket.
 
 ## Development
 

--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -2,13 +2,12 @@ require "kafka/broker"
 
 module Kafka
   class BrokerPool
-    def initialize(client_id:, connect_timeout: nil, socket_timeout: nil, logger:, ssl: nil, ssl_context: nil)
+    def initialize(client_id:, connect_timeout: nil, socket_timeout: nil, logger:, ssl_context: nil)
       @client_id = client_id
       @connect_timeout = connect_timeout
       @socket_timeout = socket_timeout
       @logger = logger
       @brokers = {}
-      @ssl = ssl
       @ssl_context = ssl_context
     end
 
@@ -23,7 +22,6 @@ module Kafka
         connect_timeout: @connect_timeout,
         socket_timeout: @socket_timeout,
         logger: @logger,
-        ssl: @ssl,
         ssl_context: @ssl_context,
       )
 

--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -43,13 +43,12 @@ module Kafka
     #   broker. Default is 10 seconds.
     #
     # @return [Connection] a new connection.
-    def initialize(host:, port:, client_id:, logger:, connect_timeout: nil, socket_timeout: nil, ssl: nil, ssl_context: nil)
+    def initialize(host:, port:, client_id:, logger:, connect_timeout: nil, socket_timeout: nil, ssl_context: nil)
       @host, @port, @client_id = host, port, client_id
       @logger = logger
 
       @connect_timeout = connect_timeout || CONNECT_TIMEOUT
       @socket_timeout = socket_timeout || SOCKET_TIMEOUT
-      @ssl = ssl
       @ssl_context = ssl_context
     end
 
@@ -104,7 +103,7 @@ module Kafka
     def open
       @logger.debug "Opening connection to #{@host}:#{@port} with client id #{@client_id}..."
 
-      if @ssl
+      if @ssl_context
         @socket = SSLSocketWithTimeout.new(@host, @port, connect_timeout: @connect_timeout, timeout: @socket_timeout, ssl_context: @ssl_context)
       else
         @socket = SocketWithTimeout.new(@host, @port, connect_timeout: @connect_timeout, timeout: @socket_timeout)

--- a/lib/kafka/ssl_socket_with_timeout.rb
+++ b/lib/kafka/ssl_socket_with_timeout.rb
@@ -19,7 +19,7 @@ module Kafka
     # @param timeout [Integer] the read and write timeout, in seconds.
     # @param ssl_context [OpenSSL::SSL::SSLContext] which SSLContext the ssl connection should use
     # @raise [Errno::ETIMEDOUT] if the timeout is exceeded.
-    def initialize(host, port, connect_timeout: nil, timeout: nil, ssl_context: nil)
+    def initialize(host, port, connect_timeout: nil, timeout: nil, ssl_context:)
       addr = Socket.getaddrinfo(host, nil)
       sockaddr = Socket.pack_sockaddr_in(port, addr[0][3])
 
@@ -53,11 +53,7 @@ module Kafka
       end
 
       # once that's connected, we can start initiating the ssl socket
-      if ssl_context
-        @ssl_socket = OpenSSL::SSL::SSLSocket.new(@tcp_socket, ssl_context)
-      else
-        @ssl_socket = OpenSSL::SSL::SSLSocket.new(@tcp_socket)
-      end
+      @ssl_socket = OpenSSL::SSL::SSLSocket.new(@tcp_socket, ssl_context)
 
       begin
         # Initiate the socket connection in the background. If it doesn't fail 

--- a/spec/ssl_socket_with_timeout_spec.rb
+++ b/spec/ssl_socket_with_timeout_spec.rb
@@ -9,7 +9,7 @@ describe Kafka::SSLSocketWithTimeout, ".open" do
     start = Time.now
 
     expect {
-      Kafka::SSLSocketWithTimeout.new(host, port, connect_timeout: timeout, timeout: 1)
+      Kafka::SSLSocketWithTimeout.new(host, port, connect_timeout: timeout, timeout: 1, ssl_context: OpenSSL::SSL::SSLContext.new)
     }.to raise_exception(Errno::ETIMEDOUT)
 
     finish = Time.now


### PR DESCRIPTION
instead of forcing the user to construct the SSL cert, take the most
common options and create an SSLContext from them.

This sidesteps a lot of potential security worries, and means our users don't need to read the docs for `SSLContext`.