### PR TITLE
Add a test that should hide exceptions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-kafka (0.3.15)
+    ruby-kafka (0.3.16)
 
 GEM
   remote: https://rubygems.org/
@@ -83,4 +83,4 @@ RUBY VERSION
    ruby 2.2.3p173
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/spec/functional/async_producer_spec.rb
+++ b/spec/functional/async_producer_spec.rb
@@ -71,12 +71,22 @@ describe "Producer API", functional: true do
   example "ssl exceptions are hidden on async producers" do
     producer = kafka.async_producer(delivery_threshold: 1)
 
-    expect(producer.instance_variable_get(:@worker)).to receive(:run).and_raise(OpenSSL::SSL::SSLError)
+    #expect(producer.instance_variable_get(:@worker)).to receive(:run).and_raise(OpenSSL::SSL::SSLError)
+
+    #expect(Kafka::SSLSocketWithTimeout.any_instance).to receive(:initialize).and_raise(OpenSSL::SSL::SSLError)
+    #expect(Kafka::SocketWithTimeout.any_instance).to receive(:initialize).and_raise(OpenSSL::SSL::SSLError)
+    #expect(Kafka::Connection.any_instance).to receive(:send_request).and_raise(OpenSSL::SSL::SSLError)
+    #expect(Kafka::Producer.any_instance).to receive(:deliver_messages_with_retries).and_raise(OpenSSL::SSL::SSLError)
+    #expect(producer).to receive(:deliver_messages).and_raise(OpenSSL::SSL::SSLError)
+    #expect(Kafka::Producer.any_instance).to receive(:deliver_messages).and_raise(OpenSSL::SSL::SSLError)
+    #expect(producer.instance_variable_get(:@worker)).to receive(:deliver_messages).and_raise(OpenSSL::SSL::SSLError)
+    expect(producer.instance_variable_get(:@worker).instance_variable_get(:@producer)).to receive(:deliver_messages).and_raise(OpenSSL::SSL::SSLError)
+    #expect(producer).to receive(:deliver_messages).and_raise(OpenSSL::SSL::SSLError)
 
     #expect {
       producer.produce("value", topic: topic, partition: 0) #}.to raise_error(OpenSSL::SSL::SSLError)
-=begin
     sleep 0.2
+=begin
 
     messages = kafka.fetch_messages(
       topic: topic,

--- a/spec/functional/async_producer_spec.rb
+++ b/spec/functional/async_producer_spec.rb
@@ -67,4 +67,46 @@ describe "Producer API", functional: true do
 
     producer.shutdown
   end
+
+  example "ssl exceptions are hidden on async producers" do
+    producer = kafka.async_producer(delivery_threshold: 1)
+
+    expect(producer.instance_variable_get(:@worker)).to receive(:run).and_raise(OpenSSL::SSL::SSLError)
+
+    #expect {
+      producer.produce("value", topic: topic, partition: 0) #}.to raise_error(OpenSSL::SSL::SSLError)
+=begin
+    sleep 0.2
+
+    messages = kafka.fetch_messages(
+      topic: topic,
+      partition: 0,
+      offset: 0,
+      max_wait_time: 0,
+    )
+
+    expect(messages.size).to eq 0
+
+    producer.shutdown
+=end
+  end
+
+  example "non existent topics throw " do
+    producer = kafka.async_producer(delivery_threshold: 1)
+
+    producer.produce("value", topic: "non_existent_topic", partition: 0)
+
+    sleep 0.2
+
+    messages = kafka.fetch_messages(
+      topic: topic,
+      partition: 0,
+      offset: 0,
+      max_wait_time: 0,
+    )
+
+    expect(messages.size).to eq 0
+
+    producer.shutdown
+  end
 end


### PR DESCRIPTION
Run with:
bundle exec rspec --tag functional spec/functional/async_producer_spec.rb:71

I saw this exception:
```
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/async_producer.rb:143:in `block in ensure_threads_running!'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/async_producer.rb:190:in `run'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/async_producer.rb:190:in `loop'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/async_producer.rb:198:in `block in run'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/async_producer.rb:223:in `deliver_messages'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/producer.rb:236:in `deliver_messages'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/instrumenter.rb:19:in `instrument'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.0.1/lib/active_support/notifications.rb:166:in `instrument'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/producer.rb:243:in `block in deliver_messages'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/producer.rb:281:in `deliver_messages_with_retries'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/cluster.rb:48:in `add_target_topics'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/cluster.rb:67:in `refresh_metadata!'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/cluster.rb:181:in `cluster_info'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/cluster.rb:193:in `fetch_cluster_info'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/cluster.rb:193:in `each'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/cluster.rb:198:in `block in fetch_cluster_info'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/broker.rb:30:in `fetch_metadata'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/connection.rb:86:in `send_request'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/instrumenter.rb:19:in `instrument'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.0.1/lib/active_support/notifications.rb:166:in `instrument'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/connection.rb:87:in `block in send_request'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/connection.rb:108:in `open'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/connection.rb:108:in `new'	2017-03-08 13:52:33
from /app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/ssl_socket_with_timeout.rb:66:in `initialize'	2017-03-08 13:52:33
/app/vendor/bundle/ruby/2.3.0/gems/ruby-kafka-0.3.16/lib/kafka/ssl_socket_with_timeout.rb:66:in `connect_nonblock': SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (OpenSSL::SSL::SSLError)
```

Which went unreported via bugsnag -- but appears to throw in this added test:

```script
{22:52}~/src/github.com/zendesk/ruby-kafka:hidden_exceptions ✗ ➭ bundle exec rspec --tag functional spec/functional/async_producer_spec.rb:71                                                      [11/1974]
Run options:
  include {:functional=>true, :locations=>{"./spec/functional/async_producer_spec.rb"=>[71]}}
  exclude {:performance=>true, :fuzz=>true}
Fetching image ches/kafka:0.9.0.1... OK
Fetching image jplock/zookeeper:3.4.6... OK
Starting cluster...
Waiting for 192.168.1.11:32785... OK
Waiting for 192.168.1.11:9093... OK
Waiting for 192.168.1.11:9094... OK
Waiting for 192.168.1.11:9095... OK

Producer API
Creating topic topic-1... OK
<Topic:topic-1  PartitionCount:3        ReplicationFactor:1     Configs:
:       Topic: topic-1  Partition: 0    Leader: 0       Replicas: 0     Isr: 0
:       Topic: topic-1  Partition: 1    Leader: 1       Replicas: 1     Isr: 1
:       Topic: topic-1  Partition: 2    Leader: 0       Replicas: 0     Isr: 0
  ssl exceptions are hidden on async producers (FAILED - 1)
Stopping cluster...

Failures:

  1) Producer API ssl exceptions are hidden on async producers
     Failure/Error: @worker_thread ||= start_thread { @worker.run }

     OpenSSL::SSL::SSLError:
       OpenSSL::SSL::SSLError
     # ./lib/kafka/async_producer.rb:143:in `block in ensure_threads_running!'

Finished in 13.17 seconds (files took 0.31366 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/functional/async_producer_spec.rb:71 # Producer API ssl exceptions are hidden on async producers

```