### PR TITLE
Expose offset retention time in the Consumer API

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -216,19 +216,25 @@ module Kafka
     #   not triggered by message processing.
     # @param heartbeat_interval [Integer] the interval between heartbeats; must be less
     #   than the session window.
+    # @param offset_retention_time [Integer] the time period that committed
+    #   offsets will be retained, in seconds. Defaults to the broker setting.
     # @return [Consumer]
-    def consumer(group_id:, session_timeout: 30, offset_commit_interval: 10, offset_commit_threshold: 0, heartbeat_interval: 10)
+    def consumer(group_id:, session_timeout: 30, offset_commit_interval: 10, offset_commit_threshold: 0, heartbeat_interval: 10, offset_retention_time: nil)
       cluster = initialize_cluster
 
       instrumenter = DecoratingInstrumenter.new(@instrumenter, {
         group_id: group_id,
       })
 
+      # The Kafka protocol expects the retention time to be in ms.
+      retention_time = (offset_retention_time && offset_retention_time * 1_000) || -1
+
       group = ConsumerGroup.new(
         cluster: cluster,
         logger: @logger,
         group_id: group_id,
         session_timeout: session_timeout,
+        retention_time: retention_time
       )
 
       offset_manager = OffsetManager.new(

--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -5,7 +5,7 @@ module Kafka
   class ConsumerGroup
     attr_reader :assigned_partitions, :generation_id
 
-    def initialize(cluster:, logger:, group_id:, session_timeout:)
+    def initialize(cluster:, logger:, group_id:, session_timeout:, retention_time:)
       @cluster = cluster
       @logger = logger
       @group_id = group_id
@@ -16,6 +16,7 @@ module Kafka
       @topics = Set.new
       @assigned_partitions = {}
       @assignment_strategy = RoundRobinAssignmentStrategy.new(cluster: @cluster)
+      @retention_time = retention_time
     end
 
     def subscribe(topic)
@@ -68,6 +69,7 @@ module Kafka
         member_id: @member_id,
         generation_id: @generation_id,
         offsets: offsets,
+        retention_time: @retention_time
       )
 
       response.topics.each do |topic, partitions|

--- a/spec/functional/batch_consumer_spec.rb
+++ b/spec/functional/batch_consumer_spec.rb
@@ -4,6 +4,7 @@ describe "Batch Consumer API", functional: true do
     message_count = 1_000
     messages = (1...message_count).to_set
     message_queue = Queue.new
+    offset_retention_time = 30
 
     topic = create_random_topic(num_partitions: 15)
 
@@ -23,7 +24,7 @@ describe "Batch Consumer API", functional: true do
     threads = 2.times.map do |thread_id|
       t = Thread.new do
         kafka = Kafka.new(seed_brokers: kafka_brokers, client_id: "test", logger: logger)
-        consumer = kafka.consumer(group_id: group_id)
+        consumer = kafka.consumer(group_id: group_id, offset_retention_time: offset_retention_time)
         consumer.subscribe(topic)
 
         consumer.each_batch do |batch|

--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -1,6 +1,7 @@
 describe "Consumer API", functional: true do
   let(:num_partitions) { 15 }
   let!(:topic) { create_random_topic(num_partitions: 3) }
+  let(:offset_retention_time) { 30 }
 
   example "consuming messages from the beginning of a topic" do
     messages = (1..1000).to_a
@@ -33,7 +34,7 @@ describe "Consumer API", functional: true do
         received_messages = []
 
         kafka = Kafka.new(seed_brokers: kafka_brokers, client_id: "test", logger: logger)
-        consumer = kafka.consumer(group_id: group_id)
+        consumer = kafka.consumer(group_id: group_id, offset_retention_time: offset_retention_time)
         consumer.subscribe(topic)
 
         consumer.each_message do |message|
@@ -68,7 +69,7 @@ describe "Consumer API", functional: true do
       received_messages = 0
 
       kafka = Kafka.new(seed_brokers: kafka_brokers, client_id: "test", logger: logger)
-      consumer = kafka.consumer(group_id: group_id)
+      consumer = kafka.consumer(group_id: group_id, offset_retention_time: offset_retention_time)
       consumer.subscribe(topic, start_from_beginning: false)
 
       consumer.each_message do |message|
@@ -123,7 +124,7 @@ describe "Consumer API", functional: true do
 
     group_id = "test#{rand(1000)}"
 
-    consumer = kafka.consumer(group_id: group_id)
+    consumer = kafka.consumer(group_id: group_id, offset_retention_time: offset_retention_time)
     consumer.subscribe(topic, start_from_beginning: true)
 
     consumer.each_message do |message|

--- a/spec/fuzz/consumer_group_spec.rb
+++ b/spec/fuzz/consumer_group_spec.rb
@@ -74,7 +74,7 @@ describe "Consumer groups", fuzz: true do
         connect_timeout: 20,
       )
 
-      consumer = kafka.consumer(group_id: "fuzz", session_timeout: 30)
+      consumer = kafka.consumer(group_id: "fuzz", session_timeout: 30, offset_retention_time: 300)
       consumer.subscribe(topic)
 
       consumer.each_message do |message|


### PR DESCRIPTION
This change implements a version of the enhancement described in https://github.com/zendesk/ruby-kafka/issues/233.

Our use case for this is a very low throughput topic where some partitions do not receive new messages within the broker's retention period setting (1 day). Previously committed offsets would be purged and the next day the partition would be read from the beginning again.

Exposing this setting to the consumer provides more flexibility than changing the broker's setting for all consumers.