### PR TITLE
Reset the consumer's position when an offset is out of range

### DIFF
--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -19,6 +19,7 @@ module Kafka
   end
 
   class OffsetOutOfRange < ProtocolError
+    attr_accessor :topic, :partition
   end
 
   # The request is for a topic or partition that does not exist on the broker.

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -263,6 +263,12 @@ module Kafka
       end
 
       operation.execute
+    rescue OffsetOutOfRange => e
+      @logger.error "Invalid offset for #{e.topic}/#{e.partition}, resetting to default offset"
+
+      @offset_manager.seek_to_default(e.topic, e.partition)
+
+      retry
     rescue ConnectionError => e
       @logger.error "Connection error while fetching messages: #{e}"
 

--- a/lib/kafka/fetch_operation.rb
+++ b/lib/kafka/fetch_operation.rb
@@ -71,6 +71,11 @@ module Kafka
           fetched_topic.partitions.map {|fetched_partition|
             begin
               Protocol.handle_error(fetched_partition.error_code)
+            rescue Kafka::OffsetOutOfRange => e
+              e.topic = fetched_topic.name
+              e.partition = fetched_partition.partition
+
+              raise e
             rescue Kafka::Error => e
               topic = fetched_topic.name
               partition = fetched_partition.partition

--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -26,6 +26,11 @@ module Kafka
       @logger.debug "Marking #{topic}/#{partition}:#{offset} as committed"
     end
 
+    def seek_to_default(topic, partition)
+      @processed_offsets[topic] ||= {}
+      @processed_offsets[topic][partition] = -1
+    end
+
     def next_offset_for(topic, partition)
       offset = @processed_offsets.fetch(topic, {}).fetch(partition) {
         committed_offset_for(topic, partition)


### PR DESCRIPTION
If the committed offset for a given partition is invalid, there's not much to do except resetting to the default offset.

This could be a horrible idea. I need to do some more research in order to verify that commits can in fact become corrupted and it's not just ruby-kafka messing up right now.