### PR TITLE
Don't discard all consumer offset data on resync

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -216,15 +216,17 @@ module Kafka
       @group.join
 
       if old_generation_id && @group.generation_id != old_generation_id + 1
-        raise "unexpected generation id #{@group.generation_id}"
+        # We've been out of the group for at least an entire generation, no
+        # sense in trying to hold on to offset data
+        @offset_manager.clear_offsets
+      else
+        # After rejoining the group we may have been assigned a new set of
+        # partitions. Keeping the old offset commits around forever would risk
+        # having the consumer go back and reprocess messages if it's assigned
+        # a partition it used to be assigned to way back. For that reason, we
+        # only keep commits for the partitions that we're still assigned.
+        @offset_manager.clear_offsets_excluding(@group.assigned_partitions)
       end
-
-      # After rejoining the group we may have been assigned a new set of
-      # partitions. Keeping the old offset commits around forever would risk
-      # having the consumer go back and reprocess messages if it's assigned
-      # a partition it used to be assigned to way back. For that reason, we
-      # only keep commits for the partitions that we're still assigned.
-      @offset_manager.clear_offsets_excluding(@group.assigned_partitions)
     end
 
     def fetch_batches(min_bytes:, max_wait_time:)

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -211,7 +211,13 @@ module Kafka
     end
 
     def join_group
+      old_generation_id = @group.generation_id
+
       @group.join
+
+      if old_generation_id && @group.generation_id != old_generation_id + 1
+        raise "unexpected generation id #{@group.generation_id}"
+      end
 
       # After rejoining the group we may have been assigned a new set of
       # partitions. Keeping the old offset commits around forever would risk

--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -3,7 +3,7 @@ require "kafka/round_robin_assignment_strategy"
 
 module Kafka
   class ConsumerGroup
-    attr_reader :assigned_partitions
+    attr_reader :assigned_partitions, :generation_id
 
     def initialize(cluster:, logger:, group_id:, session_timeout:)
       @cluster = cluster

--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -64,9 +64,15 @@ module Kafka
       end
     end
 
-    def clear_offsets
-      @uncommitted_offsets = 0
-      @processed_offsets.clear
+    def clear_offsets_excluding(excluded)
+      # Clear all offsets that aren't in `excluded`.
+      @processed_offsets.each do |topic, partitions|
+        partitions.keep_if do |partition, _|
+          excluded.fetch(topic, []).include?(partition)
+        end
+      end
+
+      # Clear the cached commits from the brokers.
       @committed_offsets = nil
     end
 

--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -64,6 +64,13 @@ module Kafka
       end
     end
 
+    def clear_offsets
+      @processed_offsets.clear
+
+      # Clear the cached commits from the brokers.
+      @committed_offsets = nil
+    end
+
     def clear_offsets_excluding(excluded)
       # Clear all offsets that aren't in `excluded`.
       @processed_offsets.each do |topic, partitions|

--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -59,7 +59,7 @@ module Kafka
     end
 
     def commit_offsets_if_necessary
-      if seconds_since_last_commit >= @commit_interval || commit_threshold_reached?
+      if commit_timeout_reached? || commit_threshold_reached?
         commit_offsets
       end
     end
@@ -92,6 +92,10 @@ module Kafka
     def committed_offset_for(topic, partition)
       @committed_offsets ||= @group.fetch_offsets
       @committed_offsets.offset_for(topic, partition)
+    end
+
+    def commit_timeout_reached?
+      @commit_interval != 0 && seconds_since_last_commit >= @commit_interval
     end
 
     def commit_threshold_reached?

--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -54,7 +54,7 @@ describe "Consumer API", functional: true do
 
     received_messages = threads.map(&:value).flatten
 
-    expect(received_messages.sort).to eq messages
+    expect(received_messages.sort).to match_array messages
   end
 
   example "consuming messages from the end of a topic" do

--- a/spec/offset_manager_spec.rb
+++ b/spec/offset_manager_spec.rb
@@ -1,0 +1,89 @@
+describe Kafka::OffsetManager do
+  let(:cluster) { double(:cluster) }
+  let(:group) { double(:group) }
+  let(:logger) { LOGGER }
+
+  let(:offset_manager) {
+    Kafka::OffsetManager.new(
+      cluster: cluster,
+      group: group,
+      logger: logger,
+      commit_interval: 0,
+      commit_threshold: 0,
+    )
+  }
+
+  before do
+    allow(group).to receive(:commit_offsets)
+  end
+
+  describe "#commit_offsets" do
+    it "commits the processed offsets to the group" do
+      offset_manager.mark_as_processed("greetings", 0, 42)
+      offset_manager.mark_as_processed("greetings", 1, 13)
+
+      offset_manager.commit_offsets
+
+      expected_offsets = {
+        "greetings" => {
+          0 => 42,
+          1 => 13,
+        }
+      }
+
+      expect(group).to have_received(:commit_offsets).with(expected_offsets)
+    end
+  end
+
+  describe "#next_offset_for" do
+    let(:fetched_offsets) { double(:fetched_offsets) }
+
+    before do
+      allow(group).to receive(:fetch_offsets).and_return(fetched_offsets)
+    end
+
+    it "returns the last committed offset plus one" do
+      allow(fetched_offsets).to receive(:offset_for).with("greetings", 0) { 41 }
+
+      offset = offset_manager.next_offset_for("greetings", 0)
+
+      expect(offset).to eq 42
+    end
+
+    it "returns the default offset if none have been committed" do
+      allow(fetched_offsets).to receive(:offset_for).with("greetings", 0) { -1 }
+      allow(cluster).to receive(:resolve_offset).with("greetings", 0, :latest) { 42 }
+      offset_manager.set_default_offset("greetings", :latest)
+
+      offset = offset_manager.next_offset_for("greetings", 0)
+
+      expect(offset).to eq 42
+    end
+
+    it "returns the next offset if we've already processed messages in the partition" do
+      offset_manager.mark_as_processed("greetings", 0, 41)
+
+      offset = offset_manager.next_offset_for("greetings", 0)
+
+      expect(offset).to eq 42
+    end
+  end
+
+  describe "#clear_offsets_excluding" do
+    it "clears offsets except for the partitions in the exclusion list" do
+      offset_manager.mark_as_processed("x", 0, 42)
+      offset_manager.mark_as_processed("x", 1, 13)
+
+      offset_manager.clear_offsets_excluding("x" => [0])
+      offset_manager.commit_offsets
+
+      expected_offsets = {
+        "x" => {
+          0 => 42,
+        }
+      }
+
+      expect(group).to have_received(:commit_offsets).with(expected_offsets)
+    end
+  end
+end


### PR DESCRIPTION
When a group resyncs we were discarding all local data about which partition offsets had been processed. Any data that had not been committed would be lost, even if the consumer was assigned some of the same partitions after the sync. With this change, consumers only discard offset data for partitions they are no longer assigned.

This should result in less reprocessing of messages. Running the consumer group fuzz test indeed indicates that this is the case, with the number of duplicates going from upwards of 10% to about 0.1%

#### Tasks

- [x] Documentation