### PR TITLE
Detect private key type (instead of always using RSA)

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -437,7 +437,7 @@ module Kafka
       if client_cert && client_cert_key
         ssl_context.set_params(
           cert: OpenSSL::X509::Certificate.new(client_cert),
-          key: OpenSSL::PKey::RSA.new(client_cert_key)
+          key: OpenSSL::PKey.read(client_cert_key)
         )
       elsif client_cert && !client_cert_key
         raise ArgumentError, "Kafka client initialized with `ssl_client_cert` but no `ssl_client_cert_key`. Please provide both."


### PR DESCRIPTION
I have a client key that is DSA encoded, and I kept getting this error:

```
/usr/local/lib/ruby/gems/2.3.0/gems/ruby-kafka-0.3.8/lib/kafka/client.rb:304:in `initialize': Neither PUB key nor PRIV key: nested asn1 error (OpenSSL::PKey::RSAError)
        from /usr/local/lib/ruby/gems/2.3.0/gems/ruby-kafka-0.3.8/lib/kafka/client.rb:304:in `new'
        from /usr/local/lib/ruby/gems/2.3.0/gems/ruby-kafka-0.3.8/lib/kafka/client.rb:304:in `build_ssl_context'
        from /usr/local/lib/ruby/gems/2.3.0/gems/ruby-kafka-0.3.8/lib/kafka/client.rb:48:in `initialize'
        from /usr/local/lib/ruby/gems/2.3.0/gems/ruby-kafka-0.3.8/lib/kafka.rb:136:in `new'
        from /usr/local/lib/ruby/gems/2.3.0/gems/ruby-kafka-0.3.8/lib/kafka.rb:136:in `new'
        from example.rb:16:in `<main>'
```

The OpenSSL docs indicate that [this method](https://ruby-doc.org/stdlib-2.0.0/libdoc/openssl/rdoc/OpenSSL/PKey.html#method-c-read-label-Parameters) can be used to instantiate a `PKey` from any type of DER- or PEM-encoded private key.

(I'm not a Ruby guy, so I apologize if I've made any errors; please let me know if I have!)