### PR TITLE
Handle MessageSizeTooLarge errors #357

### DIFF
--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -89,6 +89,11 @@ module Kafka
       @timer = Timer.new(queue: @queue, interval: delivery_interval)
     end
 
+    def with_error_handler(error_handler)
+      @worker.producer.with_error_handler(error_handler)
+      self
+    end
+
     # Produces a message to the specified topic.
     #
     # @see Kafka::Producer#produce
@@ -180,6 +185,7 @@ module Kafka
     end
 
     class Worker
+      attr_reader :producer
       def initialize(queue:, producer:, delivery_threshold:)
         @queue = queue
         @producer = producer

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -60,6 +60,12 @@ module Kafka
       @cluster = initialize_cluster
     end
 
+    # Override error handler.
+    def with_error_handler(error_handler)
+      @error_handler = error_handler
+      self
+    end
+
     # Delivers a single message to the Kafka cluster.
     #
     # **Note:** Only use this API for low-throughput scenarios. If you want to deliver
@@ -117,6 +123,7 @@ module Kafka
         compressor: compressor,
         logger: @logger,
         instrumenter: @instrumenter,
+        error_handler: @error_handler
       )
 
       operation.execute

--- a/lib/kafka/produce_operation.rb
+++ b/lib/kafka/produce_operation.rb
@@ -27,7 +27,7 @@ module Kafka
   # * `:sent_message_count` – the number of messages that were successfully sent.
   #
   class ProduceOperation
-    def initialize(cluster:, buffer:, compressor:, required_acks:, ack_timeout:, logger:, instrumenter:)
+    def initialize(cluster:, buffer:, compressor:, required_acks:, ack_timeout:, logger:, instrumenter:, error_handler: nil)
       @cluster = cluster
       @buffer = buffer
       @required_acks = required_acks
@@ -35,6 +35,7 @@ module Kafka
       @compressor = compressor
       @logger = logger
       @instrumenter = instrumenter
+      @error_handler = error_handler
     end
 
     def execute
@@ -123,7 +124,7 @@ module Kafka
               topic: topic,
               exception: [e.class.to_s, e.message],
             })
-
+            @error_handler.on_error(e, topic, partition, messages) if @error_handler
             raise e
           end
 
@@ -139,7 +140,6 @@ module Kafka
           end
         rescue Kafka::MessageSizeTooLarge
           @logger.error "Message is too large when writing to #{topic}/#{partition}"
-          @buffer.clear_messages(topic: topic, partition: partition)
         rescue Kafka::CorruptMessage
           @logger.error "Corrupt message when writing to #{topic}/#{partition}"
         rescue Kafka::UnknownTopicOrPartition

--- a/lib/kafka/produce_operation.rb
+++ b/lib/kafka/produce_operation.rb
@@ -137,6 +137,9 @@ module Kafka
               delay: ack_time - message.create_time,
             })
           end
+        rescue Kafka::MessageSizeTooLarge
+          @logger.error "Message is too large when writing to #{topic}/#{partition}"
+          @buffer.clear_messages(topic: topic, partition: partition)
         rescue Kafka::CorruptMessage
           @logger.error "Corrupt message when writing to #{topic}/#{partition}"
         rescue Kafka::UnknownTopicOrPartition

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -150,6 +150,15 @@ module Kafka
 
       # Messages added by `#produce` but not yet assigned a partition.
       @pending_message_queue = PendingMessageQueue.new
+
+      # Object/class that implements handle_error(status_code)
+      @error_handler = nil
+    end
+
+    # Override error error_handler.
+    def with_error_handler(error_handler)
+      @error_handler = error_handler
+      self
     end
 
     # Produces a message to the specified topic. Note that messages are buffered in
@@ -288,6 +297,7 @@ module Kafka
         compressor: @compressor,
         logger: @logger,
         instrumenter: @instrumenter,
+        error_handler: @error_handler,
       )
 
       loop do


### PR DESCRIPTION
When calling the `produce` (async version) on kafka and it  responds with `MessageSizeTooLarge`, the exception is being raised and the connection is abruptly terminated (see [issue 357](https://github.com/zendesk/ruby-kafka/issues/357)). This is not the behavior for other types of errors (e.g.,`CorruptMessage`) or even for the non-async version (`Kafka#deliver_messages`).

This PR adds support to handle `MessageSizeTooLarge` errors (w/o terminating the connection). Also, it clears this message from the buffer to prevent it from being retried (it's not a transient error).
