### PR TITLE
Handle rebalances in the producer

### DIFF
--- a/lib/kafka/produce_operation.rb
+++ b/lib/kafka/produce_operation.rb
@@ -138,6 +138,7 @@ module Kafka
           @logger.error "Corrupt message when writing to #{topic}/#{partition}"
         rescue Kafka::UnknownTopicOrPartition
           @logger.error "Unknown topic or partition #{topic}/#{partition}"
+          @cluster.mark_as_stale!
         rescue Kafka::LeaderNotAvailable
           @logger.error "Leader currently not available for #{topic}/#{partition}"
           @cluster.mark_as_stale!


### PR DESCRIPTION
After a rebalance the producer fails to send the messages
with 'Unknown topic or partition' error.

By forcing a cluster metadata refresh after rescuing this error the
producer adapts to the new cluster state and continues to send
the messages normally.

I reproduce the problem with the following steps:

I run the following producer script: 
```
require "kafka"

kafka = Kafka.new(seed_brokers: ["kafka.vm.skroutz.gr:9092", "kafka-b.vm.skroutz.gr:9092"], 
                  logger: Logger.new(STDOUT))

producer = kafka.async_producer(delivery_interval: 10)

while true
  producer.produce("hello", topic: "skroutz.test")
  sleep 5
end
```

