### PR TITLE
Handle connection errors in the async producer

### DIFF
--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -211,8 +211,8 @@ module Kafka
 
       def deliver_messages
         @producer.deliver_messages
-      rescue DeliveryFailed
-        # Delivery failed.
+      rescue DeliveryFailed, ConnectionError
+        # Failed to deliver messages -- nothing to do but try again later.
       end
 
       def threshold_reached?


### PR DESCRIPTION
We shouldn't crash the application when that happens. Closes #184.