### PR TITLE
Simplify the API for setting subscription starting points

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,17 +465,17 @@ consumer = kafka.consumer(
 
 #### Topic Subscriptions
 
-For each topic subscription it's possible to decide whether to consume messages starting at the beginning of the topic or to just consume new messages that are produced to the topic. This policy is configured by setting the `default_offset` argument when calling `#subscribe`:
+For each topic subscription it's possible to decide whether to consume messages starting at the beginning of the topic or to just consume new messages that are produced to the topic. This policy is configured by setting the `start_from_beginning` argument when calling `#subscribe`:
 
 ```ruby
 # Consume messages from the very beginning of the topic. This is the default.
-consumer.subscribe("users", default_offset: :earliest)
+consumer.subscribe("users", start_from_beginning: true)
 
 # Only consume new messages.
-consumer.subscribe("notifications", default_offset: :latest)
+consumer.subscribe("notifications", start_from_beginning: false)
 ```
 
-Once the consumer group has checkpointed its progress in the topic's partitions, the consumers will always start from the checkpointed offsets, regardless of the `default_offset`. As such, this setting only applies when the consumer initially starts consuming from a topic.
+Once the consumer group has checkpointed its progress in the topic's partitions, the consumers will always start from the checkpointed offsets, regardless of `start_from_beginning`. As such, this setting only applies when the consumer initially starts consuming from a topic.
 
 
 #### Consuming Messages in Batches

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -65,9 +65,16 @@ module Kafka
     #
     # @param topic [String] the name of the topic to subscribe to.
     # @param default_offset [Symbol] whether to start from the beginning or the
-    #   end of the topic's partitions.
+    #   end of the topic's partitions. Deprecated.
+    # @param start_from_beginning [Boolean] whether to start from the beginning
+    #   of the topic or just subscribe to new messages being produced. This
+    #   only applies when first consuming a topic partition – once the consumer
+    #   has checkpointed its progress, it will always resume from the last
+    #   checkpoint.
     # @return [nil]
-    def subscribe(topic, default_offset: :earliest)
+    def subscribe(topic, default_offset: nil, start_from_beginning: true)
+      default_offset ||= start_from_beginning ? :earliest : :latest
+
       @group.subscribe(topic)
       @offset_manager.set_default_offset(topic, default_offset)
 


### PR DESCRIPTION
Implements #207.

The new API will be:

```ruby
consumer.subscribe("stats", start_from_beginning: false) # default is true
```