Cluster state before rebalance:
![2016-05-26-152822_674x232_scrot](https://cloud.githubusercontent.com/assets/895410/15574797/1538b2ba-2358-11e6-8a72-5bf07108f2f3.png)

Logger output before rebalance:
```
D, [2016-05-26T15:28:58.379706 #11682] DEBUG -- : Current leader for skroutz.test/1 is node kafka-c.vm.skroutz.gr:9092 (node_id=3)
D, [2016-05-26T15:28:58.379785 #11682] DEBUG -- : Current leader for skroutz.test/2 is node kafka.vm.skroutz.gr:9092 (node_id=1)
I, [2016-05-26T15:28:58.379806 #11682]  INFO -- : Sending 1 messages to kafka-c.vm.skroutz.gr:9092 (node_id=3)
D, [2016-05-26T15:28:58.379833 #11682] DEBUG -- : Sending request 2 to kafka-c.vm.skroutz.gr:9092
D, [2016-05-26T15:28:58.379920 #11682] DEBUG -- : Waiting for response 2 from kafka-c.vm.skroutz.gr:9092
D, [2016-05-26T15:28:58.382325 #11682] DEBUG -- : Received response 2 from kafka-c.vm.skroutz.gr:9092
D, [2016-05-26T15:28:58.382374 #11682] DEBUG -- : Successfully appended 1 messages to skroutz.test/1
I, [2016-05-26T15:28:58.382394 #11682]  INFO -- : Sending 1 messages to kafka.vm.skroutz.gr:9092 (node_id=1)
D, [2016-05-26T15:28:58.382413 #11682] DEBUG -- : Sending request 5 to kafka.vm.skroutz.gr:9092
D, [2016-05-26T15:28:58.382507 #11682] DEBUG -- : Waiting for response 5 from kafka.vm.skroutz.gr:9092
D, [2016-05-26T15:28:58.384264 #11682] DEBUG -- : Received response 5 from kafka.vm.skroutz.gr:9092
D, [2016-05-26T15:28:58.384317 #11682] DEBUG -- : Successfully appended 1 messages to skroutz.test/2
```

Now I trigger a rebalance.

Cluster state after rebalance:
![2016-05-26-152953_670x228_scrot](https://cloud.githubusercontent.com/assets/895410/15574823/329fbac4-2358-11e6-9e8a-16adf220f71e.png)

Logger output after rebalance:
```
D, [2016-05-26T15:30:08.380421 #11682] DEBUG -- : Current leader for skroutz.test/1 is node kafka-c.vm.skroutz.gr:9092 (node_id=3)
D, [2016-05-26T15:30:08.380483 #11682] DEBUG -- : Current leader for skroutz.test/0 is node kafka-b.vm.skroutz.gr:9092 (node_id=2)
D, [2016-05-26T15:30:08.380509 #11682] DEBUG -- : Current leader for skroutz.test/2 is node kafka.vm.skroutz.gr:9092 (node_id=1)
I, [2016-05-26T15:30:08.380527 #11682]  INFO -- : Sending 4 messages to kafka-c.vm.skroutz.gr:9092 (node_id=3)
D, [2016-05-26T15:30:08.380557 #11682] DEBUG -- : Sending request 10 to kafka-c.vm.skroutz.gr:9092
D, [2016-05-26T15:30:08.380671 #11682] DEBUG -- : Waiting for response 10 from kafka-c.vm.skroutz.gr:9092
D, [2016-05-26T15:30:08.382102 #11682] DEBUG -- : Received response 10 from kafka-c.vm.skroutz.gr:9092
E, [2016-05-26T15:30:08.382194 #11682] ERROR -- : Unknown topic or partition skroutz.test/1
I, [2016-05-26T15:30:08.382214 #11682]  INFO -- : Sending 1 messages to kafka-b.vm.skroutz.gr:9092 (node_id=2)
D, [2016-05-26T15:30:08.382233 #11682] DEBUG -- : Sending request 9 to kafka-b.vm.skroutz.gr:9092
D, [2016-05-26T15:30:08.382283 #11682] DEBUG -- : Waiting for response 9 from kafka-b.vm.skroutz.gr:9092
D, [2016-05-26T15:30:08.383721 #11682] DEBUG -- : Received response 9 from kafka-b.vm.skroutz.gr:9092
E, [2016-05-26T15:30:08.383769 #11682] ERROR -- : Unknown topic or partition skroutz.test/0
I, [2016-05-26T15:30:08.383786 #11682]  INFO -- : Sending 1 messages to kafka.vm.skroutz.gr:9092 (node_id=1)
D, [2016-05-26T15:30:08.383805 #11682] DEBUG -- : Sending request 11 to kafka.vm.skroutz.gr:9092
D, [2016-05-26T15:30:08.383889 #11682] DEBUG -- : Waiting for response 11 from kafka.vm.skroutz.gr:9092
D, [2016-05-26T15:30:08.384873 #11682] DEBUG -- : Received response 11 from kafka.vm.skroutz.gr:9092
E, [2016-05-26T15:30:08.384921 #11682] ERROR -- : Unknown topic or partition skroutz.test/2
W, [2016-05-26T15:30:08.384937 #11682]  WARN -- : Failed to send all messages; attempting retry 1 of 2 after 1s
D, [2016-05-26T15:30:09.385085 #11682] DEBUG -- : Current leader for skroutz.test/1 is node kafka-c.vm.skroutz.gr:9092 (node_id=3)
D, [2016-05-26T15:30:09.385144 #11682] DEBUG -- : Current leader for skroutz.test/0 is node kafka-b.vm.skroutz.gr:9092 (node_id=2)
D, [2016-05-26T15:30:09.385199 #11682] DEBUG -- : Current leader for skroutz.test/2 is node kafka.vm.skroutz.gr:9092 (node_id=1)
I, [2016-05-26T15:30:09.385218 #11682]  INFO -- : Sending 4 messages to kafka-c.vm.skroutz.gr:9092 (node_id=3)
D, [2016-05-26T15:30:09.385245 #11682] DEBUG -- : Sending request 11 to kafka-c.vm.skroutz.gr:9092
D, [2016-05-26T15:30:09.385352 #11682] DEBUG -- : Waiting for response 11 from kafka-c.vm.skroutz.gr:9092
D, [2016-05-26T15:30:09.386760 #11682] DEBUG -- : Received response 11 from kafka-c.vm.skroutz.gr:9092
E, [2016-05-26T15:30:09.386820 #11682] ERROR -- : Unknown topic or partition skroutz.test/1
I, [2016-05-26T15:30:09.386836 #11682]  INFO -- : Sending 1 messages to kafka-b.vm.skroutz.gr:9092 (node_id=2)
D, [2016-05-26T15:30:09.386854 #11682] DEBUG -- : Sending request 10 to kafka-b.vm.skroutz.gr:9092
D, [2016-05-26T15:30:09.386919 #11682] DEBUG -- : Waiting for response 10 from kafka-b.vm.skroutz.gr:9092
D, [2016-05-26T15:30:09.388319 #11682] DEBUG -- : Received response 10 from kafka-b.vm.skroutz.gr:9092
E, [2016-05-26T15:30:09.388368 #11682] ERROR -- : Unknown topic or partition skroutz.test/0
I, [2016-05-26T15:30:09.388385 #11682]  INFO -- : Sending 1 messages to kafka.vm.skroutz.gr:9092 (node_id=1)
D, [2016-05-26T15:30:09.388404 #11682] DEBUG -- : Sending request 12 to kafka.vm.skroutz.gr:9092
D, [2016-05-26T15:30:09.388465 #11682] DEBUG -- : Waiting for response 12 from kafka.vm.skroutz.gr:9092
D, [2016-05-26T15:30:09.389644 #11682] DEBUG -- : Received response 12 from kafka.vm.skroutz.gr:9092
E, [2016-05-26T15:30:09.389692 #11682] ERROR -- : Unknown topic or partition skroutz.test/2
W, [2016-05-26T15:30:09.389709 #11682]  WARN -- : Failed to send all messages; attempting retry 2 of 2 after 1s
D, [2016-05-26T15:30:10.389868 #11682] DEBUG -- : Current leader for skroutz.test/1 is node kafka-c.vm.skroutz.gr:9092 (node_id=3)
D, [2016-05-26T15:30:10.389939 #11682] DEBUG -- : Current leader for skroutz.test/0 is node kafka-b.vm.skroutz.gr:9092 (node_id=2)
D, [2016-05-26T15:30:10.389975 #11682] DEBUG -- : Current leader for skroutz.test/2 is node kafka.vm.skroutz.gr:9092 (node_id=1)
I, [2016-05-26T15:30:10.389993 #11682]  INFO -- : Sending 4 messages to kafka-c.vm.skroutz.gr:9092 (node_id=3)
D, [2016-05-26T15:30:10.390023 #11682] DEBUG -- : Sending request 12 to kafka-c.vm.skroutz.gr:9092
D, [2016-05-26T15:30:10.390130 #11682] DEBUG -- : Waiting for response 12 from kafka-c.vm.skroutz.gr:9092
D, [2016-05-26T15:30:10.391432 #11682] DEBUG -- : Received response 12 from kafka-c.vm.skroutz.gr:9092
E, [2016-05-26T15:30:10.391499 #11682] ERROR -- : Unknown topic or partition skroutz.test/1
I, [2016-05-26T15:30:10.391515 #11682]  INFO -- : Sending 1 messages to kafka-b.vm.skroutz.gr:9092 (node_id=2)
D, [2016-05-26T15:30:10.391534 #11682] DEBUG -- : Sending request 11 to kafka-b.vm.skroutz.gr:9092
D, [2016-05-26T15:30:10.391589 #11682] DEBUG -- : Waiting for response 11 from kafka-b.vm.skroutz.gr:9092
D, [2016-05-26T15:30:10.393046 #11682] DEBUG -- : Received response 11 from kafka-b.vm.skroutz.gr:9092
E, [2016-05-26T15:30:10.393096 #11682] ERROR -- : Unknown topic or partition skroutz.test/0
I, [2016-05-26T15:30:10.393112 #11682]  INFO -- : Sending 1 messages to kafka.vm.skroutz.gr:9092 (node_id=1)
D, [2016-05-26T15:30:10.393131 #11682] DEBUG -- : Sending request 13 to kafka.vm.skroutz.gr:9092
D, [2016-05-26T15:30:10.393184 #11682] DEBUG -- : Waiting for response 13 from kafka.vm.skroutz.gr:9092
D, [2016-05-26T15:30:10.394341 #11682] DEBUG -- : Received response 13 from kafka.vm.skroutz.gr:9092
E, [2016-05-26T15:30:10.394390 #11682] ERROR -- : Unknown topic or partition skroutz.test/2
E, [2016-05-26T15:30:10.394407 #11682] ERROR -- : Failed to send all messages; keeping remaining messages in buffer
```





