### PR TITLE
Add a simple API for synchronously sending a single message

### DIFF
--- a/lib/kafka/compressor.rb
+++ b/lib/kafka/compressor.rb
@@ -20,7 +20,7 @@ module Kafka
     # @param codec_name [Symbol, nil]
     # @param threshold [Integer] the minimum number of messages in a message set
     #   that will trigger compression.
-    def initialize(codec_name:, threshold:, instrumenter:)
+    def initialize(codec_name: nil, threshold: 1, instrumenter:)
       @codec = Compression.find_codec(codec_name)
       @threshold = threshold
       @instrumenter = instrumenter

--- a/spec/functional/client_spec.rb
+++ b/spec/functional/client_spec.rb
@@ -21,4 +21,13 @@ describe "Producer API", functional: true do
 
     expect(kafka.partitions_for(topic)).to be > 0
   end
+
+  example "delivering a message to a topic" do
+    kafka.deliver_message("yolo", topic: topic, key: "xoxo", partition: 0)
+
+    message = kafka.fetch_messages(topic: topic, partition: 0, offset: 0).first
+
+    expect(message.value).to eq "yolo"
+    expect(message.key).to eq "xoxo"
+  end
 end


### PR DESCRIPTION
This is simple API that offers neither performance nor fault tolerance, making it ideal for Ruby! More seriously, it addresses a very specific scenario: sending one-off messages. Currently, you have to be careful to avoid leaving messages in a Producer buffer when something goes wrong, and setting up a producer in the first place when all you want is something hammer-shaped that sends a message to Kafka is something you'd expect from a Java library.

The API looks like this:

```ruby
kafka = Kafka.new(...)

kafka.deliver_message("hello, world!", topic: "greetings")
```

The API doesn't allow enabling compression, nor does it allow configuring the `required_acks` or `ack_timeout` parameters.