### PR TITLE
Allow ssl_ca_cert to be an array of PEM encoded certificates

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -454,12 +454,8 @@ module Kafka
 
       if ca_cert
         store = OpenSSL::X509::Store.new
-        if ca_cert.kind_of?(Array)
-          ca_cert.each do |cert|
-            store.add_cert(OpenSSL::X509::Certificate.new(cert))
-          end
-        else
-          store.add_cert(OpenSSL::X509::Certificate.new(ca_cert))
+        Array(ca_cert).each do |cert|
+          store.add_cert(OpenSSL::X509::Certificate.new(cert))
         end
         ssl_context.cert_store = store
       end

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -31,8 +31,8 @@ module Kafka
     # @param socket_timeout [Integer, nil] the timeout setting for socket
     #   connections. See {BrokerPool#initialize}.
     #
-    # @param ssl_ca_cert [String, nil] a PEM encoded CA cert to use with an
-    #   SSL connection.
+    # @param ssl_ca_cert [String, Array<String>, nil] a PEM encoded CA cert, or an Array of
+    #   PEM encoded CA certs, to use with an SSL connection.
     #
     # @param ssl_client_cert [String, nil] a PEM encoded client cert to use with an
     #   SSL connection. Must be used in combination with ssl_client_cert_key.
@@ -454,7 +454,13 @@ module Kafka
 
       if ca_cert
         store = OpenSSL::X509::Store.new
-        store.add_cert(OpenSSL::X509::Certificate.new(ca_cert))
+        if ca_cert.kind_of?(Array)
+          ca_cert.each do |cert|
+            store.add_cert(OpenSSL::X509::Certificate.new(cert))
+          end
+        else
+          store.add_cert(OpenSSL::X509::Certificate.new(ca_cert))
+        end
         ssl_context.cert_store = store
       end
 


### PR DESCRIPTION
`ssl_ca_cert` adds a single certificate to the OpenSSL:X509::Store, but some configurations have longer certificate chains than just one level.

This commit exposes`add_file` of OpenSSL:X509::Store to allow adding all certificates contained in a file.