### PR TITLE
Don't consider the socket open if it's closed (duh!)

### DIFF
--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -57,7 +57,7 @@ module Kafka
     end
 
     def open?
-      !@socket.nil?
+      !@socket.nil? && !@socket.closed?
     end
 
     def close

--- a/lib/kafka/socket_with_timeout.rb
+++ b/lib/kafka/socket_with_timeout.rb
@@ -83,6 +83,10 @@ module Kafka
       @socket.close
     end
 
+    def closed?
+      @socket.closed?
+    end
+
     def set_encoding(encoding)
       @socket.set_encoding(encoding)
     end

--- a/lib/kafka/ssl_socket_with_timeout.rb
+++ b/lib/kafka/ssl_socket_with_timeout.rb
@@ -147,6 +147,10 @@ module Kafka
       @ssl_socket.close
     end
 
+    def closed?
+      @tcp_socket.closed? || @ssl_socket.closed?
+    end
+
     def set_encoding(encoding)
       @tcp_socket.set_encoding(encoding)
     end


### PR DESCRIPTION
Connection errors were being raised when Kafka had killed an idle client connection. Rather than just raising an exception, we should try to reconnect if we can see that the connection has been closed.