### PR TITLE
Prevent TypeError in favor of user friendly "No partitions assigned!"

### DIFF
--- a/lib/kafka/round_robin_assignment_strategy.rb
+++ b/lib/kafka/round_robin_assignment_strategy.rb
@@ -30,7 +30,9 @@ module Kafka
         }.values
 
         members.zip(partitions_per_member).each do |member_id, member_partitions|
-          group_assignment[member_id].assign(topic, member_partitions)
+          unless member_partitions.nil?
+            group_assignment[member_id].assign(topic, member_partitions)
+          end
         end
       end
 


### PR DESCRIPTION
Although an edge case, the resulting error is understandable compared to: TypeError: no implicit conversion of nil into Array.
