### PR TITLE
#288 - busy error log spamming with unreachable kafka node

### DIFF
--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -46,6 +46,7 @@ module Kafka
       retry
     rescue ConnectionError
       @logger.error "Connection error while trying to join group `#{@group_id}`; retrying..."
+      sleep 1
       @coordinator = nil
       retry
     end


### PR DESCRIPTION
Related to #288 
AS IS: When we kill last Kafka process in a cluster with kill -9, the connection is being retried constantly, spamming about unreachable kafka cluster in the error log. When a cluster is unreachable for a longer period of time, it results in 10s of GB in the error log.

TO BE: With a simple sleep, we will still be notified and it will still retry to connect, but the frequency will be much lower, which means that it won't spam the error log.