### PR TITLE
Automatically reopen idle connections

### DIFF
--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -28,6 +28,9 @@ module Kafka
     SOCKET_TIMEOUT = 10
     CONNECT_TIMEOUT = 10
 
+    # Time after which an idle connection will be reopened.
+    IDLE_TIMEOUT = 60 * 5
+
     attr_reader :encoder
     attr_reader :decoder
 
@@ -88,13 +91,18 @@ module Kafka
 
       @instrumenter.instrument("request.connection", notification) do
         open unless open?
+        reopen if idle?
 
         @correlation_id += 1
 
         write_request(request, notification)
 
         response_class = request.response_class
-        wait_for_response(response_class, notification) unless response_class.nil?
+        response = wait_for_response(response_class, notification) unless response_class.nil?
+
+        @last_request = Time.now
+
+        response
       end
     rescue Errno::EPIPE, Errno::ECONNRESET, Errno::ETIMEDOUT, EOFError => e
       close
@@ -118,12 +126,23 @@ module Kafka
 
       # Correlation id is initialized to zero and bumped for each request.
       @correlation_id = 0
+
+      @last_request = nil
     rescue Errno::ETIMEDOUT => e
       @logger.error "Timed out while trying to connect to #{self}: #{e}"
       raise ConnectionError, e
     rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
       @logger.error "Failed to connect to #{self}: #{e}"
       raise ConnectionError, e
+    end
+
+    def reopen
+      close
+      open
+    end
+
+    def idle?
+      @last_request && @last_request < Time.now - IDLE_TIMEOUT
     end
 
     # Writes a request over the connection.


### PR DESCRIPTION
Connections that have been idle for more than five minutes are automatically reopened. This is done in order to preempt the broker-side connection killer, which by default kicks in after 10 minutes of idleness.