### PR TITLE
Rescue NotCoordinatorForGroup during heartbeats

### DIFF
--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -89,6 +89,11 @@ module Kafka
     rescue ConnectionError, UnknownMemberId, RebalanceInProgress, IllegalGeneration => e
       @logger.error "Error sending heartbeat: #{e}"
       raise HeartbeatError, e
+    rescue NotCoordinatorForGroup
+      @logger.error "Failed to find coordinator for group `#{@group_id}`; retrying..."
+      sleep 1
+      @coordinator = nil
+      retry
     end
 
     private


### PR DESCRIPTION
It is possible for a group coordinator after a group rebalance to send
a group to another group coordinator. This results in NotCoordinatorForGroup
error in the next heartbeat attempt and the consumer crashes.

This commit gracefully handles this problem by getting the new group
coordinator from the cluster and retrying the heartbeat.