### PR TITLE
Eagerly resolve default offsets in the consumer

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -216,6 +216,7 @@ module Kafka
       )
 
       offset_manager = OffsetManager.new(
+        cluster: cluster,
         group: group,
         logger: @logger,
         commit_interval: offset_commit_interval,

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -128,7 +128,16 @@ module Kafka
         }
       )
 
-      response.offset_for(topic, partition)
+      resolved_offset = response.offset_for(topic, partition)
+
+      # If we're resolving the latest offset for a partition, we get back the
+      # offset of the *next* message to be appended, rather than the offset of
+      # the message that's currently last. We'll have to correct for that.
+      if offset == -1
+        resolved_offset - 1
+      else
+        resolved_offset
+      end
     end
 
     def topics

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -105,6 +105,32 @@ module Kafka
       raise
     end
 
+    def resolve_offset(topic, partition, offset)
+      add_target_topics([topic])
+      refresh_metadata_if_necessary!
+      broker = get_leader(topic, partition)
+
+      if offset == :earliest
+        offset = -2
+      elsif offset == :latest
+        offset = -1
+      end
+
+      response = broker.list_offsets(
+        topics: {
+          topic => [
+            {
+              partition: partition,
+              time: offset,
+              max_offsets: 1,
+            }
+          ]
+        }
+      )
+
+      response.offset_for(topic, partition)
+    end
+
     def topics
       cluster_info.topics.map(&:topic_name)
     end


### PR DESCRIPTION
Previously, the first time a partition was consumed there would be no committed offset, so the consumer would use the default offset (either the earliest or the latest offset in the partition.) However, the actual offset number would only be resolved when the consumer fetched from the partition. This would leave a race condition when a consumer subscribes to the latest messages for a topic: if no messages arrive while the fetch is waiting, no offset will be committed; in the next iteration, the offset will be resolved anew, but that means skipping any message that has arrived in the meantime. Only when messages arrive *while* the consumer is doing a fetch on a partition will this race be broken.

The new behavior is to resolve the default offset as soon as possible and to commit the actual offset. This means that after a consumer has started the starting offsets are fixed.

Fixes #215.