### PR TITLE
Only fetch messages for subscribed topics

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -319,11 +319,11 @@ module Kafka
     def fetch_batches(min_bytes:, max_wait_time:)
       join_group unless @group.member?
 
-      assigned_partitions = @group.assigned_partitions
+      subscribed_partitions = @group.subscribed_partitions
 
       @heartbeat.send_if_necessary
 
-      raise "No partitions assigned!" if assigned_partitions.empty?
+      raise "No partitions assigned!" if subscribed_partitions.empty?
 
       operation = FetchOperation.new(
         cluster: @cluster,
@@ -332,7 +332,7 @@ module Kafka
         max_wait_time: max_wait_time,
       )
 
-      assigned_partitions.each do |topic, partitions|
+      subscribed_partitions.each do |topic, partitions|
         partitions.each do |partition|
           offset = @offset_manager.next_offset_for(topic, partition)
           max_bytes = @max_bytes.fetch(topic)

--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -23,6 +23,10 @@ module Kafka
       @cluster.add_target_topics([topic])
     end
 
+    def subscribed_partitions
+      @assigned_partitions.select { |topic, _| @topics.include?(topic) }
+    end
+
     def member?
       !@generation_id.nil?
     end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -39,7 +39,7 @@ describe Kafka::Consumer do
     allow(group).to receive(:subscribe)
     allow(group).to receive(:leave)
     allow(group).to receive(:member?) { true }
-    allow(group).to receive(:assigned_partitions) { assigned_partitions }
+    allow(group).to receive(:subscribed_partitions) { assigned_partitions }
 
     allow(heartbeat).to receive(:send_if_necessary)
 


### PR DESCRIPTION
We ran into an issue where a ConsumerGroup was assigned partitions for a topic that the Consumer was not subscribed to. This was a topic that the consumer group used to consume, but that we were no longer using.

This led to an exception in the OffsetManager because there was no default offset for the topic that the consumer no longer subscribes to: https://github.com/zendesk/ruby-kafka/blob/master/lib/kafka/offset_manager.rb#L104

The proposed fix here addresses the issue by only fetching from partitions for the topics that the consumer is subscribed to.

I tried to write a functional test for the ConsumerGroup to demonstrate the problem, but was unable to reproduce it using the test cluster.