### PR TITLE
Set a no output logger by default

### DIFF
--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -21,7 +21,8 @@ module Kafka
         raise ArgumentError, "At least one seed broker must be configured"
       end
 
-      @logger = logger
+      warn("No logger was configured, defaulting to not log output.") if logger.nil?
+      @logger = logger || Logger.new(nil)
       @seed_brokers = seed_brokers
       @broker_pool = broker_pool
       @cluster_info = nil

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -1,4 +1,42 @@
 describe Kafka::Cluster do
+  describe "#initialize" do
+    let(:seed_brokers) { ["test1:9092"] }
+    let(:broker_pool) { double(:broker_pool) }
+    let(:logger) { Logger.new(LOG) }
+
+    subject {
+      Kafka::Cluster.new(
+        seed_brokers: seed_brokers,
+        broker_pool: broker_pool,
+        logger: logger
+      )
+    }
+
+    context "when logger is not nil" do
+      it "sets the logger and does not warn" do
+        expect {
+          subject
+        }.to_not output.to_stderr
+        set_logger = subject.instance_variable_get("@logger")
+        expect(set_logger).to be_a Logger
+        expect(set_logger.instance_variable_get("@logdev")).to_not be_nil
+      end
+    end
+
+    context "when logger is nil" do
+      let(:logger) { nil }
+
+      it "sets a no output logger and warns about no logging" do
+        expect {
+          subject
+        }.to output("No logger was configured, defaulting to not log output.\n").to_stderr
+        set_logger = subject.instance_variable_get("@logger")
+        expect(set_logger).to be_a Logger
+        expect(set_logger.instance_variable_get("@logdev")).to be_nil
+      end
+    end
+  end
+
   describe "#get_leader" do
     let(:broker) { double(:broker) }
     let(:broker_pool) { double(:broker_pool) }


### PR DESCRIPTION
There are a lot of calls to `logger` so either a nil logger argument needs to either raise an ArgumentError or have a reasonable default.

Here I'm presuming that the logger argument being nil is merely development exploration of the gem, so defaulting to a nil logger with a warning is acceptable.

Fixes #121