### PR TITLE
Add a Datadog metrics reporter

### DIFF
--- a/lib/kafka/datadog.rb
+++ b/lib/kafka/datadog.rb
@@ -1,0 +1,208 @@
+begin
+  require "statsd"
+rescue LoadError
+  $stderr.puts "In order to report Kafka client metrics to Datadog you need to install the `dogstatsd-ruby` gem."
+  raise
+end
+
+require "active_support/subscriber"
+
+module Kafka
+
+  # Reports operational metrics to a Datadog agent using the modified Statsd protocol.
+  #
+  #     require "kafka/datadog"
+  #
+  #     # Default is "ruby_kafka".
+  #     Kafka::Datadog.namespace = "custom-namespace"
+  #
+  #     # Default is "127.0.0.1".
+  #     Kafka::Datadog.host = "statsd.something.com"
+  #
+  #     # Default is 8125.
+  #     Kafka::Datadog.port = 1234
+  #
+  # Once the file has been required, no further configuration is needed – all operational
+  # metrics are automatically emitted.
+  module Datadog
+    STATSD_NAMESPACE = "ruby_kafka"
+
+    def self.statsd
+      @statsd ||= Statsd.new(Statsd::DEFAULT_HOST, Statsd::DEFAULT_HOST, namespace: STATSD_NAMESPACE)
+    end
+
+    def self.statsd_host=(host)
+      statsd.host = host
+    end
+
+    def self.statsd_port=(port)
+      statsd.port = port
+    end
+
+    def self.namespace=(namespace)
+      statsd.namespace = namespace
+    end
+
+    class StatsdSubscriber < ActiveSupport::Subscriber
+      private
+
+      %w[increment histogram count timing gauge].each do |type|
+        define_method(type) do |*args|
+          emit(type, *args)
+        end
+      end
+
+      def emit(type, *args, tags: {})
+        tags = tags.map {|k, v| "#{k}:#{v}" }.to_a
+
+        Kafka::Datadog.statsd.send(type, *args, tags: tags)
+      end
+    end
+
+    class ConnectionSubscriber < StatsdSubscriber
+      def request(event)
+        client = event.payload.fetch(:client_id)
+        api = event.payload.fetch(:api, "unknown")
+        request_size = event.payload.fetch(:request_size, 0)
+        response_size = event.payload.fetch(:response_size, 0)
+        broker = event.payload.fetch(:broker_host)
+
+        tags = {
+          client: client,
+          api: api,
+          broker: broker
+        }
+
+        timing("api.latency", event.duration, tags: tags)
+        increment("api.calls", tags: tags)
+
+        histogram("api.request_size", request_size, tags: tags)
+        histogram("api.response_size", response_size, tags: tags)
+
+        if event.payload.key?(:exception)
+          increment("api.errors", tags: tags)
+        end
+      end
+
+      attach_to "connection.kafka"
+    end
+
+    class ConsumerSubscriber < StatsdSubscriber
+      def process_message(event)
+        lag = event.payload.fetch(:offset_lag)
+
+        tags = {
+          client: event.payload.fetch(:client_id),
+          topic: event.payload.fetch(:topic),
+          partition: event.payload.fetch(:partition),
+        }
+
+        if event.payload.key?(:exception)
+          increment("consumer.process_message.errors", tags: tags)
+        else
+          timing("consumer.process_message.latency", event.duration, tags: tags)
+          increment("consumer.messages", tags: tags)
+        end
+
+        gauge("consumer.lag", lag, tags: tags)
+      end
+
+      def process_batch(event)
+        messages = event.payload.fetch(:message_count)
+
+        tags = {
+          client: event.payload.fetch(:client_id),
+          topic: event.payload.fetch(:topic),
+          partition: event.payload.fetch(:partition),
+        }
+
+        if event.payload.key?(:exception)
+          increment("consumer.process_batch.errors", tags: tags)
+        else
+          timing("consumer.process_batch.latency", event.duration, tags: tags)
+          count("consumer.messages", messages, tags: tags)
+        end
+      end
+
+      attach_to "consumer.kafka"
+    end
+
+    class ProducerSubscriber < StatsdSubscriber
+      def produce_message(event)
+        client = event.payload.fetch(:client_id)
+        topic = event.payload.fetch(:topic)
+        buffer_size = event.payload.fetch(:buffer_size)
+        max_buffer_size = event.payload.fetch(:max_buffer_size)
+        buffer_fill_ratio = buffer_size.to_f / max_buffer_size.to_f
+
+        tags = {
+          client: client,
+        }
+
+        # This gets us the write rate.
+        increment("producer.produce.messages", tags: tags.merge(topic: topic))
+
+        # This gets us the avg/max buffer size per producer.
+        histogram("producer.buffer.size", buffer_size, tags: tags)
+
+        # This gets us the avg/max buffer fill ratio per producer.
+        histogram("producer.buffer.fill_ratio", buffer_fill_ratio, tags: tags)
+      end
+
+      def buffer_overflow(event)
+        tags = {
+          client: event.payload.fetch(:client_id),
+          topic: event.payload.fetch(:topic),
+        }
+
+        increment("producer.produce.errors", tags: tags)
+      end
+
+      def deliver_messages(event)
+        client = event.payload.fetch(:client_id)
+        message_count = event.payload.fetch(:delivered_message_count)
+        attempts = event.payload.fetch(:attempts)
+
+        tags = {
+          client: client,
+        }
+
+        if event.payload.key?(:exception)
+          increment("producer.deliver.errors", tags: tags)
+        end
+
+        timing("producer.deliver.latency", event.duration, tags: tags)
+
+        # Messages delivered to Kafka:
+        count("producer.deliver.messages", message_count, tags: tags)
+
+        # Number of attempts to deliver messages:
+        histogram("producer.deliver.attempts", attempts, tags: tags)
+      end
+
+      def ack_message(event)
+        tags = {
+          client: event.payload.fetch(:client_id),
+          topic: event.payload.fetch(:topic),
+        }
+
+        # Number of messages ACK'd for the topic.
+        increment("producer.ack.messages", tags: tags)
+
+        # Histogram of delay between a message being produced and it being ACK'd.
+        histogram("producer.ack.delay", event.payload.fetch(:delay), tags: tags)
+      end
+
+      def topic_error(event)
+        tags = {
+          client: event.payload.fetch(:client_id),
+          topic: event.payload.fetch(:topic)
+        }
+
+        increment("producer.ack.errors", tags: tags)
+      end
+
+      attach_to "producer.kafka"
+    end
+  end
+end

--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "snappy"
   spec.add_development_dependency "colored"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
+  spec.add_development_dependency "dogstatsd-ruby"
 end


### PR DESCRIPTION
Metrics will be reported using Datadog's modified Statsd client.

This reporter is specific to [Datadog](https://www.datadoghq.com/), but other reporters can easily be added.