### PR TITLE
Add an API for retrieving the last offset in a partition

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -378,6 +378,19 @@ module Kafka
       @cluster.partitions_for(topic).count
     end
 
+    # Retrieve the offset of the last message in a partition. If there are no
+    # messages in the partition -1 is returned.
+    #
+    # @param topic [String]
+    # @param partition [Integer]
+    # @return [Integer] the offset of the last message in the partition, or -1 if
+    #   there are no messages in the partition.
+    def last_offset_for(topic, partition)
+      # The offset resolution API will return the offset of the "next" message to
+      # be written when resolving the "latest" offset, so we subtract one.
+      @cluster.resolve_offset(topic, partition, :latest) - 1
+    end
+
     # Closes all connections to the Kafka brokers and frees up used resources.
     #
     # @return [nil]

--- a/spec/functional/client_spec.rb
+++ b/spec/functional/client_spec.rb
@@ -56,4 +56,15 @@ describe "Producer API", functional: true do
 
     expect(values).to eq []
   end
+
+  example "getting the last offset for a topic partition" do
+    topic = create_random_topic(num_partitions: 1, num_replicas: 1)
+
+    kafka.deliver_message("hello", topic: topic, partition: 0)
+    kafka.deliver_message("world", topic: topic, partition: 0)
+
+    offset = kafka.last_offset_for(topic, 0)
+
+    expect(offset).to eq 1
+  end
 end


### PR DESCRIPTION
Add a simple API for fetching the offset of the last message in a partition:

```ruby
kafka.last_offset_for("some-topic", 42) #=> 123
```

I may want to change the API such that the partition is specified with a keyword parameter, e.g. `partition: 42`. This would allow extending the API to support multiple partitions, e.g. `partitions: [42, 42]`.

Closes #225.