### PR TITLE
Retry requests when the connection has been closed

### DIFF
--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -134,6 +134,19 @@ describe Kafka::Connection do
       expect(response).to eq "hello!"
     end
 
+    it "retries the request if the connection has been closed" do
+      connection.send_request(request)
+      broker.kill
+
+      server.close
+      server = TCPServer.new(host, port)
+      FakeServer.start(server)
+
+      response = connection.send_request(request)
+
+      expect(response).to eq "hello!"
+    end
+
     it "emits a notification" do
       events = []
 


### PR DESCRIPTION
An alternative to #275. Always retries requests, regardless of request type.
