### PR TITLE
Require uri in case of running without bundler

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -1,4 +1,5 @@
 require "openssl"
+require "uri"
 
 require "kafka/cluster"
 require "kafka/producer"


### PR DESCRIPTION
After the release of v0.3.9 every kafka client tries to parse seed
brokers using URI which is not required by default without bundler.

This patch explicitly requires uri and allows the kafka client
to work without bundler.

Fixes #223