### PR TITLE
Improve consumer offset commit code

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -130,6 +130,10 @@ module Kafka
             return if !@running
           end
         end
+
+        # We may not have received any messages, but it's still a good idea to
+        # commit offsets if we've processed messages in the last set of batches.
+        @offset_manager.commit_offsets_if_necessary
       end
     end
 

--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -11,7 +11,7 @@ module Kafka
       @processed_offsets = {}
       @default_offsets = {}
       @committed_offsets = nil
-      @last_commit = Time.at(0)
+      @last_commit = Time.now
     end
 
     def set_default_offset(topic, default_offset)


### PR DESCRIPTION
* Commit offsets even when no messages are being processed. Before, the consumer would not commit pending offsets until a new message was processed.
* Wait for the configured amount of time before first committing offsets.