### PR TITLE
Add auto commit option to each batch 

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -272,6 +272,10 @@ module Kafka
       end
     end
 
+    def commit_offsets
+      @offset_manager.commit_offsets
+    end
+
     private
 
     def consumer_loop

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -230,9 +230,11 @@ module Kafka
     #   is ignored.
     # @param max_wait_time [Integer, Float] the maximum duration of time to wait before
     #   returning messages from the server, in seconds.
+    # @param automatically_mark_as_processed [Boolean] if true, it will mark as processed offset
+    #   when the block return. Otherwise it will not mark as processed. Defaults to true.
     # @yieldparam batch [Kafka::FetchedBatch] a message batch fetched from Kafka.
     # @return [nil]
-    def each_batch(min_bytes: 1, max_wait_time: 5)
+    def each_batch(min_bytes: 1, max_wait_time: 5, automatically_mark_as_processed: true)
       consumer_loop do
         batches = fetch_batches(min_bytes: min_bytes, max_wait_time: max_wait_time)
 
@@ -260,7 +262,7 @@ module Kafka
               end
             end
 
-            mark_message_as_processed(batch.messages.last)
+            mark_message_as_processed(batch.messages.last) if automatically_mark_as_processed
           end
 
           @offset_manager.commit_offsets_if_necessary
@@ -274,6 +276,10 @@ module Kafka
 
     def commit_offsets
       @offset_manager.commit_offsets
+    end
+
+    def mark_message_as_processed(message)
+      @offset_manager.mark_as_processed(message.topic, message.partition, message.offset)
     end
 
     private
@@ -375,10 +381,6 @@ module Kafka
       @logger.error "Connection error while fetching messages: #{e}"
 
       raise FetchError, e
-    end
-
-    def mark_message_as_processed(message)
-      @offset_manager.mark_as_processed(message.topic, message.partition, message.offset)
     end
   end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -164,4 +164,37 @@ describe Kafka::Consumer do
       consumer.commit_offsets
     end
   end
+
+  describe "#each_batch" do
+    let(:messages) {
+      [
+        Kafka::FetchedMessage.new(
+          value: "hello",
+          key: nil,
+          topic: "greetings",
+          partition: 0,
+          offset: 13,
+        )
+      ]
+    }
+
+    let(:fetched_batches) {
+      [
+        Kafka::FetchedBatch.new(
+          topic: "greetings",
+          partition: 0,
+          highwater_mark_offset: 42,
+          messages: messages,
+        )
+      ]
+    }
+
+    it "does not mark as processed when automatically_mark_as_processed is false" do
+      expect(offset_manager).not_to receive(:mark_as_processed)
+
+      consumer.each_batch(automatically_mark_as_processed: false) do |message|
+        consumer.stop
+      end
+    end
+  end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -157,4 +157,11 @@ describe Kafka::Consumer do
       end
     end
   end
+
+  describe "#commit_offsets" do
+    it "delegates to offset_manager" do
+      expect(offset_manager).to receive(:commit_offsets)
+      consumer.commit_offsets
+    end
+  end
 end


### PR DESCRIPTION
This is a follow up to https://github.com/zendesk/ruby-kafka/pull/342

* Exposes `#commit_offsets` and `#automatically_mark_as_processed ` on Consumer
* It adds `automatically_mark_as_processed` option to `#each_batch` and `#each_message`. 