### PR TITLE
Allow configuring fetch parameters when consuming messages

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -125,6 +125,24 @@ module Kafka
       end
     end
 
+    # Fetches and enumerates the messages in the topics that the consumer group
+    # subscribes to.
+    #
+    # Each batch of messages is yielded to the provided block. If the block returns
+    # without raising an exception, the batch will be considered successfully
+    # processed. At regular intervals the offset of the most recent successfully
+    # processed message batch in each partition will be committed to the Kafka
+    # offset store. If the consumer crashes or leaves the group, the group member
+    # that is tasked with taking over processing of these partitions will resume
+    # at the last committed offsets.
+    #
+    # @param min_bytes [Integer] the minimum number of bytes to read before
+    #   returning messages from the server; if `max_wait_time` is reached, this
+    #   is ignored.
+    # @param max_wait_time [Integer] the maximum duration of time to wait before
+    #   returning messages from the server, in seconds.
+    # @yieldparam batch [Kafka::FetchedBatch] a message batch fetched from Kafka.
+    # @return [nil]
     def each_batch(min_bytes: 1, max_wait_time: 5)
       consumer_loop do
         batches = fetch_batches(min_bytes: min_bytes, max_wait_time: max_wait_time)

--- a/lib/kafka/fetched_batch.rb
+++ b/lib/kafka/fetched_batch.rb
@@ -1,6 +1,18 @@
 module Kafka
+
+  # An ordered sequence of messages fetched from a Kafka partition.
   class FetchedBatch
-    attr_reader :topic, :partition, :highwater_mark_offset, :messages
+    # @return [String]
+    attr_reader :topic
+
+    # @return [Integer]
+    attr_reader :partition
+
+    # @return [Integer] the offset of the most recent message in the partition.
+    attr_reader :highwater_mark_offset
+
+    # @return [Array<Kafka::FetchedMessage>]
+    attr_reader :messages
 
     def initialize(topic:, partition:, highwater_mark_offset:, messages:)
       @topic = topic


### PR DESCRIPTION
By setting `min_bytes` and `max_wait_time` a consumer can trade off batch size and latency:

* `max_wait_time` is the maximum number of seconds the broker will wait before returning data to the client, effectively a bound on latency. A higher value allows for bigger batches.
* `min_bytes` specifies the minimum number of bytes a broker should wait for before returning data to the client. Ignored after `max_wait_time` is reached.

Note that both options are per broker, so when fetching from multiple brokers (as would be typical) the parameters would apply to individual client-broker requests, not to the overall fetch.