### PR TITLE
Simplify the offset commit error handling

### DIFF
--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -71,7 +71,7 @@ module Kafka
           Protocol.handle_error(error_code)
         end
       end
-    rescue ConnectionError, UnknownMemberId, RebalanceInProgress, IllegalGeneration => e
+    rescue Kafka::Error => e
       @logger.error "Error committing offsets: #{e}"
       raise OffsetCommitError, e
     end


### PR DESCRIPTION
Some exceptions, e.g. RequestTimedOut, were not being handled. Opting for a catch-all rescue instead.