### PR TITLE
Discard partial responses from Kafka

### DIFF
--- a/lib/kafka/protocol/decoder.rb
+++ b/lib/kafka/protocol/decoder.rb
@@ -92,7 +92,14 @@ module Kafka
       #
       # @return [String]
       def read(number_of_bytes)
-        @io.read(number_of_bytes) or raise EOFError
+        socket_data = @io.read(number_of_bytes) or raise EOFError
+
+        # check for partial response that should be ignored
+        if socket_data.size != number_of_bytes
+          raise EOFError
+        end
+
+        socket_data
       end
     end
   end


### PR DESCRIPTION
The Kafka API docs say:

> As an optimization the server is allowed to return a partial message
> at the end of the message set. Clients should handle this case.

https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-FetchAPI

Since the message declares the number of bytes to read it's possible to
ensure that many bytes were read from the socket. If there's a mismatch
then do not process those bytes as a response.

Fixes #133