### PR TITLE
Mark cluster info as stale on coordinator error

### DIFF
--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -41,6 +41,7 @@ module Kafka
       synchronize
     rescue NotCoordinatorForGroup
       @logger.error "Failed to find coordinator for group `#{@group_id}`; retrying..."
+      @cluster.mark_as_stale!
       sleep 1
       @coordinator = nil
       retry
@@ -98,6 +99,7 @@ module Kafka
       raise HeartbeatError, e
     rescue NotCoordinatorForGroup
       @logger.error "Failed to find coordinator for group `#{@group_id}`; retrying..."
+      @cluster.mark_as_stale!
       sleep 1
       @coordinator = nil
       retry


### PR DESCRIPTION
When no coordinator can be found for a group, we may need to mark the cluster as stale before proceeding.