### PR TITLE
Clear resolved offsets on group rejoins

### DIFF
--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -71,6 +71,7 @@ module Kafka
 
     def clear_offsets
       @processed_offsets.clear
+      @resolved_offsets.clear
 
       # Clear the cached commits from the brokers.
       @committed_offsets = nil
@@ -86,6 +87,7 @@ module Kafka
 
       # Clear the cached commits from the brokers.
       @committed_offsets = nil
+      @resolved_offsets.clear
     end
 
     private


### PR DESCRIPTION
We've seen cases where the consumer crashed because it was trying to look up the resolved offset for a partition that was not in the memoized hash. I believe this happened because:

1. The consumer initially gets a hash of resolved default offsets for a given topic;
2. there's a rebalance and the consumer gets assigned at least one new partition in the topic;
3. it needs to look up the resolved default offset for that partition, but it's not in the – because it's still memoized.

The solution is to clear the memoized values every time there's a rejoin.