### PR TITLE
0.10 Timestamp Support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-kafka (0.3.15.beta2)
+    ruby-kafka (0.3.15.beta3)
 
 GEM
   remote: https://rubygems.org/

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
 dependencies:
   pre:
     - docker -v
-    - docker pull ches/kafka:0.9.0.1
+    - docker pull ches/kafka:0.10.0.0
     - docker pull jplock/zookeeper:3.4.6
     - gem install bundler -v 1.9.5
 

--- a/lib/kafka/fetch_operation.rb
+++ b/lib/kafka/fetch_operation.rb
@@ -90,6 +90,7 @@ module Kafka
                 topic: fetched_topic.name,
                 partition: fetched_partition.partition,
                 offset: message.offset,
+                create_time: message.create_time,
               )
             }
 

--- a/lib/kafka/fetched_message.rb
+++ b/lib/kafka/fetched_message.rb
@@ -16,12 +16,16 @@ module Kafka
     # @return [Integer] the offset of the message in the partition.
     attr_reader :offset
 
-    def initialize(value:, key:, topic:, partition:, offset:)
+    # @return [Time] the timestamp of the message.
+    attr_reader :create_time
+
+    def initialize(value:, key:, topic:, partition:, offset:, create_time:)
       @value = value
       @key = key
       @topic = topic
       @partition = partition
       @offset = offset
+      @create_time = create_time
     end
   end
 end

--- a/lib/kafka/protocol/fetch_request.rb
+++ b/lib/kafka/protocol/fetch_request.rb
@@ -30,6 +30,10 @@ module Kafka
         1
       end
 
+      def api_version
+        2
+      end
+
       def response_class
         Protocol::FetchResponse
       end

--- a/lib/kafka/protocol/fetch_response.rb
+++ b/lib/kafka/protocol/fetch_response.rb
@@ -38,11 +38,14 @@ module Kafka
 
       attr_reader :topics
 
-      def initialize(topics: [])
+      def initialize(topics: [], throttle_time_ms: 0)
         @topics = topics
+        @throttle_time_ms = throttle_time_ms
       end
 
       def self.decode(decoder)
+        throttle_time_ms = decoder.int32
+
         topics = decoder.array do
           topic_name = decoder.string
 
@@ -68,7 +71,7 @@ module Kafka
           )
         end
 
-        new(topics: topics)
+        new(topics: topics, throttle_time_ms: throttle_time_ms)
       end
     end
   end

--- a/lib/kafka/protocol/message.rb
+++ b/lib/kafka/protocol/message.rb
@@ -6,15 +6,16 @@ module Kafka
 
     # ## API Specification
     #
-    #     Message => Crc MagicByte Attributes Key Value
+    #     Message => Crc MagicByte Attributes Timestamp Key Value
     #         Crc => int32
     #         MagicByte => int8
     #         Attributes => int8
+    #         Timestamp => int64, in ms
     #         Key => bytes
     #         Value => bytes
     #
     class Message
-      MAGIC_BYTE = 0
+      MAGIC_BYTE = 1
 
       attr_reader :key, :value, :codec_id, :offset
 
@@ -71,6 +72,7 @@ module Kafka
         end
 
         attributes = message_decoder.int8
+        timestamp = message_decoder.int64
         key = message_decoder.bytes
         value = message_decoder.bytes
 
@@ -78,7 +80,7 @@ module Kafka
         # attributes.
         codec_id = attributes & 0b111
 
-        new(key: key, value: value, codec_id: codec_id, offset: offset)
+        new(key: key, value: value, codec_id: codec_id, offset: offset, create_time: Time.at(timestamp/1000))
       end
 
       private
@@ -102,6 +104,7 @@ module Kafka
 
         encoder.write_int8(MAGIC_BYTE)
         encoder.write_int8(@codec_id)
+        encoder.write_int64((@create_time.to_f*1000).to_i)
         encoder.write_bytes(@key)
         encoder.write_bytes(@value)
 

