### PR TITLE
Make consumer heartbeat frequency configurable

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -139,8 +139,10 @@ module Kafka
     # @param offset_commit_threshold [Integer] the number of messages that can be
     #   processed before their offsets are committed. If zero, offset commits are
     #   not triggered by message processing.
+    # @param heartbeat_interval [Integer] the interval between heartbeats; must be less
+    #   than the session window.
     # @return [Consumer]
-    def consumer(group_id:, session_timeout: 30, offset_commit_interval: 10, offset_commit_threshold: 0)
+    def consumer(group_id:, session_timeout: 30, offset_commit_interval: 10, offset_commit_threshold: 0, heartbeat_interval: 10)
       group = ConsumerGroup.new(
         cluster: @cluster,
         logger: @logger,
@@ -161,6 +163,7 @@ module Kafka
         group: group,
         offset_manager: offset_manager,
         session_timeout: session_timeout,
+        heartbeat_interval: heartbeat_interval,
       )
     end
 

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -3,6 +3,7 @@ require "openssl"
 require "kafka/cluster"
 require "kafka/producer"
 require "kafka/consumer"
+require "kafka/heartbeat"
 require "kafka/async_producer"
 require "kafka/fetched_message"
 require "kafka/fetch_operation"
@@ -157,13 +158,18 @@ module Kafka
         commit_threshold: offset_commit_threshold,
       )
 
+      heartbeat = Heartbeat.new(
+        group: group,
+        interval: heartbeat_interval,
+      )
+
       Consumer.new(
         cluster: @cluster,
         logger: @logger,
         group: group,
         offset_manager: offset_manager,
         session_timeout: session_timeout,
-        heartbeat_interval: heartbeat_interval,
+        heartbeat: heartbeat,
       )
     end
 

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -43,13 +43,13 @@ module Kafka
   #
   class Consumer
 
-    def initialize(cluster:, logger:, group:, offset_manager:, session_timeout:, heartbeat_interval:)
+    def initialize(cluster:, logger:, group:, offset_manager:, session_timeout:, heartbeat:)
       @cluster = cluster
       @logger = logger
       @group = group
       @offset_manager = offset_manager
       @session_timeout = session_timeout
-      @heartbeat_interval = heartbeat_interval
+      @heartbeat = heartbeat
 
       # Whether or not the consumer is currently consuming messages.
       @running = false
@@ -109,7 +109,7 @@ module Kafka
 
             @offset_manager.commit_offsets_if_necessary
 
-            send_heartbeat_if_necessary
+            @heartbeat.send_if_necessary
             mark_message_as_processed(message)
 
             return if !@running
@@ -138,7 +138,7 @@ module Kafka
 
           @offset_manager.commit_offsets_if_necessary
 
-          send_heartbeat_if_necessary
+          @heartbeat.send_if_necessary
 
           return if !@running
         end
@@ -175,7 +175,7 @@ module Kafka
 
       assigned_partitions = @group.assigned_partitions
 
-      send_heartbeat_if_necessary
+      @heartbeat.send_if_necessary
 
       raise "No partitions assigned!" if assigned_partitions.empty?
 
@@ -201,21 +201,6 @@ module Kafka
       @logger.error "Connection error while fetching messages: #{e}"
 
       raise FetchError, e
-    end
-
-    # Sends a heartbeat if it would be necessary in order to avoid getting
-    # kicked out of the consumer group.
-    #
-    # Each consumer needs to send a heartbeat with a frequency defined by
-    # `session_timeout`.
-    #
-    def send_heartbeat_if_necessary
-      @last_heartbeat ||= Time.now
-
-      if Time.now > @last_heartbeat + @heartbeat_interval
-        @group.heartbeat
-        @last_heartbeat = Time.now
-      end
     end
 
     def mark_message_as_processed(message)

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -43,15 +43,13 @@ module Kafka
   #
   class Consumer
 
-    def initialize(cluster:, logger:, group:, offset_manager:, session_timeout:)
+    def initialize(cluster:, logger:, group:, offset_manager:, session_timeout:, heartbeat_interval:)
       @cluster = cluster
       @logger = logger
       @group = group
       @offset_manager = offset_manager
       @session_timeout = session_timeout
-
-      # Send two heartbeats in each session window, just to be sure.
-      @heartbeat_interval = @session_timeout / 2
+      @heartbeat_interval = heartbeat_interval
 
       # Whether or not the consumer is currently consuming messages.
       @running = false

--- a/lib/kafka/heartbeat.rb
+++ b/lib/kafka/heartbeat.rb
@@ -1,0 +1,16 @@
+module Kafka
+  class Heartbeat
+    def initialize(group:, interval:)
+      @group = group
+      @interval = interval
+      @last_heartbeat = Time.now
+    end
+
+    def send_if_necessary
+      if Time.now > @last_heartbeat + @interval
+        @group.heartbeat
+        @last_heartbeat = Time.now
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows configuring the consumer heartbeat interval. By default it's set to 10 seconds, which should be reasonable given the default session window size of 30 seconds.

```ruby
consumer = kafka.consumer(
  heartbeat_interval: 5, # send a heartbeat every five seconds
  # ...
)
```