### PR TITLE
Add Statsd monitoring

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-kafka (0.3.18.beta1)
+    ruby-kafka (0.3.18.beta2)
       gssapi (>= 1.2.0)
 
 GEM
@@ -58,6 +58,7 @@ GEM
     ruby-prof (0.15.9)
     slop (3.6.0)
     snappy (0.0.12)
+    statsd-ruby (1.4.0)
     thread_safe (0.3.5)
     timecop (0.8.0)
     tzinfo (1.2.2)
@@ -81,6 +82,7 @@ DEPENDENCIES
   ruby-kafka!
   ruby-prof
   snappy
+  statsd-ruby
   timecop
 
 RUBY VERSION

--- a/lib/kafka/statsd.rb
+++ b/lib/kafka/statsd.rb
@@ -1,0 +1,209 @@
+begin
+  require "statsd"
+rescue LoadError
+  $stderr.puts "In order to report Kafka client metrics to Statsd you need to install the `statsd-ruby` gem."
+  raise
+end
+
+require "active_support/subscriber"
+
+module Kafka
+  # Reports operational metrics to a Statsd agent.
+  #
+  #     require "kafka/statds"
+  #
+  #     # Default is "ruby_kafka".
+  #     Kafka::Statsd.namespace = "custom-namespace"
+  #
+  #     # Default is "127.0.0.1".
+  #     Kafka::Statsd.host = "statsd.something.com"
+  #
+  #     # Default is 8125.
+  #     Kafka::Statsd.port = 1234
+  #
+  # Once the file has been required, no further configuration is needed – all operational
+  # metrics are automatically emitted.
+  module Statsd
+    DEFAULT_NAMESPACE = "ruby_kafka"
+    DEFAULT_HOST = '127.0.0.1'
+    DEFAULT_PORT = 8125
+
+    def self.statsd
+      @statsd ||= ::Statsd.new(DEFAULT_HOST, DEFAULT_PORT).tap{ |sd| sd.namespace = DEFAULT_NAMESPACE }
+    end
+
+    def self.host=(host)
+      statsd.host = host
+      statsd.connect if statsd.respond_to?(:connect)
+    end
+
+    def self.port=(port)
+      statsd.port = port
+      statsd.connect if statsd.respond_to?(:connect)
+    end
+
+    def self.namespace=(namespace)
+      statsd.namespace = namespace
+    end
+
+    class StatsdSubscriber < ActiveSupport::Subscriber
+      private
+
+      %w[increment count timing gauge].each do |type|
+        define_method(type) do |*args|
+          Kafka::Statsd.statsd.send(type, *args)
+        end
+      end
+    end
+
+    class ConnectionSubscriber < StatsdSubscriber
+      def request(event)
+        client = event.payload.fetch(:client_id)
+        api = event.payload.fetch(:api, "unknown")
+        request_size = event.payload.fetch(:request_size, 0)
+        response_size = event.payload.fetch(:response_size, 0)
+        broker = event.payload.fetch(:broker_host)
+
+        timing("api.#{client}.#{api}.#{broker}.latency", event.duration)
+        increment("api.#{client}.#{api}.#{broker}.calls")
+
+        timing("api.#{client}.#{api}.#{broker}.request_size", request_size)
+        timing("api.#{client}.#{api}.#{broker}.response_size", response_size)
+
+        if event.payload.key?(:exception)
+          increment("api.#{client}.#{api}.#{broker}.errors")
+        end
+      end
+
+      attach_to "connection.kafka"
+    end
+
+    class ConsumerSubscriber < StatsdSubscriber
+      def process_message(event)
+        lag = event.payload.fetch(:offset_lag)
+        client = event.payload.fetch(:client_id)
+        group_id = event.payload.fetch(:group_id)
+        topic = event.payload.fetch(:topic)
+        partition = event.payload.fetch(:partition)
+
+        if event.payload.key?(:exception)
+          increment("consumer.#{client}.#{group_id}.#{topic}.#{partition}.process_message.errors")
+        else
+          timing("consumer.#{client}.#{group_id}.#{topic}.#{partition}.process_message.latency", event.duration)
+          increment("consumer.#{client}.#{group_id}.#{topic}.#{partition}.messages")
+        end
+
+        gauge("consumer.#{client}.#{group_id}.#{topic}.#{partition}.lag", lag)
+      end
+
+      def process_batch(event)
+        messages = event.payload.fetch(:message_count)
+        client = event.payload.fetch(:client_id)
+        group_id = event.payload.fetch(:group_id)
+        topic = event.payload.fetch(:topic)
+        partition = event.payload.fetch(:partition)
+
+        if event.payload.key?(:exception)
+          increment("consumer.#{client}.#{group_id}.#{topic}.#{partition}.process_batch.errors")
+        else
+          timing("consumer.#{client}.#{group_id}.#{topic}.#{partition}.process_batch.latency", event.duration)
+          count("consumer.#{client}.#{group_id}.#{topic}.#{partition}.messages", messages)
+        end
+      end
+
+      attach_to "consumer.kafka"
+    end
+
+    class ProducerSubscriber < StatsdSubscriber
+      def produce_message(event)
+        client = event.payload.fetch(:client_id)
+        topic = event.payload.fetch(:topic)
+        message_size = event.payload.fetch(:message_size)
+        buffer_size = event.payload.fetch(:buffer_size)
+        max_buffer_size = event.payload.fetch(:max_buffer_size)
+        buffer_fill_ratio = buffer_size.to_f / max_buffer_size.to_f
+
+        # This gets us the write rate.
+        increment("producer.#{client}.#{topic}.produce.messages")
+
+        timing("producer.#{client}.#{topic}.produce.message_size", message_size)
+
+        # This gets us the avg/max buffer size per producer.
+        timing("producer.#{client}.buffer.size", buffer_size)
+
+        # This gets us the avg/max buffer fill ratio per producer.
+        timing("producer.#{client}.buffer.fill_ratio", buffer_fill_ratio)
+      end
+
+      def buffer_overflow(event)
+        client = event.payload.fetch(:client_id)
+        topic = event.payload.fetch(:topic)
+
+        increment("producer.#{client}.#{topic}.produce.errors")
+      end
+
+      def deliver_messages(event)
+        client = event.payload.fetch(:client_id)
+        message_count = event.payload.fetch(:delivered_message_count)
+        attempts = event.payload.fetch(:attempts)
+
+        if event.payload.key?(:exception)
+          increment("producer.#{client}.deliver.errors")
+        end
+
+        timing("producer.#{client}.deliver.latency", event.duration)
+
+        # Messages delivered to Kafka:
+        count("producer.#{client}.deliver.messages", message_count)
+
+        # Number of attempts to deliver messages:
+        timing("producer.#{client}.deliver.attempts", attempts)
+      end
+
+      def ack_message(event)
+        client = event.payload.fetch(:client_id)
+        topic = event.payload.fetch(:topic)
+
+        # Number of messages ACK'd for the topic.
+        increment("producer.#{client}.#{topic}.ack.messages")
+
+        # Histogram of delay between a message being produced and it being ACK'd.
+        timing("producer.#{client}.#{topic}.ack.delay", event.payload.fetch(:delay))
+      end
+
+      def topic_error(event)
+        client = event.payload.fetch(:client_id)
+        topic = event.payload.fetch(:topic)
+
+        increment("producer.#{client}.#{topic}.ack.errors")
+      end
+
+      attach_to "producer.kafka"
+    end
+
+    class AsyncProducerSubscriber < StatsdSubscriber
+      def enqueue_message(event)
+        client = event.payload.fetch(:client_id)
+        topic = event.payload.fetch(:topic)
+        queue_size = event.payload.fetch(:queue_size)
+        max_queue_size = event.payload.fetch(:max_queue_size)
+        queue_fill_ratio = queue_size.to_f / max_queue_size.to_f
+
+        # This gets us the avg/max queue size per producer.
+        timing("async_producer.#{client}.#{topic}.queue.size", queue_size)
+
+        # This gets us the avg/max queue fill ratio per producer.
+        timing("async_producer.#{client}.#{topic}.queue.fill_ratio", queue_fill_ratio)
+      end
+
+      def buffer_overflow(event)
+        client = event.payload.fetch(:client_id)
+        topic = event.payload.fetch(:topic)
+
+        increment("async_producer.#{client}.#{topic}.produce.errors")
+      end
+
+      attach_to "async_producer.kafka"
+    end
+  end
+end

