### PR TITLE
Continue assigning partitions when there's an error

### DIFF
--- a/lib/kafka/pending_message_queue.rb
+++ b/lib/kafka/pending_message_queue.rb
@@ -1,8 +1,5 @@
 module Kafka
 
-  # A pending message queue holds messages that have not yet been assigned to
-  # a partition. It's designed to only remove messages once they've been
-  # successfully handled.
   class PendingMessageQueue
     attr_reader :size, :bytesize
 
@@ -26,22 +23,17 @@ module Kafka
       @bytesize = 0
     end
 
-    # Yields each message in the queue to the provided block, removing the
-    # message after the block has processed it. If the block raises an
-    # exception, the message will be retained in the queue.
+    def replace(messages)
+      clear
+      messages.each {|message| write(message) }
+    end
+
+    # Yields each message in the queue.
     #
     # @yieldparam [PendingMessage] message
     # @return [nil]
-    def dequeue_each(&block)
-      until @messages.empty?
-        message = @messages.first
-
-        yield message
-
-        @size -= 1
-        @bytesize -= message.bytesize
-        @messages.shift
-      end
+    def each(&block)
+      @messages.each(&block)
     end
   end
 end


### PR DESCRIPTION
Before, a topic error would stop messages for other topics from being assigned to a partition and therefore from being delivered. In order to better isolate topic errors, this change goes through all pending messages and writes those without errors to the produce operation buffer, leaving the rest in the pending message queue.