### PR TITLE
Manual offset management 

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -177,7 +177,7 @@ module Kafka
     #   {Kafka::ProcessingError} instance.
     # @return [nil]
     def each_message(min_bytes: 1, max_wait_time: 5, automatically_mark_as_processed: true)
-      consumer_loop do
+      consumer_loop(clear_offsets_on_join: automatically_mark_as_processed) do
         batches = fetch_batches(min_bytes: min_bytes, max_wait_time: max_wait_time)
 
         batches.each do |batch|
@@ -241,7 +241,7 @@ module Kafka
     # @yieldparam batch [Kafka::FetchedBatch] a message batch fetched from Kafka.
     # @return [nil]
     def each_batch(min_bytes: 1, max_wait_time: 5, automatically_mark_as_processed: true)
-      consumer_loop do
+      consumer_loop(clear_offsets_on_join: automatically_mark_as_processed) do
         batches = fetch_batches(min_bytes: min_bytes, max_wait_time: max_wait_time)
 
         batches.each do |batch|
@@ -298,14 +298,14 @@ module Kafka
 
     private
 
-    def consumer_loop
+    def consumer_loop(clear_offsets_on_join: false)
       @running = true
 
       while @running
         begin
           yield
         rescue HeartbeatError, OffsetCommitError
-          join_group
+          join_group(clear_offsets_on_join: clear_offsets_on_join)
         rescue FetchError, NotLeaderForPartition, UnknownTopicOrPartition
           @cluster.mark_as_stale!
         rescue LeaderNotAvailable => e
@@ -335,12 +335,12 @@ module Kafka
       make_final_offsets_commit!(attempts - 1)
     end
 
-    def join_group
+    def join_group(clear_offsets_on_join: false)
       old_generation_id = @group.generation_id
 
       @group.join
 
-      if old_generation_id && @group.generation_id != old_generation_id + 1
+      if (old_generation_id && @group.generation_id != old_generation_id + 1) || clear_offsets_on_join
         # We've been out of the group for at least an entire generation, no
         # sense in trying to hold on to offset data
         @offset_manager.clear_offsets

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -292,6 +292,10 @@ module Kafka
       @offset_manager.mark_as_buffered(message.topic, message.partition, message.offset)
     end
 
+    def subscribed_partitions
+      @group.subscribed_partitions
+    end
+
     private
 
     def consumer_loop

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -288,6 +288,10 @@ module Kafka
       @offset_manager.mark_as_processed(message.topic, message.partition, message.offset)
     end
 
+    def mark_message_as_buffered(message)
+      @offset_manager.mark_as_buffered(message.topic, message.partition, message.offset)
+    end
+
     private
 
     def consumer_loop

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -165,6 +165,13 @@ describe Kafka::Consumer do
     end
   end
 
+  describe "#subscribed_partitions" do
+    it "delegates to group" do
+      expect(group).to receive(:subscribed_partitions)
+      consumer.subscribed_partitions
+    end
+  end
+
   describe "#each_batch" do
     let(:messages) {
       [

--- a/spec/offset_manager_spec.rb
+++ b/spec/offset_manager_spec.rb
@@ -184,6 +184,14 @@ describe Kafka::OffsetManager do
 
       expect(offset).to eq 42
     end
+
+    it "returns the buffered offsets if present" do
+      offset_manager.mark_as_buffered("greetings", 0, 41)
+
+      offset = offset_manager.next_offset_for("greetings", 0)
+
+      expect(offset).to eq 42
+    end
   end
 
   describe "#clear_offsets_excluding" do


### PR DESCRIPTION
This PR intends to extend the support on the manual offset management previously introduced by https://github.com/zendesk/ruby-kafka/pull/344.  

Proposed workflow: 

```ruby
buffer = []

consumer.each_message(automatically_mark_as_processed: false) do |message|
  # Our messages are JSON with a `type` field and other stuff.
  event = JSON.parse(message.value)

  case event.fetch("type")
  when "add_to_cart"
    buffer << event
  when "complete_purchase"
    # We've received all the messages we need, time to save the transaction.
    save_transaction(buffer)

    # We must be sure we're committing/processing the offset only if we're subscribed
    # to that partition. This prevents a message on the buffer from a previously  
    # subscribed partition from committing a wrong/out of date offset
    if consumer.subscribed_partitions[message.topic].include?(message.partition)
      consumer.mark_message_as_processed(message)
      consumer.commit_offsets
   end

    buffer.clear
  end
  
  # We want to keep moving forward the offset pointer so we can keep 
  # fetching without committing the offset. 
  consumer.mark_message_as_buffered(message)
end
```

