### PR TITLE
Instrument errors in the producer

### DIFF
--- a/lib/kafka/produce_operation.rb
+++ b/lib/kafka/produce_operation.rb
@@ -63,7 +63,13 @@ module Kafka
           messages_for_broker[broker] ||= MessageBuffer.new
           messages_for_broker[broker].concat(messages, topic: topic, partition: partition)
         rescue Kafka::Error => e
-          @logger.error "Could not connect to leader for partition #{topic}/#{partition}: #{e}"
+          @logger.error "Could not connect to leader for partition #{topic}/#{partition}: #{e.message}"
+
+          @instrumenter.instrument("partition_error.producer", {
+            topic: topic,
+            partition: partition,
+            exception: [e.class.to_s, e.message],
+          })
 
           # We can't send the messages right now, so we'll just keep them in the buffer.
           # We'll mark the cluster as stale in order to force a metadata refresh.


### PR DESCRIPTION
This change will make the producer send notifications whenever a) it's not possible to find the leader of a partition or b) there's an error for a partition in a produce response. Clients can subscribe to these notifications in order to implement error monitoring.