### PR TITLE
Mark the cluster as stale on fetch error

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -189,8 +189,10 @@ module Kafka
       while @running
         begin
           yield
-        rescue HeartbeatError, OffsetCommitError, FetchError
+        rescue HeartbeatError, OffsetCommitError
           join_group
+        rescue FetchError
+          @cluster.mark_as_stale!
         rescue LeaderNotAvailable => e
           @logger.error "Leader not available; waiting 1s before retrying"
           sleep 1


### PR DESCRIPTION
There's no reason to rejoin the group when a fetch fails, it's most likely due to network errors or partition leadership changes.

Should fix #226.