### PR TITLE
Stop the consumer on SignalException

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -308,6 +308,9 @@ module Kafka
           @logger.error "Leader not available; waiting 1s before retrying"
           @cluster.mark_as_stale!
           sleep 1
+        rescue SignalException => e
+          @logger.warn "Received signal #{e.message}, shutting down"
+          @running = false
         end
       end
     ensure

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -92,6 +92,14 @@ describe Kafka::Consumer do
       expect(log.string).to include "Exception raised when processing greetings/0 at offset 13 -- RuntimeError: yolo"
     end
 
+    it "stops if SignalException is encountered" do
+      allow(fetch_operation).to receive(:execute) { raise SignalException, "SIGTERM" }
+
+      consumer.each_message {}
+
+      expect(log.string).to include "Received signal SIGTERM, shutting down"
+    end
+
     it "seeks to the default offset when the checkpoint is invalid " do
       done = false
 


### PR DESCRIPTION
This exception can be raised if a signal is sent to the process while it is in an `IO.select` call. Apparently, the normal `trap` is not enough.

We want to shut down gracefully in this event.