### PR TITLE
shuffle seed brokers before fetching metadata

### DIFF
--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -190,7 +190,7 @@ module Kafka
     # @raise [ConnectionError] if none of the nodes in `seed_brokers` are available.
     # @return [Protocol::MetadataResponse] the cluster metadata.
     def fetch_cluster_info
-      @seed_brokers.each do |node|
+      @seed_brokers.shuffle.each do |node|
         @logger.info "Fetching cluster metadata from #{node}"
 
         begin


### PR DESCRIPTION
Yesterday, a component of ours had vastly increased latency during an
outage, to the point where callers were timing out and seeing issues.

Upon tracking this down, we found that the cause of the latency was that
broker 0 was replaced. This component uses the sync producer, and as a
result of broker 0 being replaced, any produce request that fetched
metadata stalled for the default connect timeout (10s).

Instead, fetch metadata from seed brokers in a random order. This means
that a single broker going down will slow down at most 1/NBROKERS
metadata fetches, rather than every single one.