### PR TITLE
Handle oversize messages being produced and rejected by the brokers

### DIFF
--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -92,4 +92,14 @@ describe "Producer API", functional: true do
       KAFKA_CLUSTER.start_kafka_broker(0)
     end
   end
+
+  example "sending a message that's too large for Kafka to handle" do
+    producer.produce("hello", topic: "test-messages", partition: 0)
+    producer.produce("x" * 1_000_000, topic: "test-messages", partition: 0)
+    producer.produce("goodbye", topic: "test-messages", partition: 0)
+
+    expect {
+      producer.deliver_messages
+    }.to raise_exception(Kafka::DeliveryFailed)
+  end
 end


### PR DESCRIPTION
Not sure how to deal with these:
- Discard the message?
- Raise an exception and have the user code deal with it?
- Magic?
