### PR TITLE
Don't use stale offset information when consuming messages

### DIFF
--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -40,8 +40,8 @@ module Kafka
         @group.commit_offsets(@processed_offsets)
 
         @last_commit = Time.now
-        @processed_offsets.clear
-        @uncommitted_offsets = 0
+
+        clear_offsets
       end
     end
 

--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -41,7 +41,7 @@ module Kafka
 
         @last_commit = Time.now
 
-        clear_offsets
+        @uncommitted_offsets = 0
       end
     end
 


### PR DESCRIPTION
After committing offsets, the consumer would clear the information of which offsets had been processed but fail to refresh the broker supplied table, leading to erroneous offset information.

Should fix #173.

~~This means that whenever we commit offsets, we also fetch the updated offset table, which is obviously inefficient. I'll try to improve performance soon.~~ Added a commit that only clears the necessary info, since the other caches are cleared whenever the consumer re-joins the group.