### PR TITLE
Only consume the last message once

### DIFF
--- a/examples/simple-consumer.rb
+++ b/examples/simple-consumer.rb
@@ -27,22 +27,6 @@ kafka = Kafka.new(
   logger: logger,
 )
 
-begin
-  offset = :latest
-  partition = 0
-
-  loop do
-    messages = kafka.fetch_messages(
-      topic: topic,
-      partition: partition,
-      offset: offset
-    )
-
-    messages.each do |message|
-      puts message.value
-      offset = message.offset + 1
-    end
-  end
-ensure
-  kafka.close
+kafka.each_message(topic: topic) do |message|
+  puts message.value
 end

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -357,7 +357,7 @@ module Kafka
 
         batches.each do |batch|
           batch.messages.each(&block)
-          offsets[batch.partition] = batch.last_offset
+          offsets[batch.partition] = batch.last_offset + 1
         end
       end
     end

--- a/lib/kafka/fetched_batch.rb
+++ b/lib/kafka/fetched_batch.rb
@@ -26,7 +26,11 @@ module Kafka
     end
 
     def last_offset
-      messages.last.offset
+      if empty?
+        highwater_mark_offset - 1
+      else
+        messages.last.offset
+      end
     end
 
     def offset_lag


### PR DESCRIPTION
The simple consumer repeatedly consumed the last message in a partition.