### PR TITLE
Update producer.rb

### DIFF
--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -320,6 +320,8 @@ module Kafka
       end
 
       unless @pending_message_queue.empty?
+        # Mark the cluster as stale in order to force a cluster metadata refresh.
+        @cluster.mark_as_stale!
         raise DeliveryFailed, "Failed to assign partitions to #{@pending_message_queue.size} messages"
       end
 


### PR DESCRIPTION
Referring to these 2  issue 
https://github.com/zendesk/ruby-kafka/issues/293
 https://github.com/fluent/fluent-plugin-kafka/issues/97

from the looks need to refresh metadata when failed to assign partition, as producer can't rebalance due to broker imbalance, hence metadata needs to be refreshed.