### PR TITLE
Periodically re-commit previously committed offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ Changes and additions to the library will be listed here.
 
 ## Unreleased
 
+- Re-commit previously committed offsets periodically with an interval of half
+  the offset retention time, starting with the first commit (#318).
+- Expose offset retention time in the Consumer API (#316).
+
 ## v0.3.16
 
 - Fix SSL socket timeout (#283).
 - Update to the latest Datadog gem (#296).
 - Automatically detect private key type (#297).
+- Only fetch messages for subscribed topics (#309).
 
 ## v0.3.15
 

--- a/README.md
+++ b/README.md
@@ -505,6 +505,10 @@ By default, offsets are committed every 10 seconds. You can increase the frequen
 
 In addition to the time based trigger it's possible to trigger checkpointing in response to _n_ messages having been processed, known as the _offset commit threshold_. This puts a bound on the number of messages that can be double-processed before the problem is detected. Setting this to 1 will cause an offset commit to take place every time a message has been processed. By default this trigger is disabled.
 
+Stale offsets are periodically purged by the broker. The broker setting `offsets.retention.minutes` controls the retention window for committed offsets, and defaults to 1 day. The length of the retention window, known as _offset retention time_, can be changed for the consumer.
+
+Previously committed offsets are re-committed, to reset the retention window, at the first commit and periodically at an interval of half the _offset retention time_.
+
 ```ruby
 consumer = kafka.consumer(
   group_id: "some-group",
@@ -514,6 +518,9 @@ consumer = kafka.consumer(
 
   # Commit offsets when 100 messages have been processed.
   offset_commit_threshold: 100,
+
+  # Increase the length of time that committed offsets are kept.
+  offset_retention_time: 7 * 60 * 60
 )
 ```
 

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -243,6 +243,7 @@ module Kafka
         logger: @logger,
         commit_interval: offset_commit_interval,
         commit_threshold: offset_commit_threshold,
+        offset_retention_time: offset_retention_time
       )
 
       heartbeat = Heartbeat.new(


### PR DESCRIPTION
This change addresses Issue https://github.com/zendesk/ruby-kafka/issues/317.

Previously committed offsets are re-committed at the first commit and periodically after that at an interval that is half the _offset retention time_. If the _offset retention time_ is not specified for the consumer, then half of the broker's default setting (1 day) is used.