### PR TITLE
Batch oriented consumer API

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -235,7 +235,7 @@ module Kafka
 
       operation.fetch_from_partition(topic, partition, offset: offset, max_bytes: max_bytes)
 
-      operation.execute
+      operation.execute.flat_map {|batch| batch.messages }
     end
 
     # Lists all topics in the cluster.

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -93,27 +93,28 @@ module Kafka
 
       while @running
         begin
-          batch = fetch_batch
+          fetch_batches.each do |batch|
+            batch.messages.each do |message|
+              Instrumentation.instrument("process_message.consumer.kafka") do |notification|
+                notification.update(
+                  topic: message.topic,
+                  partition: message.partition,
+                  offset: message.offset,
+                  offset_lag: batch.highwater_mark_offset - message.offset,
+                  key: message.key,
+                  value: message.value,
+                )
 
-          batch.each do |message|
-            Instrumentation.instrument("process_message.consumer.kafka") do |notification|
-              notification.update(
-                topic: message.topic,
-                partition: message.partition,
-                offset: message.offset,
-                key: message.key,
-                value: message.value,
-              )
+                yield message
+              end
 
-              yield message
+              @offset_manager.commit_offsets_if_necessary
+
+              send_heartbeat_if_necessary
+              mark_message_as_processed(message)
+
+              break if !@running
             end
-
-            @offset_manager.commit_offsets_if_necessary
-
-            send_heartbeat_if_necessary
-            mark_message_as_processed(message)
-
-            break if !@running
           end
         rescue ConnectionError => e
           @logger.error "Connection error while sending heartbeat; rejoining"
@@ -148,10 +149,8 @@ module Kafka
       @group.join
     end
 
-    def fetch_batch
+    def fetch_batches
       join_group unless @group.member?
-
-      @logger.debug "Fetching a batch of messages"
 
       assigned_partitions = @group.assigned_partitions
 
@@ -170,17 +169,13 @@ module Kafka
         partitions.each do |partition|
           offset = @offset_manager.next_offset_for(topic, partition)
 
-          @logger.debug "Fetching from #{topic}/#{partition} starting at offset #{offset}"
+          @logger.debug "Fetching batch from #{topic}/#{partition} starting at offset #{offset}"
 
           operation.fetch_from_partition(topic, partition, offset: offset)
         end
       end
 
-      messages = operation.execute
-
-      @logger.info "Fetched #{messages.count} messages"
-
-      messages
+      operation.execute
     rescue ConnectionError => e
       @logger.error "Connection error while fetching messages: #{e}"
 

--- a/lib/kafka/fetched_batch.rb
+++ b/lib/kafka/fetched_batch.rb
@@ -1,0 +1,12 @@
+module Kafka
+  class FetchedBatch
+    attr_reader :topic, :partition, :highwater_mark_offset, :messages
+
+    def initialize(topic:, partition:, highwater_mark_offset:, messages:)
+      @topic = topic
+      @partition = partition
+      @highwater_mark_offset = highwater_mark_offset
+      @messages = messages
+    end
+  end
+end

--- a/lib/kafka/fetched_batch.rb
+++ b/lib/kafka/fetched_batch.rb
@@ -8,5 +8,9 @@ module Kafka
       @highwater_mark_offset = highwater_mark_offset
       @messages = messages
     end
+
+    def empty?
+      @messages.empty?
+    end
   end
 end

--- a/spec/functional/batch_consumer_spec.rb
+++ b/spec/functional/batch_consumer_spec.rb
@@ -1,0 +1,63 @@
+describe "Batch Consumer API", functional: true do
+  let(:logger) { Logger.new(LOG) }
+
+  before do
+    require "test_cluster"
+  end
+
+  example "consuming messages using the batch API" do
+    num_partitions = 15
+    message_count = 1_000
+    messages = (1...message_count).to_set
+    message_queue = Queue.new
+
+    KAFKA_CLUSTER.create_topic("topic-with-consumers", num_partitions: num_partitions, num_replicas: 1)
+
+    Thread.new do
+      kafka = Kafka.new(seed_brokers: KAFKA_BROKERS, client_id: "test")
+      producer = kafka.producer
+
+      messages.each do |i|
+        producer.produce(i.to_s, topic: "topic-with-consumers", partition_key: i.to_s)
+      end
+
+      producer.deliver_messages
+    end
+
+    threads = 2.times.map do |thread_id|
+      t = Thread.new do
+        kafka = Kafka.new(seed_brokers: KAFKA_BROKERS, client_id: "test", logger: logger)
+        consumer = kafka.consumer(group_id: "test")
+        consumer.subscribe("topic-with-consumers")
+
+        consumer.each_batch do |batch|
+          batch.messages.each do |message|
+            message_queue << Integer(message.value)
+          end
+        end
+      end
+
+      t.abort_on_exception = true
+
+      t
+    end
+
+    received_messages = Set.new
+    duplicates = Set.new
+
+    loop do
+      message = message_queue.pop
+
+      if received_messages.include?(message)
+        duplicates.add(message)
+      else
+        received_messages.add(message)
+      end
+
+      break if received_messages.size == messages.size
+    end
+
+    expect(received_messages).to eq messages
+    expect(duplicates).to eq Set.new
+  end
+end

--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -32,12 +32,14 @@ describe "Consumer API", functional: true do
       producer.deliver_messages
     end
 
+    group_id = "test#{rand(1000)}"
+
     threads = 2.times.map do |thread_id|
       t = Thread.new do
         received_messages = 0
 
         kafka = Kafka.new(seed_brokers: KAFKA_BROKERS, client_id: "test", logger: logger)
-        consumer = kafka.consumer(group_id: "test")
+        consumer = kafka.consumer(group_id: group_id)
         consumer.subscribe("topic-with-consumers")
 
         consumer.each_message do |message|


### PR DESCRIPTION
This API allows consumers to work on entire _batches_ of messages, where a _batch_ is a continuous set of messages from the same topic/partition. The use cases for typically revolve around wanting to amortize the cost of writing messages to an external store.

This is the proposed API:

```ruby
consumer = kafka.consumer(group_id: "my-group")

consumer.each_batch do |batch|
  txn = SomeStore::Transaction.new
  batch.messages.each {|message| txn.add(message.value) }
  txn.commit
end
```

Each message batch is yielded to the provided block; after the block returns, a heartbeat is sent to the group coordinator and perhaps the offset of the partition is committed (depending on configuration). This means that

1. The block should not spend more time than `session_timeout`, or the consumer will be kicked from the group.
2. The block must only return if _all_ messages in the batch have been successfully processed – otherwise, an exception must be raised.