### PR TITLE
Fix invalid BufferOverflow error in AsyncProducer

### DIFF
--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -122,6 +122,7 @@ module Kafka
     # @see Kafka::Producer#shutdown
     # @return [nil]
     def shutdown
+      @timer_thread && @timer_thread.exit
       @queue << [:shutdown, nil]
       @worker_thread && @worker_thread.join
 


### PR DESCRIPTION
The shutdown method used to terminate only the Worker thread and not
the Timer thread. The Timer thread continues to push `deliver_messages`
to the queue but the Worker thread is not alive to consume them.
After some time the queue fills with `deliver_messages` and the next
try to produce a message fails with `Kafka::BufferOverflow`.

This commit fixes the issue by terminating the Timer thread
together with the Worker thread on shutdown.

Code to reproduce:
```
require "kafka"

kafka = Kafka.new(seed_brokers: ['kafka.vm.skroutz.gr:9092',
                                 'kafka-b.vm.skroutz.gr:9092',
                                 'kafka-c.vm.skroutz.gr:9092'],
                  logger: Logger.new(STDOUT))

producer = kafka.async_producer(delivery_interval: 1, max_queue_size: 10) 

at_exit { producer.shutdown }

producer.produce("test1", topic: "skroutz.scratch.v1")

producer.shutdown

sleep 15

producer.produce("test2", topic: "skroutz.scratch.v1")
```

Output before fix:
```
I, [2016-07-29T13:19:59.298416 #6947]  INFO -- : New topics added to target list: skroutz.scratch.v1
I, [2016-07-29T13:19:59.298495 #6947]  INFO -- : Fetching cluster metadata from kafka://kafka.vm.skroutz.gr:9092
D, [2016-07-29T13:19:59.298560 #6947] DEBUG -- : Opening connection to kafka.vm.skroutz.gr:9092 with client id ruby-kafka...
D, [2016-07-29T13:19:59.302985 #6947] DEBUG -- : Sending request 1 to kafka.vm.skroutz.gr:9092
D, [2016-07-29T13:19:59.303079 #6947] DEBUG -- : Waiting for response 1 from kafka.vm.skroutz.gr:9092
D, [2016-07-29T13:19:59.304349 #6947] DEBUG -- : Received response 1 from kafka.vm.skroutz.gr:9092
I, [2016-07-29T13:19:59.304385 #6947]  INFO -- : Discovered cluster metadata; nodes: kafka-b.vm.skroutz.gr:9092 (node_id=2), kafka.vm.skroutz.gr:9092 (node_id=1), kafka-c.vm.skroutz.gr:9092 (node_id=3)
D, [2016-07-29T13:19:59.304412 #6947] DEBUG -- : Closing socket to kafka.vm.skroutz.gr:9092
D, [2016-07-29T13:19:59.304515 #6947] DEBUG -- : Current leader for skroutz.scratch.v1/0 is node kafka.vm.skroutz.gr:9092 (node_id=1)
I, [2016-07-29T13:19:59.304557 #6947]  INFO -- : Sending 1 messages to kafka.vm.skroutz.gr:9092 (node_id=1)
D, [2016-07-29T13:19:59.304591 #6947] DEBUG -- : Opening connection to kafka.vm.skroutz.gr:9092 with client id ruby-kafka...
D, [2016-07-29T13:19:59.305354 #6947] DEBUG -- : Sending request 1 to kafka.vm.skroutz.gr:9092
D, [2016-07-29T13:19:59.305452 #6947] DEBUG -- : Waiting for response 1 from kafka.vm.skroutz.gr:9092
D, [2016-07-29T13:19:59.317600 #6947] DEBUG -- : Received response 1 from kafka.vm.skroutz.gr:9092
D, [2016-07-29T13:19:59.317643 #6947] DEBUG -- : Successfully appended 1 messages to skroutz.scratch.v1/0
I, [2016-07-29T13:19:59.317674 #6947]  INFO -- : Disconnecting broker 1
D, [2016-07-29T13:19:59.317690 #6947] DEBUG -- : Closing socket to kafka.vm.skroutz.gr:9092
I, [2016-07-29T13:20:14.318053 #6947]  INFO -- : Disconnecting broker 1
D, [2016-07-29T13:20:14.318131 #6947] DEBUG -- : Closing socket to kafka.vm.skroutz.gr:9092
/home/charkost/.gem/ruby/2.1.0/gems/ruby-kafka-0.3.11/lib/kafka/async_producer.rb:152:in `buffer_overflow': Kafka::BufferOverflow (Kafka::BufferOverflow)
	from /home/charkost/.gem/ruby/2.1.0/gems/ruby-kafka-0.3.11/lib/kafka/async_producer.rb:100:in `produce'
	from kafka_regr.rb:18:in `<main>'

