### PR TITLE
Accept IPv6 addresses for seed_brokers

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -328,12 +328,10 @@ module Kafka
       end
       brokers = []
       seed_brokers.each do |connection|
-        if connection =~ /:\/\//
-          u = URI.parse(connection)
-          brokers << "#{u.host}:#{u.port}"
-        else
-          brokers << connection
-        end
+        connection.prepend("kafka://") unless connection =~ /:\/\//
+        uri = URI.parse(connection)
+        uri.port ||= 9092 # Default Kafka port.
+        brokers << uri
       end
       brokers
     end

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -13,7 +13,7 @@ module Kafka
     #
     # The cluster will try to fetch cluster metadata from one of the brokers.
     #
-    # @param seed_brokers [Array<String>]
+    # @param seed_brokers [Array<URI>]
     # @param broker_pool [Kafka::BrokerPool]
     # @param logger [Logger]
     def initialize(seed_brokers:, broker_pool:, logger:)
@@ -136,10 +136,7 @@ module Kafka
         @logger.info "Fetching cluster metadata from #{node}"
 
         begin
-          host, port = node.split(":", 2)
-          port ||= 9092 # Default Kafka port.
-
-          broker = @broker_pool.connect(host, port.to_i)
+          broker = @broker_pool.connect(node.hostname, node.port)
           cluster_info = broker.fetch_metadata(topics: @target_topics)
 
           @stale = false

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -5,7 +5,7 @@ describe Kafka::Cluster do
 
     let(:cluster) {
       Kafka::Cluster.new(
-        seed_brokers: ["test1:9092"],
+        seed_brokers: [URI("kafka://test1:9092")],
         broker_pool: broker_pool,
         logger: LOGGER,
       )
@@ -73,7 +73,7 @@ describe Kafka::Cluster do
 
     it "raises ConnectionError if unable to connect to any of the seed brokers" do
       cluster = Kafka::Cluster.new(
-        seed_brokers: ["not-there:9092", "not-here:9092"],
+        seed_brokers: [URI("kafka://not-there:9092"), URI("kafka://not-here:9092")],
         broker_pool: broker_pool,
         logger: LOGGER,
       )


### PR DESCRIPTION
With the previous normalization/parsing process it was impossible
to use IPv6 addresses directly in the seed_brokers array/string.

This commit enables the client to accept IPv6 addresses with port
in the following URI-like format:

`[2a00:1450:400d:802::200e]:9092`