### PR TITLE
Skip empty batches

### DIFF
--- a/lib/kafka/fetched_batch.rb
+++ b/lib/kafka/fetched_batch.rb
@@ -26,6 +26,7 @@ module Kafka
     end
 
     def last_offset
+      return -2 if messages.empty?
       messages.last.offset
     end
 


### PR DESCRIPTION
Previously we were erroring out in fetch_batch#last_offset because messages
would be empty so last would return nil and then nil wouldn't define offset.
I fixed this by returning -2 if messages was empty, thereby avoiding the error.

Fixes #237