### PR TITLE
throw proper topic errors when starting to consume a topic

### DIFF
--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -46,6 +46,10 @@ module Kafka
         @target_topics.merge(new_topics)
 
         refresh_metadata!
+
+        cluster_info.topics.each do |topic|
+          Protocol.handle_error(topic.topic_error_code)
+        end
       end
     end
 


### PR DESCRIPTION
this actually only throws the *first* topic error that we see, but it's close enough; I was getting an odd "couldn't find group co-ordinator" error, when in fact I had mis-configured my cluster and should have been getting a "no leader" error. 

