### PR TITLE
Add Topic to Datadog Metrics

### DIFF
--- a/lib/kafka/datadog.rb
+++ b/lib/kafka/datadog.rb
@@ -249,7 +249,6 @@ module Kafka
       def drop_messages(event)
         tags = {
           client: event.payload.fetch(:client_id),
-          topic: event.payload.fetch(:topic),
         }
 
         message_count = event.payload.fetch(:message_count)

--- a/lib/kafka/datadog.rb
+++ b/lib/kafka/datadog.rb
@@ -145,6 +145,7 @@ module Kafka
 
         tags = {
           client: client,
+          topic: topic,
         }
 
         # This gets us the write rate.
@@ -226,6 +227,7 @@ module Kafka
 
         tags = {
           client: client,
+          topic: topic,
         }
 
         # This gets us the avg/max queue size per producer.
@@ -247,6 +249,7 @@ module Kafka
       def drop_messages(event)
         tags = {
           client: event.payload.fetch(:client_id),
+          topic: event.payload.fetch(:topic),
         }
 
         message_count = event.payload.fetch(:message_count)


### PR DESCRIPTION
I noticed that the topic was extracted from the event, but it wasn't passed into the tags for datadog. Just adding them in the places where it was missing.