```
After fix:
```
I, [2016-07-29T14:28:57.147097 #15439]  INFO -- : New topics added to target list: skroutz.scratch.v1
I, [2016-07-29T14:28:57.147197 #15439]  INFO -- : Fetching cluster metadata from kafka://kafka.vm.skroutz.gr:9092
D, [2016-07-29T14:28:57.147306 #15439] DEBUG -- : Opening connection to kafka.vm.skroutz.gr:9092 with client id ruby-kafka...
D, [2016-07-29T14:28:57.149729 #15439] DEBUG -- : Sending request 1 to kafka.vm.skroutz.gr:9092
D, [2016-07-29T14:28:57.149844 #15439] DEBUG -- : Waiting for response 1 from kafka.vm.skroutz.gr:9092
D, [2016-07-29T14:28:57.150792 #15439] DEBUG -- : Received response 1 from kafka.vm.skroutz.gr:9092
I, [2016-07-29T14:28:57.150838 #15439]  INFO -- : Discovered cluster metadata; nodes: kafka-b.vm.skroutz.gr:9092 (node_id=2), kafka.vm.skroutz.gr:9092 (node_id=1), kafka-c.vm.skroutz.gr:9092 (node_id=3)
D, [2016-07-29T14:28:57.150889 #15439] DEBUG -- : Closing socket to kafka.vm.skroutz.gr:9092
D, [2016-07-29T14:28:57.151012 #15439] DEBUG -- : Current leader for skroutz.scratch.v1/0 is node kafka.vm.skroutz.gr:9092 (node_id=1)
I, [2016-07-29T14:28:57.151071 #15439]  INFO -- : Sending 1 messages to kafka.vm.skroutz.gr:9092 (node_id=1)
D, [2016-07-29T14:28:57.151127 #15439] DEBUG -- : Opening connection to kafka.vm.skroutz.gr:9092 with client id ruby-kafka...
D, [2016-07-29T14:28:57.152137 #15439] DEBUG -- : Sending request 1 to kafka.vm.skroutz.gr:9092
D, [2016-07-29T14:28:57.152250 #15439] DEBUG -- : Waiting for response 1 from kafka.vm.skroutz.gr:9092
D, [2016-07-29T14:28:57.155555 #15439] DEBUG -- : Received response 1 from kafka.vm.skroutz.gr:9092
D, [2016-07-29T14:28:57.155612 #15439] DEBUG -- : Successfully appended 1 messages to skroutz.scratch.v1/0
I, [2016-07-29T14:28:57.155678 #15439]  INFO -- : Disconnecting broker 1
D, [2016-07-29T14:28:57.155706 #15439] DEBUG -- : Closing socket to kafka.vm.skroutz.gr:9092
D, [2016-07-29T14:29:12.156172 #15439] DEBUG -- : Current leader for skroutz.scratch.v1/0 is node kafka.vm.skroutz.gr:9092 (node_id=1)
I, [2016-07-29T14:29:12.156238 #15439]  INFO -- : Sending 1 messages to kafka.vm.skroutz.gr:9092 (node_id=1)
D, [2016-07-29T14:29:12.156328 #15439] DEBUG -- : Opening connection to kafka.vm.skroutz.gr:9092 with client id ruby-kafka...
D, [2016-07-29T14:29:12.158886 #15439] DEBUG -- : Sending request 1 to kafka.vm.skroutz.gr:9092
D, [2016-07-29T14:29:12.158997 #15439] DEBUG -- : Waiting for response 1 from kafka.vm.skroutz.gr:9092
D, [2016-07-29T14:29:12.162998 #15439] DEBUG -- : Received response 1 from kafka.vm.skroutz.gr:9092
D, [2016-07-29T14:29:12.163037 #15439] DEBUG -- : Successfully appended 1 messages to skroutz.scratch.v1/0
I, [2016-07-29T14:29:12.163080 #15439]  INFO -- : Disconnecting broker 1
D, [2016-07-29T14:29:12.163124 #15439] DEBUG -- : Closing socket to kafka.vm.skroutz.gr:9092

```