### PR TITLE
Track message delivery delays

### DIFF
--- a/lib/kafka/message_buffer.rb
+++ b/lib/kafka/message_buffer.rb
@@ -14,8 +14,8 @@ module Kafka
       @bytesize = 0
     end
 
-    def write(value:, key:, topic:, partition:)
-      message = Protocol::Message.new(key: key, value: value)
+    def write(value:, key:, topic:, partition:, create_time: Time.now)
+      message = Protocol::Message.new(key: key, value: value, create_time: create_time)
 
       buffer_for(topic, partition) << message
 
@@ -60,8 +60,8 @@ module Kafka
       @buffer.delete(topic) if @buffer[topic].empty?
     end
 
-    def message_count_for_partition(topic:, partition:)
-      buffer_for(topic, partition).count
+    def messages_for(topic:, partition:)
+      buffer_for(topic, partition)
     end
 
     # Clears messages across all topics and partitions.

--- a/lib/kafka/pending_message.rb
+++ b/lib/kafka/pending_message.rb
@@ -2,14 +2,15 @@ module Kafka
   class PendingMessage
     attr_reader :value, :key, :topic, :partition, :partition_key
 
-    attr_reader :bytesize
+    attr_reader :bytesize, :create_time
 
-    def initialize(value:, key:, topic:, partition:, partition_key:)
+    def initialize(value:, key:, topic:, partition:, partition_key:, create_time:)
       @key = key
       @value = value
       @topic = topic
       @partition = partition
       @partition_key = partition_key
+      @create_time = create_time
 
       @bytesize = key.to_s.bytesize + value.to_s.bytesize
     end

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -181,12 +181,15 @@ module Kafka
     # @raise [BufferOverflow] if the maximum buffer size has been reached.
     # @return [nil]
     def produce(value, key: nil, topic:, partition: nil, partition_key: nil)
+      create_time = Time.now
+
       message = PendingMessage.new(
         value: value,
         key: key,
         topic: topic,
         partition: partition,
         partition_key: partition_key,
+        create_time: create_time,
       )
 
       if buffer_size >= @max_buffer_size
@@ -204,6 +207,7 @@ module Kafka
         value: value,
         key: key,
         topic: topic,
+        create_time: create_time,
         buffer_size: buffer_size,
         max_buffer_size: @max_buffer_size,
       })
@@ -322,6 +326,7 @@ module Kafka
           key: message.key,
           topic: message.topic,
           partition: partition,
+          create_time: message.create_time,
         )
       end
     rescue Kafka::Error => e

--- a/lib/kafka/protocol/message.rb
+++ b/lib/kafka/protocol/message.rb
@@ -18,13 +18,14 @@ module Kafka
 
       attr_reader :key, :value, :codec_id, :offset
 
-      attr_reader :bytesize
+      attr_reader :bytesize, :create_time
 
-      def initialize(value:, key: nil, codec_id: 0, offset: -1)
+      def initialize(value:, key: nil, create_time: Time.now, codec_id: 0, offset: -1)
         @key = key
         @value = value
         @codec_id = codec_id
         @offset = offset
+        @create_time = create_time
 
         @bytesize = @key.to_s.bytesize + @value.to_s.bytesize
       end


### PR DESCRIPTION
Write down the time a message was produced and include timing information in the message ack notifications. This will also fit well with [KIP-32](https://cwiki.apache.org/confluence/display/KAFKA/KIP-32+-+Add+timestamps+to+Kafka+message) once we switch to Kafka 0.10 APIs in the future.

My main concern is the switch to instrumenting individual message acks – when buffering e.g. 1,000 messages and delivering them at once, the cost of instrumentation could stack up...