### PR TITLE
Add NoPartitionsAssignedError

### DIFF
--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -142,6 +142,9 @@ module Kafka
   class FetchError < Error
   end
 
+  class NoPartitionsAssignedError < Error
+  end
+
   # Initializes a new Kafka client.
   #
   # @see Client#initialize

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -353,7 +353,7 @@ module Kafka
 
       @heartbeat.send_if_necessary
 
-      raise "No partitions assigned!" if subscribed_partitions.empty?
+      raise NoPartitionsAssignedError if subscribed_partitions.empty?
 
       operation = FetchOperation.new(
         cluster: @cluster,


### PR DESCRIPTION
* Raise a more meaningfull error when no partitions are
  assigned

This small change is to make easier/cleaner handling this error on the client side.  