### PR TITLE
Return all topics from Client#topics

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -366,6 +366,7 @@ module Kafka
     #
     # @return [Array<String>] the list of topic names.
     def topics
+      @cluster.clear_target_topics
       @cluster.topics
     end
 

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -32,6 +32,11 @@ module Kafka
       @target_topics = Set.new
     end
 
+    # Adds a list of topics to the target list. Only the topics on this list will
+    # be queried for metadata.
+    #
+    # @param topics [Array<String>]
+    # @return [nil]
     def add_target_topics(topics)
       new_topics = Set.new(topics) - @target_topics
 
@@ -42,6 +47,15 @@ module Kafka
 
         refresh_metadata!
       end
+    end
+
+    # Clears the list of target topics.
+    #
+    # @see #add_target_topics
+    # @return [nil]
+    def clear_target_topics
+      @target_topics.clear
+      refresh_metadata!
     end
 
     def mark_as_stale!

--- a/spec/functional/client_spec.rb
+++ b/spec/functional/client_spec.rb
@@ -3,6 +3,10 @@ describe "Producer API", functional: true do
 
   example "listing all topics in the cluster" do
     expect(kafka.topics).to include topic
+
+    topic2 = create_random_topic(num_partitions: 1)
+
+    expect(kafka.topics).to include(topic, topic2)
   end
 
   example "fetching the partition count for a topic" do


### PR DESCRIPTION
Previously, if the client had add a set of topics to its internal list, only those topics would be returned.

Fixes #234.