### PR TITLE
Make `#produce` safer

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -100,7 +100,6 @@ module Kafka
         partition,
         partition_key,
         create_time,
-        key.to_s.bytesize + value.to_s.bytesize
       )
 
       if partition.nil?

--- a/lib/kafka/pending_message.rb
+++ b/lib/kafka/pending_message.rb
@@ -1,11 +1,15 @@
 module Kafka
-  PendingMessage = Struct.new(
-    "PendingMessage",
-    :value,
-    :key,
-    :topic,
-    :partition,
-    :partition_key,
-    :create_time,
-    :bytesize)
+  class PendingMessage
+    attr_reader :value, :key, :topic, :partition, :partition_key, :create_time, :bytesize
+
+    def initialize(value, key, topic, partition, partition_key, create_time)
+      @value = value
+      @key = key
+      @topic = topic
+      @partition = partition
+      @partition_key = partition_key
+      @create_time = create_time
+      @bytesize = key.bytesize + value.bytesize
+    end
+  end
 end

--- a/lib/kafka/pending_message.rb
+++ b/lib/kafka/pending_message.rb
@@ -9,7 +9,7 @@ module Kafka
       @partition = partition
       @partition_key = partition_key
       @create_time = create_time
-      @bytesize = key.bytesize + value.bytesize
+      @bytesize = key.to_s.bytesize + value.to_s.bytesize
     end
   end
 end

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -185,8 +185,8 @@ module Kafka
       create_time = Time.now
 
       message = PendingMessage.new(
-        value.to_s,
-        key.to_s,
+        value && value.to_s,
+        key && key.to_s,
         topic.to_s,
         partition && Integer(partition),
         partition_key && partition_key.to_s,

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -185,11 +185,11 @@ module Kafka
       create_time = Time.now
 
       message = PendingMessage.new(
-        value,
-        key,
-        topic,
-        partition,
-        partition_key,
+        value.to_s,
+        key.to_s,
+        topic.to_s,
+        partition && Integer(partition),
+        partition_key && partition_key.to_s,
         create_time,
         key.to_s.bytesize + value.to_s.bytesize
       )

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -191,7 +191,6 @@ module Kafka
         partition && Integer(partition),
         partition_key && partition_key.to_s,
         create_time,
-        key.to_s.bytesize + value.to_s.bytesize
       )
 
       if buffer_size >= @max_buffer_size

--- a/spec/fake_broker.rb
+++ b/spec/fake_broker.rb
@@ -10,7 +10,7 @@ class FakeBroker
     @messages.each do |topic, messages_for_topic|
       messages_for_topic.each do |partition, messages_for_partition|
         messages_for_partition.each do |message|
-          messages << message.value
+          messages << message
         end
       end
     end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -69,6 +69,28 @@ describe Kafka::Producer do
         producer.deliver_messages
       }.to raise_exception(Kafka::Error)
     end
+
+    it "requires `partition` to be an Integer" do
+      expect {
+        producer.produce("hello", topic: "greetings", partition: "x")
+      }.to raise_exception(ArgumentError)
+    end
+
+    it "converts the value to a string" do
+      producer.produce(42, topic: "greetings", partition: 0)
+
+      producer.deliver_messages
+
+      expect(broker1.messages.map(&:value)).to eq ["42"]
+    end
+
+    it "converts `key` to a string" do
+      producer.produce("hello", topic: "greetings", key: 42, partition: 0)
+
+      producer.deliver_messages
+
+      expect(broker1.messages.map(&:key)).to eq ["42"]
+    end
   end
 
   describe "#deliver_messages" do
@@ -78,8 +100,8 @@ describe Kafka::Producer do
 
       producer.deliver_messages
 
-      expect(broker1.messages).to eq ["hello1"]
-      expect(broker2.messages).to eq ["hello2"]
+      expect(broker1.messages.map(&:value)).to eq ["hello1"]
+      expect(broker2.messages.map(&:value)).to eq ["hello2"]
     end
 
     it "handles when a partition temporarily doesn't have a leader" do
@@ -116,7 +138,7 @@ describe Kafka::Producer do
 
       producer.deliver_messages
       expect(broker1.messages).to be_empty
-      expect(broker2.messages).to eq(%w(hello0 hello1))
+      expect(broker2.messages.map(&:value)).to eq(%w(hello0 hello1))
     end
 
     it "handles when there's a connection error when fetching topic metadata" do

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -84,12 +84,28 @@ describe Kafka::Producer do
       expect(broker1.messages.map(&:value)).to eq ["42"]
     end
 
+    it "doesn't convert the value to a string if it's nil" do
+      producer.produce(nil, topic: "greetings", partition: 0)
+
+      producer.deliver_messages
+
+      expect(broker1.messages.map(&:value)).to eq [nil]
+    end
+
     it "converts `key` to a string" do
       producer.produce("hello", topic: "greetings", key: 42, partition: 0)
 
       producer.deliver_messages
 
       expect(broker1.messages.map(&:key)).to eq ["42"]
+    end
+
+    it "doesn't convert `key` to a string if it's nil" do
+      producer.produce("hello", topic: "greetings", key: nil, partition: 0)
+
+      producer.deliver_messages
+
+      expect(broker1.messages.map(&:key)).to eq [nil]
     end
   end
 


### PR DESCRIPTION
* Call `#to_s` on arguments expected to be strings – this avoids situations where the encoder fails in the background thread.
* Make PendingMessage a normal class.