### PR TITLE
Remove Instrumentation readme ordering bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ By default, nothing is logged.
 
 ### Instrumentation
 
-Most operations are instrumented using [Active Support Notifications](http://api.rubyonrails.org/classes/ActiveSupport/Notifications.html). In order to subscribe to notifications, make sure to require the notifications library _before_ you require ruby-kafka, e.g.
+Most operations are instrumented using [Active Support Notifications](http://api.rubyonrails.org/classes/ActiveSupport/Notifications.html). In order to subscribe to notifications, make sure to require the notifications library:
 
 ```ruby
 require "active_support/notifications"


### PR DESCRIPTION
I believe the change in 3bdd25ea9fbfd7e0305eae3a0292413534e8a0cc
made inclusion ordering not required, as it moved away from
the singleton.

Having read the code, as well as tested with the following simple
example, I believe this to be the case:

```ruby
require "kafka"
require "active_support/notifications"

ActiveSupport::Notifications.subscribe(/.*\.kafka$/) do |*args|
  event = ActiveSupport::Notifications::Event.new(*args)
  puts "Received notification `#{event.name}` with payload: #{event.payload.inspect}"
end

instrumenter = Kafka::Instrumenter.new(client_id: "test")
instrumenter.instrument("test_event", foo: :bar) { 1 + 1 }
```

I suppose if you have gem requirements staggered after Kafka
consumers/producers are initialized, this may still be good advice.