### PR TITLE
Rescue EHOSTUNREACH in case of turned off broker

### DIFF
--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -118,7 +118,7 @@ module Kafka
     rescue Errno::ETIMEDOUT => e
       @logger.error "Timed out while trying to connect to #{self}: #{e}"
       raise ConnectionError, e
-    rescue SocketError, Errno::ECONNREFUSED => e
+    rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
       @logger.error "Failed to connect to #{self}: #{e}"
       raise ConnectionError, e
     end


### PR DESCRIPTION
EHOSTUNREACH is raised when we try to connect to a turned off broker.
We should rescue this error in order to mark cluster as stale and fetch
the metadata of the new cluster state without this broker.