### PR TITLE
Provide access to the list of messages failed in DeliveryFailed

### DIFF
--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -203,6 +203,13 @@ module Kafka
 
   # Raised if not all messages could be sent by a producer.
   class DeliveryFailed < Error
+    attr_reader :failed_messages
+
+    def initialize(message, failed_messages)
+      @failed_messages = failed_messages
+
+      super(message)
+    end
   end
 
   class HeartbeatError < Error

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -142,7 +142,7 @@ module Kafka
       operation.execute
 
       unless buffer.empty?
-        raise DeliveryFailed
+        raise DeliveryFailed.new(nil, [message])
       end
     end
 

--- a/lib/kafka/pending_message.rb
+++ b/lib/kafka/pending_message.rb
@@ -11,5 +11,15 @@ module Kafka
       @create_time = create_time
       @bytesize = key.to_s.bytesize + value.to_s.bytesize
     end
+
+    def ==(other)
+      @value == other.value &&
+        @key == other.key &&
+        @topic == other.topic &&
+        @partition == other.partition &&
+        @partition_key == other.partition_key &&
+        @create_time == other.create_time &&
+        @bytesize == other.bytesize
+    end
   end
 end

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -320,7 +320,11 @@ module Kafka
 
         notification[:attempts] = attempt
 
-        @cluster.refresh_metadata_if_necessary!
+        begin
+          @cluster.refresh_metadata_if_necessary!
+        rescue ConnectionError => e
+          raise DeliveryFailed, e
+        end
 
         assign_partitions!
         operation.execute

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -257,6 +257,32 @@ module Kafka
       @pending_message_queue.bytesize + @buffer.bytesize
     end
 
+    # The messages waiting to get delivered.
+    #
+    # @return [Array<Kafka::PendingMessage>]
+    def buffer_messages
+      messages = []
+
+      @pending_message_queue.each do |message|
+        messages << message
+      end
+
+      @buffer.each do |topic, partition, messages_for_partition|
+        messages_for_partition.each do |message|
+          messages << PendingMessage.new(
+            message.value,
+            message.key,
+            topic,
+            partition,
+            nil,
+            message.create_time
+          )
+        end
+      end
+
+      messages
+    end
+
     # Deletes all buffered messages.
     #
     # @return [nil]

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -257,32 +257,6 @@ module Kafka
       @pending_message_queue.bytesize + @buffer.bytesize
     end
 
-    # The messages waiting to get delivered.
-    #
-    # @return [Array<Kafka::PendingMessage>]
-    def buffer_messages
-      messages = []
-
-      @pending_message_queue.each do |message|
-        messages << message
-      end
-
-      @buffer.each do |topic, partition, messages_for_partition|
-        messages_for_partition.each do |message|
-          messages << PendingMessage.new(
-            message.value,
-            message.key,
-            topic,
-            partition,
-            nil,
-            message.create_time
-          )
-        end
-      end
-
-      messages
-    end
-
     # Deletes all buffered messages.
     #
     # @return [nil]
@@ -323,7 +297,7 @@ module Kafka
         begin
           @cluster.refresh_metadata_if_necessary!
         rescue ConnectionError => e
-          raise DeliveryFailed, e
+          raise DeliveryFailed.new(e, buffer_messages)
         end
 
         assign_partitions!
@@ -351,13 +325,13 @@ module Kafka
       unless @pending_message_queue.empty?
         # Mark the cluster as stale in order to force a cluster metadata refresh.
         @cluster.mark_as_stale!
-        raise DeliveryFailed, "Failed to assign partitions to #{@pending_message_queue.size} messages"
+        raise DeliveryFailed.new("Failed to assign partitions to #{@pending_message_queue.size} messages", buffer_messages)
       end
 
       unless @buffer.empty?
         partitions = @buffer.map {|topic, partition, _| "#{topic}/#{partition}" }.join(", ")
 
-        raise DeliveryFailed, "Failed to send messages to #{partitions}"
+        raise DeliveryFailed.new("Failed to send messages to #{partitions}", buffer_messages)
       end
     end
 
