### PR TITLE
add the ability to load an ssl certificate from a file

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -34,6 +34,9 @@ module Kafka
     # @param ssl_ca_cert [String, Array<String>, nil] a PEM encoded CA cert, or an Array of
     #   PEM encoded CA certs, to use with an SSL connection.
     #
+    # @param ssl_ca_cert_file_path [String, nil] a path on the filesystem to a PEM encoded CA cert
+    #   to use with an SSL connection.
+    #
     # @param ssl_client_cert [String, nil] a PEM encoded client cert to use with an
     #   SSL connection. Must be used in combination with ssl_client_cert_key.
     #
@@ -46,13 +49,13 @@ module Kafka
     #
     # @return [Client]
     def initialize(seed_brokers:, client_id: "ruby-kafka", logger: nil, connect_timeout: nil, socket_timeout: nil,
-                   ssl_ca_cert: nil, ssl_client_cert: nil, ssl_client_cert_key: nil,
+                   ssl_ca_cert_file_path: nil, ssl_ca_cert: nil, ssl_client_cert: nil, ssl_client_cert_key: nil,
                    sasl_gssapi_principal: nil, sasl_gssapi_keytab: nil)
       @logger = logger || Logger.new(nil)
       @instrumenter = Instrumenter.new(client_id: client_id)
       @seed_brokers = normalize_seed_brokers(seed_brokers)
 
-      ssl_context = build_ssl_context(ssl_ca_cert, ssl_client_cert, ssl_client_cert_key)
+      ssl_context = build_ssl_context(ssl_ca_cert_file_path, ssl_ca_cert, ssl_client_cert, ssl_client_cert_key)
 
       @connection_builder = ConnectionBuilder.new(
         client_id: client_id,
@@ -464,8 +467,8 @@ module Kafka
       )
     end
 
-    def build_ssl_context(ca_cert, client_cert, client_cert_key)
-      return nil unless ca_cert || client_cert || client_cert_key
+    def build_ssl_context(ca_cert_file_path, ca_cert, client_cert, client_cert_key)
+      return nil unless ca_cert_file_path || ca_cert || client_cert || client_cert_key
 
       ssl_context = OpenSSL::SSL::SSLContext.new
 
@@ -480,10 +483,13 @@ module Kafka
         raise ArgumentError, "Kafka client initialized with `ssl_client_cert_key`, but no `ssl_client_cert`. Please provide both."
       end
 
-      if ca_cert
+      if ca_cert || ca_cert_file_path
         store = OpenSSL::X509::Store.new
         Array(ca_cert).each do |cert|
           store.add_cert(OpenSSL::X509::Certificate.new(cert))
+        end
+        if ca_cert_file_path
+          store.add_file(ca_cert_file_path)
         end
         ssl_context.cert_store = store
       end


### PR DESCRIPTION
This is needed so that we can support multiple PEM encoded certs in the
same file, as ruby's openssl bindings do not allow you to parse PEMs in
any other way (unless you write your own parser).