### PR TITLE
Allow setting a timeout on a partition pause

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-kafka (0.3.8)
+    ruby-kafka (0.3.15.beta2)
 
 GEM
   remote: https://rubygems.org/
@@ -55,6 +55,7 @@ GEM
     slop (3.6.0)
     snappy (0.0.12)
     thread_safe (0.3.5)
+    timecop (0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
@@ -76,6 +77,7 @@ DEPENDENCIES
   ruby-kafka!
   ruby-prof
   snappy
+  timecop
 
 BUNDLED WITH
    1.10.6

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -137,7 +137,15 @@ module Kafka
         # automatically resumed. When pausing, the timeout is translated to an
         # absolute point in time.
         timeout = partitions.fetch(partition)
-        timeout.nil? || Time.now < timeout
+
+        if timeout.nil?
+          true
+        elsif Time.now < timeout
+          true
+        else
+          resume(topic, partition)
+          false
+        end
       end
     end
 

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -100,12 +100,16 @@ module Kafka
     # idea to simply pause the partition until the error can be resolved, allowing
     # the rest of the partitions to continue being processed.
     #
+    # If the `timeout` argument is passed, the partition will automatically be
+    # resumed when the timeout expires.
+    #
     # @param topic [String]
     # @param partition [Integer]
+    # @param timeout [Integer] the number of seconds to pause the partition for.
     # @return [nil]
-    def pause(topic, partition)
-      @paused_partitions[topic] ||= Set.new
-      @paused_partitions[topic] << partition
+    def pause(topic, partition, timeout: nil)
+      @paused_partitions[topic] ||= {}
+      @paused_partitions[topic][partition] = timeout && Time.now + timeout
     end
 
     # Resume processing of a topic partition.
@@ -115,7 +119,7 @@ module Kafka
     # @param partition [Integer]
     # @return [nil]
     def resume(topic, partition)
-      paused_partitions = @paused_partitions.fetch(topic, [])
+      paused_partitions = @paused_partitions.fetch(topic, {})
       paused_partitions.delete(partition)
     end
 
@@ -126,7 +130,15 @@ module Kafka
     # @param partition [Integer]
     # @return [Boolean] true if the partition is paused, false otherwise.
     def paused?(topic, partition)
-      @paused_partitions.fetch(topic, []).include?(partition)
+      partitions = @paused_partitions.fetch(topic, {})
+
+      if partitions.key?(partition)
+        # Users can set an optional timeout, after which the partition is
+        # automatically resumed. When pausing, the timeout is translated to an
+        # absolute point in time.
+        timeout = partitions.fetch(partition)
+        timeout.nil? || Time.now < timeout
+      end
     end
 
     # Fetches and enumerates the messages in the topics that the consumer group

--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
   spec.add_development_dependency "dogstatsd-ruby"
   spec.add_development_dependency "ruby-prof"
+  spec.add_development_dependency "timecop"
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -137,14 +137,14 @@ describe Kafka::Consumer do
 
       Timecop.freeze time do
         consumer.pause("greetings", 0, timeout: 30)
-      end
 
-      Timecop.freeze time + 29 do
-        expect(consumer.paused?("greetings", 0)).to eq true
-      end
+        Timecop.travel 29 do
+          expect(consumer.paused?("greetings", 0)).to eq true
+        end
 
-      Timecop.freeze time + 31 do
-        expect(consumer.paused?("greetings", 0)).to eq false
+        Timecop.travel 31 do
+          expect(consumer.paused?("greetings", 0)).to eq false
+        end
       end
     end
   end


### PR DESCRIPTION
Although pausing a partition is a good way to avoid a single message causing a complete crash of a consumer, it may sometimes make sense to retry processing of the message, even if the user hasn't gone in and deployed a code change to handle the error, as sometimes the exception is due to an external resource referenced by the message that's in a temporary error state.

This change allows pausing a partition while setting a timeout for the pause. After the timeout expires, the partition is resumed.