### PR TITLE
Allow committing offsets manually 

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -246,7 +246,7 @@ module Kafka
         commit_interval: offset_commit_interval,
         commit_threshold: offset_commit_threshold,
         offset_retention_time: offset_retention_time,
-        offset_commit_enabled: offset_commit_enabled
+        commit_enabled: offset_commit_enabled
       )
 
       heartbeat = Heartbeat.new(

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -218,8 +218,10 @@ module Kafka
     #   than the session window.
     # @param offset_retention_time [Integer] the time period that committed
     #   offsets will be retained, in seconds. Defaults to the broker setting.
+    # @param offset_commit_enabled [Boolean] if true, it will commit offsets when necessary.
+    #   Otherwise it won't commit offsets. Defaults to true.
     # @return [Consumer]
-    def consumer(group_id:, session_timeout: 30, offset_commit_interval: 10, offset_commit_threshold: 0, heartbeat_interval: 10, offset_retention_time: nil)
+    def consumer(group_id:, session_timeout: 30, offset_commit_interval: 10, offset_commit_threshold: 0, heartbeat_interval: 10, offset_retention_time: nil, offset_commit_enabled: true)
       cluster = initialize_cluster
 
       instrumenter = DecoratingInstrumenter.new(@instrumenter, {
@@ -243,7 +245,8 @@ module Kafka
         logger: @logger,
         commit_interval: offset_commit_interval,
         commit_threshold: offset_commit_threshold,
-        offset_retention_time: offset_retention_time
+        offset_retention_time: offset_retention_time,
+        offset_commit_enabled: offset_commit_enabled
       )
 
       heartbeat = Heartbeat.new(

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -230,9 +230,11 @@ module Kafka
     #   is ignored.
     # @param max_wait_time [Integer, Float] the maximum duration of time to wait before
     #   returning messages from the server, in seconds.
+    # @param auto_commit_offsets [Boolean] if true, it will commit offsets when necessary.
+    #   Otherwise it won't commit offsets.
     # @yieldparam batch [Kafka::FetchedBatch] a message batch fetched from Kafka.
     # @return [nil]
-    def each_batch(min_bytes: 1, max_wait_time: 5)
+    def each_batch(min_bytes: 1, max_wait_time: 5, auto_commit_offsets: true)
       consumer_loop do
         batches = fetch_batches(min_bytes: min_bytes, max_wait_time: max_wait_time)
 
@@ -263,7 +265,7 @@ module Kafka
             mark_message_as_processed(batch.messages.last)
           end
 
-          @offset_manager.commit_offsets_if_necessary
+          @offset_manager.commit_offsets_if_necessary if auto_commit_offsets
 
           @heartbeat.send_if_necessary
 

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -272,6 +272,10 @@ module Kafka
       end
     end
 
+    def commit_offsets
+      @offset_manager.commit_offsets
+    end
+
     private
 
     def consumer_loop

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -200,7 +200,7 @@ module Kafka
             end
 
             mark_message_as_processed(message)
-            @offset_manager.commit_offsets_if_necessary
+            @offset_manager.commit_offsets_if_necessary if @offset_manager.offset_commit_enabled
 
             @heartbeat.send_if_necessary
 
@@ -210,7 +210,7 @@ module Kafka
 
         # We may not have received any messages, but it's still a good idea to
         # commit offsets if we've processed messages in the last set of batches.
-        @offset_manager.commit_offsets_if_necessary
+        @offset_manager.commit_offsets_if_necessary if @offset_manager.offset_commit_enabled
       end
     end
 
@@ -230,11 +230,9 @@ module Kafka
     #   is ignored.
     # @param max_wait_time [Integer, Float] the maximum duration of time to wait before
     #   returning messages from the server, in seconds.
-    # @param auto_commit_offsets [Boolean] if true, it will commit offsets when necessary.
-    #   Otherwise it won't commit offsets.
     # @yieldparam batch [Kafka::FetchedBatch] a message batch fetched from Kafka.
     # @return [nil]
-    def each_batch(min_bytes: 1, max_wait_time: 5, auto_commit_offsets: true)
+    def each_batch(min_bytes: 1, max_wait_time: 5)
       consumer_loop do
         batches = fetch_batches(min_bytes: min_bytes, max_wait_time: max_wait_time)
 
@@ -265,7 +263,7 @@ module Kafka
             mark_message_as_processed(batch.messages.last)
           end
 
-          @offset_manager.commit_offsets_if_necessary if auto_commit_offsets
+          @offset_manager.commit_offsets_if_necessary if @offset_manager.offset_commit_enabled
 
           @heartbeat.send_if_necessary
 

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -297,7 +297,7 @@ module Kafka
     ensure
       # In order to quickly have the consumer group re-balance itself, it's
       # important that members explicitly tell Kafka when they're leaving.
-      make_final_offsets_commit!
+      make_final_offsets_commit! if @offset_manager.commit_enabled
       @group.leave rescue nil
       @running = false
     end

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -200,7 +200,7 @@ module Kafka
             end
 
             mark_message_as_processed(message)
-            @offset_manager.commit_offsets_if_necessary if @offset_manager.offset_commit_enabled
+            @offset_manager.commit_offsets_if_necessary
 
             @heartbeat.send_if_necessary
 
@@ -210,7 +210,7 @@ module Kafka
 
         # We may not have received any messages, but it's still a good idea to
         # commit offsets if we've processed messages in the last set of batches.
-        @offset_manager.commit_offsets_if_necessary if @offset_manager.offset_commit_enabled
+        @offset_manager.commit_offsets_if_necessary
       end
     end
 
@@ -263,7 +263,7 @@ module Kafka
             mark_message_as_processed(batch.messages.last)
           end
 
-          @offset_manager.commit_offsets_if_necessary if @offset_manager.offset_commit_enabled
+          @offset_manager.commit_offsets_if_necessary
 
           @heartbeat.send_if_necessary
 

--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -4,6 +4,8 @@ module Kafka
     # The default broker setting for offsets.retention.minutes is 1440.
     DEFAULT_RETENTION_TIME = 1440 * 60
 
+    attr_reader :commit_enabled
+
     def initialize(cluster:, group:, logger:, commit_interval:, commit_threshold:, offset_retention_time:, commit_enabled:)
       @cluster = cluster
       @group = group
@@ -72,7 +74,7 @@ module Kafka
     end
 
     def commit_offsets_if_necessary
-      return unless @commit_enabled
+      return unless commit_enabled
       recommit = recommit_timeout_reached?
       if recommit || commit_timeout_reached? || commit_threshold_reached?
         commit_offsets(recommit)

--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -4,12 +4,15 @@ module Kafka
     # The default broker setting for offsets.retention.minutes is 1440.
     DEFAULT_RETENTION_TIME = 1440 * 60
 
-    def initialize(cluster:, group:, logger:, commit_interval:, commit_threshold:, offset_retention_time:)
+    attr_reader :offset_commit_enabled
+
+    def initialize(cluster:, group:, logger:, commit_interval:, commit_threshold:, offset_retention_time:, offset_commit_enabled:)
       @cluster = cluster
       @group = group
       @logger = logger
       @commit_interval = commit_interval
       @commit_threshold = commit_threshold
+      @offset_commit_enabled = offset_commit_enabled
 
       @uncommitted_offsets = 0
       @processed_offsets = {}

--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -4,15 +4,13 @@ module Kafka
     # The default broker setting for offsets.retention.minutes is 1440.
     DEFAULT_RETENTION_TIME = 1440 * 60
 
-    attr_reader :offset_commit_enabled
-
-    def initialize(cluster:, group:, logger:, commit_interval:, commit_threshold:, offset_retention_time:, offset_commit_enabled:)
+    def initialize(cluster:, group:, logger:, commit_interval:, commit_threshold:, offset_retention_time:, commit_enabled:)
       @cluster = cluster
       @group = group
       @logger = logger
       @commit_interval = commit_interval
       @commit_threshold = commit_threshold
-      @offset_commit_enabled = offset_commit_enabled
+      @commit_enabled = commit_enabled
 
       @uncommitted_offsets = 0
       @processed_offsets = {}
@@ -74,6 +72,7 @@ module Kafka
     end
 
     def commit_offsets_if_necessary
+      return unless @commit_enabled
       recommit = recommit_timeout_reached?
       if recommit || commit_timeout_reached? || commit_threshold_reached?
         commit_offsets(recommit)

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -30,7 +30,7 @@ describe Kafka::Consumer do
     allow(cluster).to receive(:add_target_topics)
     allow(cluster).to receive(:refresh_metadata_if_necessary!)
 
-    allow(offset_manager).to receive(:offset_commit_enabled).and_return(true)
+    allow(offset_manager).to receive(:commit_enabled).and_return(true)
     allow(offset_manager).to receive(:commit_offsets)
     allow(offset_manager).to receive(:commit_offsets_if_necessary)
     allow(offset_manager).to receive(:set_default_offset)
@@ -163,51 +163,6 @@ describe Kafka::Consumer do
     it "delegates to offset_manager" do
       expect(offset_manager).to receive(:commit_offsets)
       consumer.commit_offsets
-    end
-  end
-
-  describe "#each_batch" do
-    let(:messages) {
-      [
-        Kafka::FetchedMessage.new(
-          value: "hello",
-          key: nil,
-          topic: "greetings",
-          partition: 0,
-          offset: 13,
-        )
-      ]
-    }
-
-    let(:fetched_batches) {
-      [
-        Kafka::FetchedBatch.new(
-          topic: "greetings",
-          partition: 0,
-          highwater_mark_offset: 42,
-          messages: messages,
-        )
-      ]
-    }
-
-    context "offset_commit_enabled" do
-      it "does not commit when disabled" do
-        allow(offset_manager).to receive(:offset_commit_enabled).and_return(false)
-        expect(offset_manager).not_to receive(:commit_offsets_if_necessary)
-
-        consumer.each_batch do |batch|
-          consumer.stop
-        end
-      end
-
-      it "commits when enable" do
-        allow(offset_manager).to receive(:offset_commit_enabled).and_return(true)
-        expect(offset_manager).to receive(:commit_offsets_if_necessary)
-
-        consumer.each_batch do |batch|
-          consumer.stop
-        end
-      end
     end
   end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -157,4 +157,11 @@ describe Kafka::Consumer do
       end
     end
   end
+
+  describe "#commit_offsets" do
+    it "delegates to offset_manager" do
+      expect(offset_manager).to receive(:commit_offsets)
+      consumer.commit_offsets
+    end
+  end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -164,4 +164,37 @@ describe Kafka::Consumer do
       consumer.commit_offsets
     end
   end
+
+  describe "#each_batch" do
+    let(:messages) {
+      [
+        Kafka::FetchedMessage.new(
+          value: "hello",
+          key: nil,
+          topic: "greetings",
+          partition: 0,
+          offset: 13,
+        )
+      ]
+    }
+
+    let(:fetched_batches) {
+      [
+        Kafka::FetchedBatch.new(
+          topic: "greetings",
+          partition: 0,
+          highwater_mark_offset: 42,
+          messages: messages,
+        )
+      ]
+    }
+
+    it "does not commit offsets when auto_commit_offsets is off" do
+      consumer.each_batch(auto_commit_offsets: false) do |batch|
+        consumer.stop
+      end
+
+      expect(offset_manager).not_to receive(:commit_offsets_if_necessary)
+    end
+  end
 end

--- a/spec/offset_manager_spec.rb
+++ b/spec/offset_manager_spec.rb
@@ -13,12 +13,12 @@ describe Kafka::OffsetManager do
       commit_interval: commit_interval,
       commit_threshold: 0,
       offset_retention_time: offset_retention_time,
-      offset_commit_enabled: offset_commit_enabled
+      commit_enabled: commit_enabled
     )
   }
   let(:offset_retention_time) { nil }
   let(:commit_interval) { 0 }
-  let(:offset_commit_enabled) { true }
+  let(:commit_enabled) { true }
 
 
   before do
@@ -150,6 +150,15 @@ describe Kafka::OffsetManager do
 
           expect(commits.last).to eq(expected_offsets)
         end
+      end
+    end
+
+    context "commit disabled" do
+      let(:commit_enabled) { false }
+
+      it "it does nothing" do
+        expect(offset_manager).not_to receive(:commit_offsets)
+        offset_manager.commit_offsets_if_necessary
       end
     end
 

--- a/spec/offset_manager_spec.rb
+++ b/spec/offset_manager_spec.rb
@@ -12,11 +12,14 @@ describe Kafka::OffsetManager do
       logger: logger,
       commit_interval: commit_interval,
       commit_threshold: 0,
-      offset_retention_time: offset_retention_time
+      offset_retention_time: offset_retention_time,
+      offset_commit_enabled: offset_commit_enabled
     )
   }
   let(:offset_retention_time) { nil }
   let(:commit_interval) { 0 }
+  let(:offset_commit_enabled) { true }
+
 
   before do
     allow(group).to receive(:commit_offsets)


### PR DESCRIPTION
This PR exposes `#commit_offsets` on Consumer and adds an option to avoid auto commit offsets on `#each_batch` 

 