### PR TITLE
Handle message buffer edge case

### DIFF
--- a/lib/kafka/message_buffer.rb
+++ b/lib/kafka/message_buffer.rb
@@ -27,7 +27,7 @@ module Kafka
       buffer_for(topic, partition).concat(messages)
 
       @size += messages.count
-      @bytesize += messages.map(&:bytesize).reduce(:+)
+      @bytesize += messages.map(&:bytesize).reduce(0, :+)
     end
 
     def to_h

--- a/spec/message_buffer_spec.rb
+++ b/spec/message_buffer_spec.rb
@@ -1,6 +1,22 @@
 describe Kafka::MessageBuffer do
   let(:buffer) { Kafka::MessageBuffer.new }
 
+  describe "#concat" do
+    it "adds the messages to the buffer" do
+      buffer.concat(["foo"], topic: "foo", partition: 0)
+
+      expect(buffer.size).to eq 1
+      expect(buffer.bytesize).to eq 3
+    end
+
+    it "handles empty arrays" do
+      buffer.concat([], topic: "foo", partition: 0)
+
+      expect(buffer.size).to eq 0
+      expect(buffer.bytesize).to eq 0
+    end
+  end
+
   describe "#size" do
     it "returns the number of messages in the buffer" do
       buffer.concat(["a", "b", "c"], topic: "bar", partition: 3)


### PR DESCRIPTION
For some reason, `#concat` is sometimes called with an empty array. This caused the code to blow up.

Fixes #188.