### PR TITLE
Need nil check for block because some points don't pass block

### DIFF
--- a/lib/kafka/instrumenter.rb
+++ b/lib/kafka/instrumenter.rb
@@ -18,7 +18,7 @@ module Kafka
 
         @backend.instrument("#{event_name}.#{NAMESPACE}", payload, &block)
       else
-        yield payload
+        block.call(payload) if block
       end
     end
   end


### PR DESCRIPTION
For example, this point doesn't pass block: https://github.com/zendesk/ruby-kafka/blob/7ffcf2c953b3560014c9312533e6a7eed8663fb4/lib/kafka/producer.rb#L207