### PR TITLE
Beginning of 0.10.x support - timestamps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-kafka (0.3.15.beta2)
+    ruby-kafka (0.3.15.beta3)
 
 GEM
   remote: https://rubygems.org/
@@ -79,5 +79,8 @@ DEPENDENCIES
   snappy
   timecop
 
+RUBY VERSION
+   ruby 2.2.3p173
+
 BUNDLED WITH
-   1.10.6
+   1.12.0

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
 dependencies:
   pre:
     - docker -v
-    - docker pull ches/kafka:0.9.0.1
+    - docker pull ches/kafka:0.10.0.0
     - docker pull jplock/zookeeper:3.4.6
     - gem install bundler -v 1.9.5
 

--- a/lib/kafka/fetch_operation.rb
+++ b/lib/kafka/fetch_operation.rb
@@ -90,6 +90,7 @@ module Kafka
                 topic: fetched_topic.name,
                 partition: fetched_partition.partition,
                 offset: message.offset,
+                timestamp: message.timestamp
               )
             }
 

--- a/lib/kafka/fetched_message.rb
+++ b/lib/kafka/fetched_message.rb
@@ -16,12 +16,16 @@ module Kafka
     # @return [Integer] the offset of the message in the partition.
     attr_reader :offset
 
-    def initialize(value:, key:, topic:, partition:, offset:)
+    # @return [Integer] the timestamp associated with the message.
+    attr_reader :timestamp
+
+    def initialize(value:, key:, topic:, partition:, offset:, timestamp:)
       @value = value
       @key = key
       @topic = topic
       @partition = partition
       @offset = offset
+      @timestamp = timestamp
     end
   end
 end

--- a/lib/kafka/protocol/fetch_request.rb
+++ b/lib/kafka/protocol/fetch_request.rb
@@ -30,6 +30,10 @@ module Kafka
         1
       end
 
+      def api_version
+        2
+      end
+
       def response_class
         Protocol::FetchResponse
       end

--- a/lib/kafka/protocol/fetch_response.rb
+++ b/lib/kafka/protocol/fetch_response.rb
@@ -38,11 +38,14 @@ module Kafka
 
       attr_reader :topics
 
-      def initialize(topics: [])
+      def initialize(topics: [], throttle_time_ms: 0)
         @topics = topics
+        @throttle_time_ms = throttle_time_ms
       end
 
       def self.decode(decoder)
+        throttle_time_ms = decoder.int32
+        
         topics = decoder.array do
           topic_name = decoder.string
 
@@ -68,7 +71,7 @@ module Kafka
           )
         end
 
-        new(topics: topics)
+        new(topics: topics, throttle_time_ms: throttle_time_ms)
       end
     end
   end

--- a/lib/kafka/protocol/produce_request.rb
+++ b/lib/kafka/protocol/produce_request.rb
@@ -17,9 +17,10 @@ module Kafka
     #         Offset => int64
     #         MessageSize => int32
     #
-    #     Message => Crc MagicByte Attributes Key Value
+    #     Message => Crc MagicByte Timestamp Attributes Key Value
     #         Crc => int32
     #         MagicByte => int8
+    #         Timestamp => int64
     #         Attributes => int8
     #         Key => bytes
     #         Value => bytes
@@ -38,6 +39,10 @@ module Kafka
 
       def api_key
         0
+      end
+
+      def api_version
+        2
       end
 
       def response_class

--- a/lib/kafka/protocol/produce_response.rb
+++ b/lib/kafka/protocol/produce_response.rb
@@ -11,19 +11,21 @@ module Kafka
       end
 
       class PartitionInfo
-        attr_reader :partition, :error_code, :offset
+        attr_reader :partition, :error_code, :offset, :timestamp
 
-        def initialize(partition:, error_code:, offset:)
+        def initialize(partition:, error_code:, offset:, timestamp:)
           @partition = partition
           @error_code = error_code
           @offset = offset
+          @timestamp = timestamp
         end
       end
 
       attr_reader :topics
 
-      def initialize(topics: [])
+      def initialize(topics: [], throttle_time_ms: 0)
         @topics = topics
+        @throttle_time_ms = throttle_time_ms
       end
 
       def each_partition
@@ -43,13 +45,15 @@ module Kafka
               partition: decoder.int32,
               error_code: decoder.int16,
               offset: decoder.int64,
+              timestamp: decoder.int64
             )
           end
 
           TopicInfo.new(topic: topic, partitions: partitions)
         end
+        throttle_time_ms = decoder.int32
 
-        new(topics: topics)
+        new(topics: topics, throttle_time_ms: throttle_time_ms)
       end
     end
   end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -58,6 +58,7 @@ describe Kafka::Consumer do
           topic: "greetings",
           partition: 0,
           offset: 13,
+          timestamp: Time.now
         )
       ]
     }

--- a/spec/fake_broker.rb
+++ b/spec/fake_broker.rb
@@ -35,6 +35,7 @@ class FakeBroker
             partition: partition,
             error_code: error_code_for_partition(topic, partition),
             offset: message_set.messages.size,
+            timestamp: Time.now.to_i
           )
         }
       )
@@ -59,4 +60,3 @@ class FakeBroker
     @partition_errors[topic][partition]
   end
 end
-

--- a/spec/test_cluster.rb
+++ b/spec/test_cluster.rb
@@ -11,7 +11,7 @@ class TestCluster
   }
 
   DOCKER_HOSTNAME = URI(DOCKER_HOST).host
-  KAFKA_IMAGE = "ches/kafka:0.9.0.1"
+  KAFKA_IMAGE = "ches/kafka:0.10.0.0"
   ZOOKEEPER_IMAGE = "jplock/zookeeper:3.4.6"
   KAFKA_CLUSTER_SIZE = 3
 


### PR DESCRIPTION
This Pull Request begins the work to support Kafka version 0.10.x, which has protocol changes outlined here: https://cwiki.apache.org/confluence/display/KAFKA/KIP-32+-+Add+timestamps+to+Kafka+message

I'm opening this PR now as per conversations with @dasch 
