### PR TITLE
Avoid calling the ListOffsets Kafka API for each assigned partition

### DIFF
--- a/spec/offset_manager_spec.rb
+++ b/spec/offset_manager_spec.rb
@@ -51,8 +51,9 @@ describe Kafka::OffsetManager do
     end
 
     it "returns the default offset if none have been committed" do
+      allow(group).to receive(:assigned_partitions) { { "greetings" => [0] } }
       allow(fetched_offsets).to receive(:offset_for).with("greetings", 0) { -1 }
-      allow(cluster).to receive(:resolve_offset).with("greetings", 0, :latest) { 42 }
+      allow(cluster).to receive(:resolve_offsets).with("greetings", [0], :latest) { { 0 => 42 } }
       offset_manager.set_default_offset("greetings", :latest)
 
       offset = offset_manager.next_offset_for("greetings", 0)


### PR DESCRIPTION
We've run into problems when a consumer is assigned a _lot_ of partitions – since the current code resolves the starting position for each partition in a separate Kafka API call, the consumer would exceed the session timeout doing those calls before being able to do any work. Since it would be kicked out of the group before being ready to commit those offsets, it would have to start over, causing an infinite loop of ListOffsets calls.

This change makes each consumer execute the minimum number of API calls to resolve the starting position for _all_ partitions in a given topic. It's possible to further optimize by having just a single call to each broker that queries across all topics, but that would complicate matters further right now.