### PR TITLE
Ensures that kafka has the offset off the next message

### DIFF
--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -22,7 +22,10 @@ module Kafka
     def mark_as_processed(topic, partition, offset)
       @uncommitted_offsets += 1
       @processed_offsets[topic] ||= {}
-      @processed_offsets[topic][partition] = offset
+
+      # The committed offset should always be the offset of the next message that the
+      # application will read, thus adding one to the last message processed
+      @processed_offsets[topic][partition] = offset + 1
       @logger.debug "Marking #{topic}/#{partition}:#{offset} as committed"
     end
 
@@ -41,8 +44,8 @@ module Kafka
       if offset < 0
         resolve_offset(topic, partition)
       else
-        # The next offset is the last offset plus one.
-        offset + 1
+        # The next offset is the last offset.
+        offset
       end
     end
 

--- a/spec/offset_manager_spec.rb
+++ b/spec/offset_manager_spec.rb
@@ -72,7 +72,7 @@ describe Kafka::OffsetManager do
 
       expected_offsets = {
         "x" => {
-          0 => kind_of(Numeric),
+          0 => 43,
         }
       }
 

--- a/spec/offset_manager_spec.rb
+++ b/spec/offset_manager_spec.rb
@@ -26,8 +26,8 @@ describe Kafka::OffsetManager do
 
       expected_offsets = {
         "greetings" => {
-          0 => 42,
-          1 => 13,
+          0 => 43,
+          1 => 14,
         }
       }
 
@@ -42,12 +42,12 @@ describe Kafka::OffsetManager do
       allow(group).to receive(:fetch_offsets).and_return(fetched_offsets)
     end
 
-    it "returns the last committed offset plus one" do
+    it "returns the last committed offset" do
       allow(fetched_offsets).to receive(:offset_for).with("greetings", 0) { 41 }
 
       offset = offset_manager.next_offset_for("greetings", 0)
 
-      expect(offset).to eq 42
+      expect(offset).to eq 41
     end
 
     it "returns the default offset if none have been committed" do
@@ -55,14 +55,6 @@ describe Kafka::OffsetManager do
       allow(fetched_offsets).to receive(:offset_for).with("greetings", 0) { -1 }
       allow(cluster).to receive(:resolve_offsets).with("greetings", [0], :latest) { { 0 => 42 } }
       offset_manager.set_default_offset("greetings", :latest)
-
-      offset = offset_manager.next_offset_for("greetings", 0)
-
-      expect(offset).to eq 42
-    end
-
-    it "returns the next offset if we've already processed messages in the partition" do
-      offset_manager.mark_as_processed("greetings", 0, 41)
 
       offset = offset_manager.next_offset_for("greetings", 0)
 
@@ -80,7 +72,7 @@ describe Kafka::OffsetManager do
 
       expected_offsets = {
         "x" => {
-          0 => 42,
+          0 => kind_of(Numeric),
         }
       }
 


### PR DESCRIPTION
This PR fixes issue #280 

@dasch I tried to follow your recommendation to move +1 to `commit _offsets` but `offset_manager#next_offset_for` is involved in two scenarios:

1) When `@processed_offsets` is not initialized and it reads from kafka
2) While the batch is not committed, thus depending on `@processed_offsets` to get the next offset

+1 is in `offset_manager#mark_as_processed` now to keep all the logic inside the offset manager.