--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "colored"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
   spec.add_development_dependency "dogstatsd-ruby", ">= 2.0.0"
+  spec.add_development_dependency "statsd-ruby"
   spec.add_development_dependency "ruby-prof"
   spec.add_development_dependency "timecop"
 end

--- a/spec/fake_statsd_agent.rb
+++ b/spec/fake_statsd_agent.rb
@@ -1,0 +1,39 @@
+require "socket"
+
+class FakeStatsdAgent
+  attr_reader :host, :port, :metrics
+
+  def initialize
+    @host = "127.0.0.1"
+    @port = 9998
+    @socket = UDPSocket.new
+    @thread = nil
+    @metrics = []
+
+    @socket.bind(@host, @port)
+  end
+
+  def start
+    @thread = Thread.new { loop { receive } }
+    @thread.abort_on_exception = true
+  end
+
+  def wait_for_metrics(count: 1)
+    deadline = Time.now + 10
+
+    until @metrics.count >= count || Time.now > deadline
+      sleep 0.1
+    end
+  end
+
+  private
+
+  def receive
+    data, sender = @socket.recvfrom(512)
+
+    data.split("\n").each do |message|
+      metric = message.split(":").first
+      @metrics << metric if metric
+    end
+  end
+end

--- a/spec/functional/statsd_spec.rb
+++ b/spec/functional/statsd_spec.rb
@@ -1,0 +1,22 @@
+require "kafka/statsd"
+require "socket"
+require "fake_statsd_agent"
+
+describe "Reporting metrics to Statsd", functional: true do
+  example "reporting connection metrics" do
+    agent = FakeStatsdAgent.new
+
+    Kafka::Statsd.port = agent.port
+
+    agent.start
+
+    kafka.topics
+
+    agent.wait_for_metrics(count: 4)
+
+    expect(agent.metrics).to include(/ruby_kafka\.api\.\w+\.\w+\.[\w\.]+\.calls/)
+    expect(agent.metrics).to include(/ruby_kafka\.api\.\w+\.\w+\.[\w\.]+\.latency/)
+    expect(agent.metrics).to include(/ruby_kafka\.api\.\w+\.\w+\.[\w\.]+\.request_size/)
+    expect(agent.metrics).to include(/ruby_kafka\.api\.\w+\.\w+\.[\w\.]+\.response_size/)
+  end
+end


### PR DESCRIPTION
Allow to monitor client activity by sending metrics to  statsd (same metrics as for datadog).