### PR TITLE
Move to the Kafka 0.10 message format (with timestamps)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
 dependencies:
   pre:
     - docker -v
-    - docker pull ches/kafka:0.9.0.1
+    - docker pull ches/kafka:0.10.0.0
     - docker pull jplock/zookeeper:3.4.6
     - gem install bundler -v 1.9.5
 

--- a/lib/kafka/fetch_operation.rb
+++ b/lib/kafka/fetch_operation.rb
@@ -90,6 +90,7 @@ module Kafka
                 topic: fetched_topic.name,
                 partition: fetched_partition.partition,
                 offset: message.offset,
+                create_time: message.create_time,
               )
             }
 

--- a/lib/kafka/fetched_message.rb
+++ b/lib/kafka/fetched_message.rb
@@ -16,12 +16,16 @@ module Kafka
     # @return [Integer] the offset of the message in the partition.
     attr_reader :offset
 
-    def initialize(value:, key:, topic:, partition:, offset:)
+    # @return [Time] the timestamp of the message.
+    attr_reader :create_time
+
+    def initialize(value:, key:, topic:, partition:, offset:, create_time:)
       @value = value
       @key = key
       @topic = topic
       @partition = partition
       @offset = offset
+      @create_time = create_time
     end
   end
 end

--- a/lib/kafka/protocol/fetch_request.rb
+++ b/lib/kafka/protocol/fetch_request.rb
@@ -30,6 +30,10 @@ module Kafka
         FETCH_API
       end
 
+      def api_version
+        2
+      end
+
       def response_class
         Protocol::FetchResponse
       end

--- a/lib/kafka/protocol/fetch_response.rb
+++ b/lib/kafka/protocol/fetch_response.rb
@@ -38,11 +38,14 @@ module Kafka
 
       attr_reader :topics
 
-      def initialize(topics: [])
+      def initialize(topics: [], throttle_time_ms: 0)
         @topics = topics
+        @throttle_time_ms = throttle_time_ms
       end
 
       def self.decode(decoder)
+        throttle_time_ms = decoder.int32
+
         topics = decoder.array do
           topic_name = decoder.string
 
@@ -68,7 +71,7 @@ module Kafka
           )
         end
 
-        new(topics: topics)
+        new(topics: topics, throttle_time_ms: throttle_time_ms)
       end
     end
   end

--- a/lib/kafka/protocol/produce_request.rb
+++ b/lib/kafka/protocol/produce_request.rb
@@ -40,6 +40,10 @@ module Kafka
         PRODUCE_API
       end
 
+      def api_version
+        2
+      end
+
       def response_class
         requires_acks? ? Protocol::ProduceResponse : nil
       end

--- a/lib/kafka/protocol/produce_response.rb
+++ b/lib/kafka/protocol/produce_response.rb
@@ -11,19 +11,21 @@ module Kafka
       end
 
       class PartitionInfo
-        attr_reader :partition, :error_code, :offset
+        attr_reader :partition, :error_code, :offset, :timestamp
 
-        def initialize(partition:, error_code:, offset:)
+        def initialize(partition:, error_code:, offset:, timestamp:)
           @partition = partition
           @error_code = error_code
           @offset = offset
+          @timestamp = timestamp
         end
       end
 
-      attr_reader :topics
+      attr_reader :topics, :throttle_time_ms
 
-      def initialize(topics: [])
+      def initialize(topics: [], throttle_time_ms: 0)
         @topics = topics
+        @throttle_time_ms = throttle_time_ms
       end
 
       def each_partition
@@ -43,13 +45,16 @@ module Kafka
               partition: decoder.int32,
               error_code: decoder.int16,
               offset: decoder.int64,
+              timestamp: Time.at(decoder.int64/1000.0),
             )
           end
 
           TopicInfo.new(topic: topic, partitions: partitions)
         end
 
-        new(topics: topics)
+        throttle_time_ms = decoder.int32
+
+        new(topics: topics, throttle_time_ms: throttle_time_ms)
       end
     end
   end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -58,6 +58,7 @@ describe Kafka::Consumer do
           topic: "greetings",
           partition: 0,
           offset: 13,
+          create_time: Time.now,
         )
       ]
     }
@@ -182,6 +183,7 @@ describe Kafka::Consumer do
           topic: "greetings",
           partition: 0,
           offset: 13,
+          create_time: Time.now,
         )
       ]
     }

--- a/spec/fake_broker.rb
+++ b/spec/fake_broker.rb
@@ -35,6 +35,7 @@ class FakeBroker
             partition: partition,
             error_code: error_code_for_partition(topic, partition),
             offset: message_set.messages.size,
+            timestamp: (Time.now.to_f*1000).to_i,
           )
         }
       )

--- a/spec/test_cluster.rb
+++ b/spec/test_cluster.rb
@@ -18,7 +18,7 @@ class TestCluster
   }
 
   DOCKER_HOSTNAME = URI(DOCKER_HOST).host
-  KAFKA_IMAGE = "ches/kafka:0.9.0.1"
+  KAFKA_IMAGE = "ches/kafka:0.10.0.0"
   ZOOKEEPER_IMAGE = "jplock/zookeeper:3.4.6"
   KAFKA_CLUSTER_SIZE = 3
 


### PR DESCRIPTION
#376 was merged, effectively ending backwards compatibility with Kafka 0.9, because I thought we were ready to move off Kafka 0.9. This has proven to not be the case, so I'm not comfortable with having the main line of development (master) only be compatible with a version of Kafka I'm not personally running.

Native Kafka 0.10 support (without protocol format re-writing on the broker side) has been postponed.