### PR TITLE
Retry final offsets commit if timed out

### DIFF
--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -147,5 +147,14 @@ describe Kafka::Consumer do
         end
       end
     end
+
+    it 'retries final offsets commit at the end' do
+      allow(offset_manager).to receive(:commit_offsets).
+        exactly(4).times { raise(Kafka::ConnectionError) }
+
+      consumer.each_message do |message|
+        consumer.stop
+      end
+    end
   end
 end


### PR DESCRIPTION
It turns out it's a pretty common situation when we get `ConnectionError` right after we stopped consumer.
Retrying offsets commitment allows us to make sure it is commited properly to avoid situation when large batch of messages will be processed again after consumer's restart.