### PR TITLE
Refactor functional specs & improve resilience

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -183,6 +183,9 @@ module Kafka
           yield
         rescue HeartbeatError, OffsetCommitError, FetchError
           join_group
+        rescue LeaderNotAvailable => e
+          @logger.error "Leader not available; waiting 1s before retrying"
+          sleep 1
         end
       end
     ensure

--- a/lib/kafka/round_robin_assignment_strategy.rb
+++ b/lib/kafka/round_robin_assignment_strategy.rb
@@ -37,6 +37,9 @@ module Kafka
       end
 
       group_assignment
+    rescue Kafka::LeaderNotAvailable
+      sleep 1
+      retry
     end
   end
 end

--- a/spec/functional/batch_consumer_spec.rb
+++ b/spec/functional/batch_consumer_spec.rb
@@ -11,14 +11,14 @@ describe "Batch Consumer API", functional: true do
     messages = (1...message_count).to_set
     message_queue = Queue.new
 
-    KAFKA_CLUSTER.create_topic("topic-with-batch-consumers", num_partitions: num_partitions, num_replicas: 1)
+    topic = create_random_topic(num_partitions: 15)
 
     Thread.new do
       kafka = Kafka.new(seed_brokers: KAFKA_BROKERS, client_id: "test")
       producer = kafka.producer
 
       messages.each do |i|
-        producer.produce(i.to_s, topic: "topic-with-batch-consumers", partition_key: i.to_s)
+        producer.produce(i.to_s, topic: topic, partition_key: i.to_s)
       end
 
       producer.deliver_messages
@@ -30,7 +30,7 @@ describe "Batch Consumer API", functional: true do
       t = Thread.new do
         kafka = Kafka.new(seed_brokers: KAFKA_BROKERS, client_id: "test", logger: logger)
         consumer = kafka.consumer(group_id: group_id)
-        consumer.subscribe("topic-with-batch-consumers")
+        consumer.subscribe(topic)
 
         consumer.each_batch do |batch|
           batch.messages.each do |message|

--- a/spec/functional/client_spec.rb
+++ b/spec/functional/client_spec.rb
@@ -16,16 +16,18 @@ describe "Producer API", functional: true do
     kafka.close
   end
 
+  let!(:topic) { create_random_topic(num_partitions: 3) }
+
   example "listing all topics in the cluster" do
-    expect(kafka.topics).to include "test-messages"
+    expect(kafka.topics).to include topic
   end
 
   example "fetching the partition count for a topic" do
-    expect(kafka.partitions_for("test-messages")).to eq 3
+    expect(kafka.partitions_for(topic)).to eq 3
   end
 
   example "fetching the partition count for a topic that doesn't yet exist" do
-    topic = "unknown-topic"
+    topic = "unknown-topic-#{rand(1000)}"
 
     expect { kafka.partitions_for(topic) }.to raise_exception(Kafka::LeaderNotAvailable)
 

--- a/spec/functional/compression_spec.rb
+++ b/spec/functional/compression_spec.rb
@@ -8,6 +8,8 @@ describe "Compression", functional: true do
     require "test_cluster"
   end
 