@@ -408,6 +382,29 @@ module Kafka
       end
 
       @pending_message_queue.replace(failed_messages)
+    end
+
+    def buffer_messages
+      messages = []
+
+      @pending_message_queue.each do |message|
+        messages << message
+      end
+
+      @buffer.each do |topic, partition, messages_for_partition|
+        messages_for_partition.each do |message|
+          messages << PendingMessage.new(
+            message.value,
+            message.key,
+            topic,
+            partition,
+            nil,
+            message.create_time
+          )
+        end
+      end
+
+      messages
     end
 
     def buffer_overflow(topic, message)

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -1,4 +1,5 @@
 require "fake_broker"
+require "timecop"
 
 describe Kafka::Producer do
   let(:logger) { LOGGER }
@@ -230,6 +231,16 @@ describe Kafka::Producer do
 
       expect(event.payload[:topic]).to eq "greetings"
       expect(event.payload[:exception]).to eq ["Kafka::UnknownTopicOrPartition", "Kafka::UnknownTopicOrPartition"]
+    end
+  end
+
+  describe "#buffer_messages" do
+    it "returns all pending messages" do
+      time = Time.now
+      Timecop.freeze(time) { producer.produce("hello1", topic: "greetings", partition: 0) }
+      expect(producer.buffer_messages).to eq [Kafka::PendingMessage.new("hello1", nil, "greetings", 0, nil, time)]
+      producer.clear_buffer
+      expect(producer.buffer_messages).to eq []
     end
   end
 


### PR DESCRIPTION
In our application, we are consuming messages from an internal queueing system and attempting to publish them to Kafka through ruby-kafka.  If only a subset of those messages succeed, then we need to make sure that only those messages get deleted from our queueing system.  Since we have multiple processes running on this internal queue, we want to know which messages are still remaining (i.e. which ones failed) so that we don't delete those from our internal queue.

As an example, Amazon SQS consumers must explicitly mark messages as successful and any messages that failed will get picked up by another consumer at some point in the future.

There are a few ways we could address this:

(1) Change `deliver_messages` to return the list of messages that were successfully delivered. This doesn't really align with how the current API behaves and raises exceptions on partial failures.

(2) Provide access to the list of remaining messages that need to get sent after `deliver_messages` is invoked. e.g.

```ruby
begin
  producer.produce("hello1", topic: "greetings", partition: 0)
  producer.produce("hello1", topic: "greetings", partition: 1)
  producer.deliver_messages
rescue Kafka::DeliveryFailed
  producer.buffer_messages # Only failed messages will be here
end
```

(3) Provide access to the list of remaining messages that need to get sent in `DeliveryFailed` exceptions.  e.g.

For example:

```ruby
begin
  producer.produce("hello1", topic: "greetings", partition: 0)
  producer.produce("hello1", topic: "greetings", partition: 1)
  producer.deliver_messages
rescue Kafka::DeliveryFailed => ex
  ex.failed_messages
end
```

Since failures are the exceptional case, supporting a new API on `Producer` doesn't make quite as much sense -- we really only want to expose lists of failed messages when a failure has actually occurred.  Additionally, exposing the list of buffer messages when delivery hasn't even been attempted might result in misuse of the feature.  For these reasons, (3) seems like the most appropriate option.

In order to support this feature, 2 additional changes were made:

1. `Kafka::PendingMessage` now supports equality checks with other pending messages.  This is the object that's returned from `Kafka::DeliveryFailed#failed_messages` and providing equality checks helps us write specs against it.  If we would prefer to move that functionality into the spec itself, we can do that as well.  Open to thoughts / feedback here.

2. `Kafka::Producer#deliver_messages` had scenarios in which it could raise a `Kafka::ConnectionError` instead of `Kafka::DeliveryFailed` exception which would make it impossible to get the list of failed messages.  `#deliver_messages` will now always raise a `Kafka::DeliveryFailed` exception.