### PR TITLE
Instrument topic errors

### DIFF
--- a/lib/kafka/produce_operation.rb
+++ b/lib/kafka/produce_operation.rb
@@ -65,9 +65,8 @@ module Kafka
         rescue Kafka::Error => e
           @logger.error "Could not connect to leader for partition #{topic}/#{partition}: #{e.message}"
 
-          @instrumenter.instrument("partition_error.producer", {
+          @instrumenter.instrument("topic_error.producer", {
             topic: topic,
-            partition: partition,
             exception: [e.class.to_s, e.message],
           })
 
@@ -118,9 +117,8 @@ module Kafka
           begin
             Protocol.handle_error(partition_info.error_code)
           rescue ProtocolError => e
-            @instrumenter.instrument("partition_error.producer", {
+            @instrumenter.instrument("topic_error.producer", {
               topic: topic,
-              partition: partition,
               exception: [e.class.to_s, e.message],
             })
 

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -345,7 +345,12 @@ module Kafka
             partition: partition,
             create_time: message.create_time,
           )
-        rescue Kafka::Error
+        rescue Kafka::Error => e
+          @instrumenter.instrument("topic_error.producer", {
+            topic: message.topic,
+            exception: [e.class.to_s, e.message],
+          })
+
           failed_messages << message
         end
       end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -140,7 +140,7 @@ describe Kafka::Producer do
         events << ActiveSupport::Notifications::Event.new(*args)
       }
 
-      ActiveSupport::Notifications.subscribed(subscriber, "partition_error.producer.kafka") do
+      ActiveSupport::Notifications.subscribed(subscriber, "topic_error.producer.kafka") do
         producer.produce("hello1", topic: "greetings", partition: 0)
         expect { producer.deliver_messages }.to raise_error(Kafka::DeliveryFailed)
       end
@@ -148,7 +148,6 @@ describe Kafka::Producer do
       event = events.last
 
       expect(event.payload[:topic]).to eq "greetings"
-      expect(event.payload[:partition]).to eq 0
       expect(event.payload[:exception]).to eq ["Kafka::UnknownTopicOrPartition", "hello"]
     end
 
@@ -165,7 +164,7 @@ describe Kafka::Producer do
         events << ActiveSupport::Notifications::Event.new(*args)
       }
 
-      ActiveSupport::Notifications.subscribed(subscriber, "partition_error.producer.kafka") do
+      ActiveSupport::Notifications.subscribed(subscriber, "topic_error.producer.kafka") do
         producer.produce("hello1", topic: "greetings", partition: 0)
         expect { producer.deliver_messages }.to raise_error(Kafka::DeliveryFailed)
       end
@@ -173,7 +172,6 @@ describe Kafka::Producer do
       event = events.last
 
       expect(event.payload[:topic]).to eq "greetings"
-      expect(event.payload[:partition]).to eq 0
       expect(event.payload[:exception]).to eq ["Kafka::UnknownTopicOrPartition", "Kafka::UnknownTopicOrPartition"]
     end
   end


### PR DESCRIPTION
Currently, there's no direct way of tracking the errors encountered when assigning partitions to messages. Furthermore, the partition error instrument is confusing and too granular.