+  let!(:topic) { create_random_topic(num_partitions: 3) }
+
   example "producing and consuming snappy-compressed messages" do
     producer = kafka.producer(
       compression_codec: :snappy,
@@ -17,13 +19,13 @@ describe "Compression", functional: true do
 
     last_offset = fetch_last_offset
 
-    producer.produce("message1", topic: "test-messages", partition: 0)
-    producer.produce("message2", topic: "test-messages", partition: 0)
+    producer.produce("message1", topic: topic, partition: 0)
+    producer.produce("message2", topic: topic, partition: 0)
 
     producer.deliver_messages
 
     messages = kafka.fetch_messages(
-      topic: "test-messages",
+      topic: topic,
       partition: 0,
       offset: last_offset + 1,
     )
@@ -40,13 +42,13 @@ describe "Compression", functional: true do
 
     last_offset = fetch_last_offset
 
-    producer.produce("message1", topic: "test-messages", partition: 0)
-    producer.produce("message2", topic: "test-messages", partition: 0)
+    producer.produce("message1", topic: topic, partition: 0)
+    producer.produce("message2", topic: topic, partition: 0)
 
     producer.deliver_messages
 
     messages = kafka.fetch_messages(
-      topic: "test-messages",
+      topic: topic,
       partition: 0,
       offset: last_offset + 1,
     )
@@ -55,7 +57,7 @@ describe "Compression", functional: true do
   end
 
   def fetch_last_offset
-    last_message = kafka.fetch_messages(topic: "test-messages", partition: 0, offset: 0).last
+    last_message = kafka.fetch_messages(topic: topic, partition: 0, offset: 0).last
     last_message ? last_message.offset : 0
   end
 end

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -1,7 +1,7 @@
 describe "Producer API", functional: true do
   let(:logger) { LOGGER }
   let(:kafka) { Kafka.new(seed_brokers: KAFKA_BROKERS, client_id: "test", logger: logger) }
-  let(:producer) { kafka.producer(max_retries: 1, retry_backoff: 0) }
+  let(:producer) { kafka.producer(max_retries: 3, retry_backoff: 1) }
 
   before do
     require "test_cluster"
@@ -11,39 +11,41 @@ describe "Producer API", functional: true do
     producer.shutdown
   end
 
+  let!(:topic) { create_random_topic(num_partitions: 3) }
+
   example "writing messages using the buffered producer" do
     value1 = rand(10_000).to_s
     value2 = rand(10_000).to_s
 
-    producer.produce(value1, key: "x", topic: "test-messages", partition: 0)
-    producer.produce(value2, key: "y", topic: "test-messages", partition: 1)
+    producer.produce(value1, key: "x", topic: topic, partition: 0)
+    producer.produce(value2, key: "y", topic: topic, partition: 1)
 
     producer.deliver_messages
 
-    message1 = kafka.fetch_messages(topic: "test-messages", partition: 0, offset: :earliest).last
-    message2 = kafka.fetch_messages(topic: "test-messages", partition: 1, offset: :earliest).last
+    message1 = kafka.fetch_messages(topic: topic, partition: 0, offset: :earliest).last
+    message2 = kafka.fetch_messages(topic: topic, partition: 1, offset: :earliest).last
 
     expect(message1.value).to eq value1
     expect(message2.value).to eq value2
   end
 
   example "having the producer assign partitions based on partition keys" do
-    producer.produce("hello1", key: "x", topic: "test-messages", partition_key: "xk")
-    producer.produce("hello2", key: "y", topic: "test-messages", partition_key: "yk")
+    producer.produce("hello1", key: "x", topic: topic, partition_key: "xk")
+    producer.produce("hello2", key: "y", topic: topic, partition_key: "yk")
 
     producer.deliver_messages
   end
 
   example "having the producer assign partitions based on message keys" do
-    producer.produce("hello1", key: "x", topic: "test-messages")
-    producer.produce("hello2", key: "y", topic: "test-messages")
+    producer.produce("hello1", key: "x", topic: topic)
+    producer.produce("hello2", key: "y", topic: topic)
 
     producer.deliver_messages
   end
 
   example "omitting message keys entirely" do
-    producer.produce("hello1", topic: "test-messages")
-    producer.produce("hello2", topic: "test-messages")
+    producer.produce("hello1", topic: topic)
+    producer.produce("hello2", topic: topic)
 
     producer.deliver_messages
   end
@@ -77,15 +79,17 @@ describe "Producer API", functional: true do
   end
 
   example "handle a broker going down after the initial discovery" do
+    topic = create_random_topic(num_partitions: 3, num_replicas: 2)
+
     begin
-      producer = kafka.producer(max_retries: 10, retry_backoff: 1)
+      producer = kafka.producer(max_retries: 30, retry_backoff: 2)
 
       KAFKA_CLUSTER.kill_kafka_broker(0)
 
       # Write to all partitions so that we'll be sure to hit the broker.
-      producer.produce("hello1", key: "x", topic: "test-messages", partition: 0)
-      producer.produce("hello1", key: "x", topic: "test-messages", partition: 1)
-      producer.produce("hello1", key: "x", topic: "test-messages", partition: 2)
+      producer.produce("hello1", key: "x", topic: topic, partition: 0)
+      producer.produce("hello1", key: "x", topic: topic, partition: 1)
+      producer.produce("hello1", key: "x", topic: topic, partition: 2)
 
       producer.deliver_messages
     ensure

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,9 +10,33 @@ Dotenv.load
 LOGGER = Logger.new(ENV.key?("LOG_TO_STDERR") ? $stderr : StringIO.new)
 LOGGER.level = Logger.const_get(ENV.fetch("LOG_LEVEL", "INFO"))
 
+module SpecHelpers
+  def generate_topic_name
+    @@topic_number ||= 0
+    @@topic_number += 1
+
+    "topic-#{@@topic_number}"
+  end
+
+  def create_random_topic(*args)
+    topic = generate_topic_name
+    create_topic(topic, *args)
+    topic
+  end
+
+  def create_topic(*args)
+    cluster.create_topic(*args)
+  end
+
+  def cluster
+    KAFKA_CLUSTER
+  end
+end
+
 RSpec.configure do |config|
   config.filter_run_excluding functional: true, performance: true, fuzz: true
   config.include RSpec::Benchmark::Matchers
+  config.include SpecHelpers
 end
 
 ActiveSupport::Notifications.subscribe(/.*\.kafka$/) do |*args|

--- a/spec/test_cluster.rb
+++ b/spec/test_cluster.rb
@@ -96,12 +96,12 @@ class TestCluster
       "--zookeeper zk",
     ]
 
-    puts "Creating topic #{topic}..."
+    print "Creating topic #{topic}... "
     out, err, status = @kafka.exec(command)
 
     raise "Command failed: #{out}" if status != 0
 
-    sleep 2
+    puts "OK"
   end
 
   def stop
@@ -137,11 +137,8 @@ class TestCluster
   end
 end
 
-KAFKA_TOPIC = "test-messages"
-
 KAFKA_CLUSTER = TestCluster.new
 KAFKA_CLUSTER.start
-KAFKA_CLUSTER.create_topic(KAFKA_TOPIC, num_partitions: 3, num_replicas: 2)
 
 KAFKA_BROKERS = KAFKA_CLUSTER.kafka_hosts
 


### PR DESCRIPTION
Rather than re-using the same topic across examples we now create topics on demand. This change flushed out a few errors related to partitions not having a leader, which were fixed at the same time.