### PR TITLE
Fetch messages concurrently from all brokers

### DIFF
--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -40,6 +40,22 @@ module Kafka
       @connection.send_request(request)
     end
 
+    # Fetches messages asynchronously.
+    #
+    # The fetch request is sent to the broker, but the response is not read.
+    # This allows the broker to process the request, wait for new messages,
+    # and send a response without the client having to wait. In order to
+    # read the response, call `#call` on the returned object. This will
+    # block the caller until the response is available.
+    #
+    # @param (see Kafka::Protocol::FetchRequest#initialize)
+    # @return [Kafka::AsyncResponse]
+    def fetch_messages_async(**options)
+      request = Protocol::FetchRequest.new(**options)
+
+      @connection.send_async_request(request)
+    end
+
     # Lists the offset of the specified topics and partitions.
     #
     # @param (see Kafka::Protocol::ListOffsetRequest#initialize)

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -316,7 +316,7 @@ module Kafka
 
     def make_final_offsets_commit!(attempts = 3)
       @offset_manager.commit_offsets
-    rescue ConnectionError
+    rescue ConnectionError, Kafka::OffsetCommitError
       # It's important to make sure final offsets commit is done
       # As otherwise messages that have been processed after last auto-commit
       # will be processed again and that may be huge amount of messages

--- a/lib/kafka/instrumenter.rb
+++ b/lib/kafka/instrumenter.rb
@@ -6,19 +6,35 @@ module Kafka
       @default_payload = default_payload
 
       if defined?(ActiveSupport::Notifications)
-        @backend = ActiveSupport::Notifications
+        @backend = ActiveSupport::Notifications.instrumenter
       else
         @backend = nil
       end
     end
 
-    def instrument(event_name, payload = {}, &block)
+    def instrument(event_name, payload = {})
       if @backend
         payload.update(@default_payload)
 
-        @backend.instrument("#{event_name}.#{NAMESPACE}", payload, &block)
+        @backend.instrument("#{event_name}.#{NAMESPACE}", payload) { yield payload if block_given? }
       else
-        block.call(payload) if block
+        yield payload if block_given?
+      end
+    end
+
+    def start(event_name, payload = {})
+      if @backend
+        payload.update(@default_payload)
+
+        @backend.start("#{event_name}.#{NAMESPACE}", payload)
+      end
+    end
+
+    def finish(event_name, payload = {})
+      if @backend
+        payload.update(@default_payload)
+
+        @backend.finish("#{event_name}.#{NAMESPACE}", payload)
       end
     end
   end
@@ -31,6 +47,14 @@ module Kafka
 
     def instrument(event_name, payload = {}, &block)
       @backend.instrument(event_name, @extra_payload.merge(payload), &block)
+    end
+
+    def start(event_name, payload = {})
+      @backend.start(event_name, @extra_payload.merge(payload))
+    end
+
+    def finish(event_name, payload = {})
+      @backend.finish(event_name, @extra_payload.merge(payload))
     end
   end
 end

--- a/lib/kafka/protocol/null_response.rb
+++ b/lib/kafka/protocol/null_response.rb
@@ -1,0 +1,11 @@
+module Kafka
+  module Protocol
+
+    # A response class used when no response is expected.
+    class NullResponse
+      def self.decode(decoder)
+        nil
+      end
+    end
+  end
+end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -87,7 +87,7 @@ describe Kafka::Connection do
       expect(response).to eq "hello!"
     end
 
-    it "skips responses to previous requests" do
+    it "skips responses to previous requests if there's no async response in the pipeline" do
       # By passing nil as the final argument we're telling Connection that we're
       # not expecting a response, so it won't read one. However, the fake broker
       # *is* writing a response, so we'll get that the next time we read a response,
@@ -152,6 +152,45 @@ describe Kafka::Connection do
       expect(event.payload[:api]).to eq :produce
       expect(event.payload[:request_size]).to eq 22
       expect(event.payload[:response_size]).to eq 12
+    end
+  end
+
+  describe "#send_async_request" do
+    let(:api_key) { 0 }
+    let(:response_decoder) { double(:response_decoder) }
+
+    before do
+      allow(response_decoder).to receive(:decode) {|decoder|
+        decoder.string
+      }
+    end
+
+    it "asynchronously sends the request" do
+      request1 = double(:request1, api_key: api_key, response_class: response_decoder)
+      request2 = double(:request2, api_key: api_key, response_class: response_decoder)
+
+      allow(request1).to receive(:encode) {|encoder| encoder.write_string("response1") }
+      allow(request2).to receive(:encode) {|encoder| encoder.write_string("response2") }
+
+      response1 = connection.send_async_request(request1)
+      response2 = connection.send_async_request(request2)
+
+      expect(response1.call).to eq "response1"
+      expect(response2.call).to eq "response2"
+    end
+
+    it "allows blocking on later requests before previous ones" do
+      request1 = double(:request1, api_key: api_key, response_class: response_decoder)
+      request2 = double(:request2, api_key: api_key, response_class: response_decoder)
+
+      allow(request1).to receive(:encode) {|encoder| encoder.write_string("response1") }
+      allow(request2).to receive(:encode) {|encoder| encoder.write_string("response2") }
+
+      response1 = connection.send_async_request(request1)
+      response2 = connection.send_async_request(request2)
+
+      expect(response2.call).to eq "response2"
+      expect(response1.call).to eq "response1"
     end
   end
 end


### PR DESCRIPTION
The consumer will write a request to each broker it needs messages from before reading any responses. It will then block on the socket of the first broker in the list until there's a response, after which it will start processing messages; then continue with the next broker; etc.

This is by no means the optimal design, but it balances simplicity and efficiency.