### PR TITLE
Block on async responses in the order they become ready

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -298,7 +298,7 @@ module Kafka
           yield
         rescue HeartbeatError, OffsetCommitError
           join_group
-        rescue FetchError, NotLeaderForPartition, UnknownTopicOrPartition
+        rescue ConnectionError, FetchError, NotLeaderForPartition, UnknownTopicOrPartition
           @cluster.mark_as_stale!
         rescue LeaderNotAvailable => e
           @logger.error "Leader not available; waiting 1s before retrying"

--- a/lib/kafka/fetch_operation.rb
+++ b/lib/kafka/fetch_operation.rb
@@ -73,19 +73,9 @@ module Kafka
       }
 
       until pending_responses.empty?
-        # Select a response that's ready, with a timeout of `@max_wait_time`.
-        ready_responses, _, _ = IO.select(pending_responses, nil, nil, @max_wait_time)
+        response = pick_response(pending_responses)
 
-        if ready_responses.nil?
-          @logger.debug "Still waiting for #{pending_responses.count} fetch responses..."
-          next # go back to waiting for a response to become ready.
-        end
-
-        # The response is no longer pending.
-        pending_responses.delete(ready_responses.first)
-
-        # Block on the async response -- it should be ready now.
-        response = ready_responses.first.call
+        next if response.nil?
 
         response.topics.each {|fetched_topic|
           fetched_topic.partitions.each {|fetched_partition|
@@ -129,6 +119,26 @@ module Kafka
     end
 
     private
+
+    def pick_response(pending_responses)
+      if pending_responses.count == 1
+        pending_responses.pop.call
+      else
+        # Select a response that's ready, with a timeout of `@max_wait_time`.
+        ready_responses, _, _ = IO.select(pending_responses, nil, nil, @max_wait_time)
+
+        if ready_responses.nil?
+          @logger.debug "Still waiting for #{pending_responses.count} fetch responses..."
+          return nil # go back to waiting for a response to become ready.
+        end
+
+        # The response is no longer pending.
+        pending_responses.delete(ready_responses.first)
+
+        # Block on the async response -- it should be ready now.
+        ready_responses.first.call
+      end
+    end
 
     def resolve_offsets(broker, topics)
       pending_topics = {}

--- a/lib/kafka/fetch_operation.rb
+++ b/lib/kafka/fetch_operation.rb
@@ -60,7 +60,7 @@ module Kafka
         end
       end
 
-      responses = topics_by_broker.map {|broker, topics|
+      pending_responses = topics_by_broker.map {|broker, topics|
         resolve_offsets(broker, topics)
 
         options = {
@@ -72,8 +72,20 @@ module Kafka
         broker.fetch_messages_async(**options)
       }
 
-      responses.each {|response_future|
-        response = response_future.call
+      until pending_responses.empty?
+        # Select a response that's ready, with a timeout of `@max_wait_time`.
+        ready_responses, _, _ = IO.select(pending_responses, nil, nil, @max_wait_time)
+
+        if ready_responses.nil?
+          @logger.debug "Still waiting for #{pending_responses.count} fetch responses..."
+          next # go back to waiting for a response to become ready.
+        end
+
+        # The response is no longer pending.
+        pending_responses.delete(ready_responses.first)
+
+        # Block on the async response -- it should be ready now.
+        response = ready_responses.first.call
 
         response.topics.each {|fetched_topic|
           fetched_topic.partitions.each {|fetched_partition|
@@ -109,7 +121,7 @@ module Kafka
             )
           }
         }
-      }
+      end
     rescue Kafka::ConnectionError, Kafka::LeaderNotAvailable, Kafka::NotLeaderForPartition
       @cluster.mark_as_stale!
 

--- a/lib/kafka/socket_with_timeout.rb
+++ b/lib/kafka/socket_with_timeout.rb
@@ -87,6 +87,10 @@ module Kafka
       @socket.closed?
     end
 
+    def to_io
+      @socket.to_io
+    end
+
     def set_encoding(encoding)
       @socket.set_encoding(encoding)
     end

--- a/lib/kafka/ssl_socket_with_timeout.rb
+++ b/lib/kafka/ssl_socket_with_timeout.rb
@@ -163,6 +163,10 @@ module Kafka
       @tcp_socket.closed? || @ssl_socket.closed?
     end
 
+    def to_io
+      @tcp_socket.to_io
+    end
+
     def set_encoding(encoding)
       @tcp_socket.set_encoding(encoding)
     end


### PR DESCRIPTION
Currently, we send a fetch request to each broker before blocking on the first one while we're waiting for a response. This is inefficient when the first broker in the list is not the first to respond – which will often be the case when there's an uneven data load.

This change orders the reads by when the async responses become _ready_, as indicated by calling `IO.select` on their backing socket. After sending the requests, we'll wait for a response to become ready. If there's a timeout, we'll start waiting again. If one or more of the responses become ready, we select the first one, read it and return the data to the client, then move on to the rest of the pending responses.

This allows us to immediately process messages returned by brokers that see a lot of throughput without having to wait for the other brokers to "time out" while waiting for messages to arrive (due to `max_wait_time`).

The next logical step would be to pre-fetch messages after reading a response, but before letting the client process the messages. That's for another PR, though.