### PR TITLE
Allow pausing partitions in the consumer

### DIFF
--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -9,6 +9,10 @@ module Kafka
     attr_reader :topic, :partition, :offset
 
     def initialize(topic, partition, offset)
+      @topic = topic
+      @partition = partition
+      @offset = offset
+
       super()
     end
   end

--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -4,6 +4,15 @@ module Kafka
   class Error < StandardError
   end
 
+  # There was an error processing a message.
+  class ProcessingError < Error
+    attr_reader :topic, :partition, :offset
+
+    def initialize(topic, partition, offset)
+      super()
+    end
+  end
+
   # Subclasses of this exception class map to an error code described in the
   # Kafka protocol specification.
   #

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -144,7 +144,7 @@ module Kafka
                 backtrace = e.backtrace.join("\n")
                 @logger.error "Exception raised when processing #{location} -- #{e.class}: #{e}\n#{backtrace}"
 
-                raise
+                raise ProcessingError.new(message.topic, message.partition, message.offset)
               end
             end
 

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -94,11 +94,26 @@ module Kafka
       @running = false
     end
 
+    # Pause processing of a specific topic partition.
+    #
+    # When a specific message causes the processor code to fail, it can be a good
+    # idea to simply pause the partition until the error can be resolved, allowing
+    # the rest of the partitions to continue being processed.
+    #
+    # @param topic [String]
+    # @param partition [Integer]
+    # @return [nil]
     def pause(topic, partition)
       @paused_partitions[topic] ||= Set.new
       @paused_partitions[topic] << partition
     end
 
+    # Whether the topic partition is currently paused.
+    #
+    # @see #pause
+    # @param topic [String]
+    # @param partition [Integer]
+    # @return [Boolean] true if the partition is paused, false otherwise.
     def paused?(topic, partition)
       @paused_partitions.fetch(topic, []).include?(partition)
     end

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -108,6 +108,17 @@ module Kafka
       @paused_partitions[topic] << partition
     end
 
+    # Resume processing of a topic partition.
+    #
+    # @see #pause
+    # @param topic [String]
+    # @param partition [Integer]
+    # @return [nil]
+    def resume(topic, partition)
+      paused_partitions = @paused_partitions.fetch(topic, [])
+      paused_partitions.delete(partition)
+    end
+
     # Whether the topic partition is currently paused.
     #
     # @see #pause

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -76,7 +76,11 @@ describe Kafka::Consumer do
         consumer.each_message do |message|
           raise "yolo"
         end
-      }.to raise_exception(Kafka::ProcessingError)
+      }.to raise_exception(Kafka::ProcessingError) {|exception|
+        expect(exception.topic).to eq "greetings"
+        expect(exception.partition).to eq 0
+        expect(exception.offset).to eq 13
+      }
 
       expect(log.string).to include "Exception raised when processing greetings/0 at offset 13 -- RuntimeError: yolo"
     end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -111,6 +111,14 @@ describe Kafka::Consumer do
       end
 
       expect(fetch_operation).to_not have_received(:fetch_from_partition).with("greetings", 42, anything)
+
+      consumer.resume("greetings", 42)
+
+      consumer.each_message do |message|
+        consumer.stop
+      end
+
+      expect(fetch_operation).to have_received(:fetch_from_partition).with("greetings", 42, anything)
     end
   end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -100,5 +100,17 @@ describe Kafka::Consumer do
 
       expect(offset_manager).to have_received(:seek_to_default)
     end
+
+    it "does not fetch messages from paused partitions" do
+      assigned_partitions["greetings"] << 42
+
+      consumer.pause("greetings", 42)
+
+      consumer.each_message do |message|
+        consumer.stop
+      end
+
+      expect(fetch_operation).to_not have_received(:fetch_from_partition).with("greetings", 42, anything)
+    end
   end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -71,14 +71,14 @@ describe Kafka::Consumer do
       ]
     }
 
-    it "logs exceptions raised in the block" do
+    it "raises ProcessingError if the processing code fails" do
       expect {
         consumer.each_message do |message|
-          raise "hello"
+          raise "yolo"
         end
-      }.to raise_exception(RuntimeError, "hello")
+      }.to raise_exception(Kafka::ProcessingError)
 
-      expect(log.string).to include "Exception raised when processing greetings/0 at offset 13 -- RuntimeError: hello"
+      expect(log.string).to include "Exception raised when processing greetings/0 at offset 13 -- RuntimeError: yolo"
     end
 
     it "seeks to the default offset when the checkpoint is invalid " do

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -80,6 +80,11 @@ describe Kafka::Consumer do
         expect(exception.topic).to eq "greetings"
         expect(exception.partition).to eq 0
         expect(exception.offset).to eq 13
+
+        cause = exception.cause
+
+        expect(cause.class).to eq RuntimeError
+        expect(cause.message).to eq "yolo"
       }
 
       expect(log.string).to include "Exception raised when processing greetings/0 at offset 13 -- RuntimeError: yolo"


### PR DESCRIPTION
In some cases, a specific message with e.g. a malformed payload will cause a consumer's message processor to raise an exception, e.g.

```ruby
consumer.each_message do |message|
  value = JSON.parse(message.value) # <-- this could fail!
  ...
end
```

There are myriad other ways a processor could fail, and oftentimes the cause will be deterministic and based on a single message containing something unexpected.

For this reason, the official Java client allows [pausing specific partitions](https://kafka.apache.org/090/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#pause(org.apache.kafka.common.TopicPartition...)), making the consumer skip them when fetching messages. An operator would typically have to look into the matter, fix the underlying issues, and resume processing. In the meantime, processing of the _other_ partitions can continue uninterrupted.

This PR replicates that behavior in ruby-kafka. Currently, only explicitly pausing and resuming partitions is supported, but in the future it would be possible to e.g. set timeouts on pauses, allowing a partition to be automatically resumed after a while. This could be a nice fit in cases where the underlying error was not caused directly by the message, but rather by some resource referenced from the message, e.g. a shard of a database being unavailable.

The user would use the API like this:

```ruby
begin
  consumer.each_message do |message|
    ...
  end
rescue Kafka::ProcessingError => e
  # Here we elect to pause the partition from which the message was read:
  consumer.pause(e.topic, e.partition)

  # Report the exception to some error aggregator:
  ErrorTracker.report(e.cause)

  # Go back into the processing loop:
  retry
end
```