--- a/lib/kafka/protocol/message.rb
+++ b/lib/kafka/protocol/message.rb
@@ -80,7 +80,7 @@ module Kafka
         # attributes.
         codec_id = attributes & 0b111
 
-        new(key: key, value: value, codec_id: codec_id, offset: offset, create_time: Time.at(timestamp/1000))
+        new(key: key, value: value, codec_id: codec_id, offset: offset, create_time: Time.at(timestamp/1000.0))
       end
 
       private

--- a/lib/kafka/protocol/produce_request.rb
+++ b/lib/kafka/protocol/produce_request.rb
@@ -37,6 +37,10 @@ module Kafka
       end
 
       def api_key
+        0
+      end
+
+      def api_version
         2
       end
 

--- a/lib/kafka/protocol/produce_request.rb
+++ b/lib/kafka/protocol/produce_request.rb
@@ -37,7 +37,7 @@ module Kafka
       end
 
       def api_key
-        0
+        2
       end
 
       def response_class

--- a/lib/kafka/protocol/produce_response.rb
+++ b/lib/kafka/protocol/produce_response.rb
@@ -11,19 +11,21 @@ module Kafka
       end
 
       class PartitionInfo
-        attr_reader :partition, :error_code, :offset
+        attr_reader :partition, :error_code, :offset, :timestamp
 
-        def initialize(partition:, error_code:, offset:)
+        def initialize(partition:, error_code:, offset:, timestamp:)
           @partition = partition
           @error_code = error_code
           @offset = offset
+          @timestamp = timestamp
         end
       end
 
-      attr_reader :topics
+      attr_reader :topics, :throttle_time_ms
 
-      def initialize(topics: [])
+      def initialize(topics: [], throttle_time_ms: 0)
         @topics = topics
+        @throttle_time_ms = throttle_time_ms
       end
 
       def each_partition
@@ -43,13 +45,16 @@ module Kafka
               partition: decoder.int32,
               error_code: decoder.int16,
               offset: decoder.int64,
+              timestamp: decoder.int64,
             )
           end
 
           TopicInfo.new(topic: topic, partitions: partitions)
         end
 
-        new(topics: topics)
+        throttle_time_ms = decoder.int32
+
+        new(topics: topics, throttle_time_ms: throttle_time_ms)
       end
     end
   end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -58,6 +58,7 @@ describe Kafka::Consumer do
           topic: "greetings",
           partition: 0,
           offset: 13,
+          create_time: Time.now,
         )
       ]
     }

--- a/spec/fake_broker.rb
+++ b/spec/fake_broker.rb
@@ -35,7 +35,7 @@ class FakeBroker
             partition: partition,
             error_code: error_code_for_partition(topic, partition),
             offset: message_set.messages.size,
-            timestamp: Time.now.to_f * 1000,
+            timestamp: (Time.now.to_f*1000).to_i,
           )
         }
       )

--- a/spec/fake_broker.rb
+++ b/spec/fake_broker.rb
@@ -35,6 +35,7 @@ class FakeBroker
             partition: partition,
             error_code: error_code_for_partition(topic, partition),
             offset: message_set.messages.size,
+            timestamp: Time.now.to_f * 1000,
           )
         }
       )

--- a/spec/test_cluster.rb
+++ b/spec/test_cluster.rb
@@ -11,7 +11,7 @@ class TestCluster
   }
 
   DOCKER_HOSTNAME = URI(DOCKER_HOST).host
-  KAFKA_IMAGE = "ches/kafka:0.9.0.1"
+  KAFKA_IMAGE = "ches/kafka:0.10.0.0"
   ZOOKEEPER_IMAGE = "jplock/zookeeper:3.4.6"
   KAFKA_CLUSTER_SIZE = 3
 


### PR DESCRIPTION
This is our take on v 0.10.x support (message timestamps).

It basically implemented what @dasch mentioned in https://github.com/zendesk/ruby-kafka/issues/270#issuecomment-242332398, plus `FetchRequest` also has `api_version` set to 2.
