### PR TITLE
Add an experimental simplified consumer API

### DIFF
--- a/lib/kafka/fetched_batch.rb
+++ b/lib/kafka/fetched_batch.rb
@@ -25,11 +25,15 @@ module Kafka
       @messages.empty?
     end
 
+    def last_offset
+      messages.last.offset
+    end
+
     def offset_lag
       if empty?
         0
       else
-        highwater_mark_offset - messages.last.offset
+        highwater_mark_offset - last_offset
       end
     end
   end

--- a/spec/functional/client_spec.rb
+++ b/spec/functional/client_spec.rb
@@ -30,4 +30,26 @@ describe "Producer API", functional: true do
     expect(message.value).to eq "yolo"
     expect(message.key).to eq "xoxo"
   end
+
+  example "enumerating the messages in a topic" do
+    values = (1..10).to_a
+
+    values.each do |value|
+      kafka.deliver_message(value.to_s, topic: topic)
+    end
+
+    kafka.each_message(topic: topic) do |message|
+      value = Integer(message.value)
+      values.delete(value)
+
+      if message.value == "5"
+        values << 666
+        kafka.deliver_message("666", topic: topic)
+      end
+
+      break if values.empty?
+    end
+
+    expect(values).to eq []
+  end
 end


### PR DESCRIPTION
The API is extremely simple, but also lacks flexibility:

```ruby
kafka = Kafka.new(...)
kafka.each_message(topic: "greetings") do |message|
  puts message.value
end
```

This will be fine for simple use cases, but of course won't suffice when e.g. checkpointing or distribution is required.