### PR TITLE
Only use the three lowest attribute bits for the codec id

### DIFF
--- a/lib/kafka/compressor.rb
+++ b/lib/kafka/compressor.rb
@@ -34,7 +34,7 @@ module Kafka
 
       wrapper_message = Protocol::Message.new(
         value: compressed_data,
-        attributes: @codec.codec_id,
+        codec_id: @codec.codec_id,
       )
 
       Protocol::MessageSet.new(messages: [wrapper_message])


### PR DESCRIPTION
In anticipation of KIP-32, which starts using the 4th lowest attribute bit.