### PR TITLE
Reset member id when not known by coordinator

### DIFF
--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -113,7 +113,7 @@ module Kafka
     rescue UnknownMemberId
       @logger.error "Failed to join group; resetting member id and retrying in 1s..."
 
-      @member_id = nil
+      @member_id = ""
       sleep 1
 
       retry


### PR DESCRIPTION
We've seen this pop up in production. Setting to nil seems to cause issues.