### PR TITLE
PendingMessage: Use struct instead of class to improve performance

### DIFF
--- a/lib/kafka/pending_message.rb
+++ b/lib/kafka/pending_message.rb
@@ -1,18 +1,11 @@
 module Kafka
-  class PendingMessage
-    attr_reader :value, :key, :topic, :partition, :partition_key
-
-    attr_reader :bytesize, :create_time
-
-    def initialize(value:, key:, topic:, partition:, partition_key:, create_time:)
-      @key = key
-      @value = value
-      @topic = topic
-      @partition = partition
-      @partition_key = partition_key
-      @create_time = create_time
-
-      @bytesize = key.to_s.bytesize + value.to_s.bytesize
-    end
-  end
+  PendingMessage = Struct.new(
+    "PendingMessage",
+    :value,
+    :key,
+    :topic,
+    :partition,
+    :partition_key,
+    :create_time,
+    :bytesize)
 end

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -185,12 +185,13 @@ module Kafka
       create_time = Time.now
 
       message = PendingMessage.new(
-        value: value,
-        key: key,
-        topic: topic,
-        partition: partition,
-        partition_key: partition_key,
-        create_time: create_time,
+        value,
+        key,
+        topic,
+        partition,
+        partition_key,
+        create_time,
+        key.to_s.bytesize + value.to_s.bytesize
       )
 
       if buffer_size >= @max_buffer_size


### PR DESCRIPTION
Now I'm working on replacing poseidon with ruby-kafka in fluent-plugin-kafka.
I checked the performance and I found PendingMessage initialization consumes CPU because Producer#produce is called frequently.

I tested simple benchmark and it shows class with keyword argument is slower.
So using struct is better for `PendingMessage` usecase.

- Benchmark code:

```rb
require 'benchmark'

class PendingMessage1
  attr_reader :value, :key, :topic, :partition, :partition_key

  attr_reader :bytesize, :create_time

  def initialize(value:, key:, topic:, partition:, partition_key:, create_time:)
    @key = key
    @value = value
    @topic = topic
    @partition = partition
    @partition_key = partition_key
    @create_time = create_time

    @bytesize = key.to_s.bytesize + value.to_s.bytesize
  end
end

class PendingMessage2
  attr_reader :value, :key, :topic, :partition, :partition_key

  attr_reader :bytesize, :create_time

  def initialize(value, key, topic, partition, partition_key, create_time)
    @key = key
    @value = value
    @topic = topic
    @partition = partition
    @partition_key = partition_key
    @create_time = create_time

    @bytesize = key.to_s.bytesize + value.to_s.bytesize
  end
end

PendingMessageS = Struct.new("PendingMessageS", :value, :key, :topic, :partition, :partition_key, :create_time, :bytesize)


n = 1000000
value = "foooooooooooooooooooooooo"
key = "key"
topic = "kafka"
partition = 1
partition_key = "field"
create_time = Time.now.to_i

Benchmark.bmbm do |x|
  x.report('class1') {
    n.times do
      PendingMessage1.new(
        value: value,
        key: key,
        topic: topic,
        partition: partition,
        partition_key: partition_key,
        create_time: create_time)
    end
  }
  x.report('class2') {
    n.times do
      PendingMessage2.new(
        value, key, topic, partition, partition_key, create_time)
    end
  }
  x.report('struct') {
    n.times do
      PendingMessageS.new(
        value, key, topic, partition, partition_key, create_time,
        key.to_s.bytesize + value.to_s.bytesize)
    end
  }
end
```

- Result with ruby 2.3.1

```
Rehearsal ------------------------------------------
class1   1.830000   0.020000   1.850000 (  1.853243)
class2   0.630000   0.000000   0.630000 (  0.648974)
struct   0.430000   0.010000   0.440000 (  0.436509)
--------------------------------- total: 2.920000sec

             user     system      total        real
class1   1.830000   0.010000   1.840000 (  1.839984)
class2   0.630000   0.000000   0.630000 (  0.639363)
struct   0.430000   0.000000   0.430000 (  0.432769)
```