### PR TITLE
Remove the `shutdown` method from Consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,15 +313,10 @@ consumer = kafka.consumer(group_id: "my-consumer")
 
 consumer.subscribe("greetings")
 
-begin
-  # This will loop indefinitely, yielding each message in turn.
-  consumer.each_message do |message|
-    puts message.topic, message.partition
-    puts message.offset, message.key, message.value
-  end
-ensure
-  # Always make sure to shut down the consumer properly.
-  consumer.shutdown
+# This will loop indefinitely, yielding each message in turn.
+consumer.each_message do |message|
+  puts message.topic, message.partition
+  puts message.offset, message.key, message.value
 end
 ```
 

--- a/examples/firehose-consumer.rb
+++ b/examples/firehose-consumer.rb
@@ -35,20 +35,16 @@ threads = NUM_THREADS.times.map do |worker_id|
     consumer = kafka.consumer(group_id: "firehose")
     consumer.subscribe(KAFKA_TOPIC)
 
-    begin
-      i = 0
-      consumer.each_message do |message|
-        i += 1
+    i = 0
+    consumer.each_message do |message|
+      i += 1
 
-        if i % 1000 == 0
-          queue << i
-          i = 0
-        end
-
-        sleep 0.01
+      if i % 1000 == 0
+        queue << i
+        i = 0
       end
-    ensure
-      consumer.shutdown
+
+      sleep 0.01
     end
   end
 end

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -31,22 +31,14 @@ module Kafka
   #     # Subscribe to a Kafka topic:
   #     consumer.subscribe("messages")
   #
-  #     begin
-  #       # Loop forever, reading in messages from all topics that have been
-  #       # subscribed to.
-  #       consumer.each_message do |message|
-  #         puts message.topic
-  #         puts message.partition
-  #         puts message.key
-  #         puts message.value
-  #         puts message.offset
-  #       end
-  #     ensure
-  #       # Make sure to shut down the consumer after use. This lets
-  #       # the consumer notify the Kafka cluster that it's leaving
-  #       # the group, causing a synchronization and re-balancing of
-  #       # the group.
-  #       consumer.shutdown
+  #     # Loop forever, reading in messages from all topics that have been
+  #     # subscribed to.
+  #     consumer.each_message do |message|
+  #       puts message.topic
+  #       puts message.partition
+  #       puts message.key
+  #       puts message.value
+  #       puts message.offset
   #     end
   #
   class Consumer
@@ -130,24 +122,11 @@ module Kafka
           join_group
         end
       end
-    end
-
-    # Shuts down the consumer.
-    #
-    # In order to quickly have the consumer group re-balance itself, it's
-    # important that members explicitly tell Kafka when they're leaving.
-    # Therefore it's a good idea to call this method whenever your consumer
-    # is about to quit. If this method is not called, it may take up to
-    # the amount of time defined by the `session_timeout` parameter for
-    # Kafka to realize that this consumer is no longer present and trigger
-    # a group re-balance. In that period of time, the partitions that used
-    # to be assigned to this consumer won't be processed.
-    #
-    # @return [nil]
-    def shutdown
+    ensure
+      # In order to quickly have the consumer group re-balance itself, it's
+      # important that members explicitly tell Kafka when they're leaving.
       @offset_manager.commit_offsets
       @group.leave
-    rescue ConnectionError
     end
 
     private

--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -45,8 +45,6 @@ describe "Producer API", functional: true do
           received_messages += 1
         end
 
-        consumer.shutdown
-
         received_messages
       end
 


### PR DESCRIPTION
The consumer now automatically leaves the group when the `each_message` loop is broken. I may re-introduce `shutdown` with different semantics later in order to improve controlled shutdowns, e.g. a signal trap.