### PR TITLE
Remove abort_on_exception in favor of error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,20 @@ When calling `#shutdown`, the producer will attempt to deliver the messages and 
 
 **Note:** if the calling thread produces messages faster than the producer can write them to Kafka, you'll eventually run into problems. The internal queue used for sending messages from the calling thread to the background worker has a size limit; once this limit is reached, a call to `#produce` will raise `Kafka::BufferOverflow`.
 
+You may also provide a custom error handler to connect with any error handling service you might use.
+
+```ruby
+# Our custom error handler. Any errors that happen in the background thread will end up here.
+error_handler = lambda do |error, _logger, payload|
+  MyErrorHandlingService.handle(error, payload)
+end
+
+# `#async_producer` will create a new asynchronous producer.
+producer = kafka.async_producer(error_handler: error_handler)
+
+# ...
+```
+
 #### Serialization
 
 This library is agnostic to which serialization format you prefer. Both the value and key of a message is treated as a binary string of data. This makes it easier to use whatever serialization format you want, since you don't have to do anything special to make it work with ruby-kafka. Here's an example of encoding data with JSON:

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ You may also provide a custom error handler to connect with any error handling s
 
 ```ruby
 # Our custom error handler. Any errors that happen in the background thread will end up here.
-error_handler = lambda do |error, _logger, payload|
+error_handler = lambda do |error, payload|
   MyErrorHandlingService.handle(error, payload)
 end
 

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -157,9 +157,7 @@ module Kafka
     end
 
     def start_thread(&block)
-      thread = Thread.new(&block)
-      thread.abort_on_exception = true
-      thread
+      Thread.new(&block)
     end
 
     def buffer_overflow(topic)

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -68,6 +68,7 @@ module Kafka
     #   buffered messages that will automatically trigger a delivery.
     # @param delivery_interval [Integer] if greater than zero, the number of
     #   seconds between automatic message deliveries.
+    # @param error_handler [Proc] optional error handler to handle producer exceptions.
     #
     def initialize(sync_producer:, max_queue_size: 1000, delivery_threshold: 0, delivery_interval: 0, instrumenter:,
                    logger:, error_handler: nil)

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 require "openssl"
 require "uri"
 

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -209,6 +209,7 @@ module Kafka
     #   buffered messages that will automatically trigger a delivery.
     # @param delivery_interval [Integer] if greater than zero, the number of
     #   seconds between automatic message deliveries.
+    # @param error_handler [Proc] optional error handler to handle producer exceptions.
     #
     # @see AsyncProducer
     # @return [AsyncProducer]

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require "openssl"
 require "uri"
 
@@ -212,7 +213,7 @@ module Kafka
     #
     # @see AsyncProducer
     # @return [AsyncProducer]
-    def async_producer(delivery_interval: 0, delivery_threshold: 0, max_queue_size: 1000, **options)
+    def async_producer(error_handler: nil, delivery_interval: 0, delivery_threshold: 0, max_queue_size: 1000, **options)
       sync_producer = producer(**options)
 
       AsyncProducer.new(
@@ -222,6 +223,7 @@ module Kafka
         max_queue_size: max_queue_size,
         instrumenter: @instrumenter,
         logger: @logger,
+        error_handler: error_handler,
       )
     end
 

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -212,7 +212,7 @@ module Kafka
     #
     # @see AsyncProducer
     # @return [AsyncProducer]
-    def async_producer(error_handler: nil, delivery_interval: 0, delivery_threshold: 0, max_queue_size: 1000, **options)
+    def async_producer(delivery_interval: 0, delivery_threshold: 0, error_handler: nil, max_queue_size: 1000, **options)
       sync_producer = producer(**options)
 
       AsyncProducer.new(

--- a/spec/async_producer_spec.rb
+++ b/spec/async_producer_spec.rb
@@ -16,12 +16,52 @@ class FakeInstrumenter
 end
 
 describe Kafka::AsyncProducer do
-  describe "#shutdown" do
-    let(:sync_producer) { double(:sync_producer, produce: nil, shutdown: nil, deliver_messages: nil) }
-    let(:log) { StringIO.new }
-    let(:logger) { Logger.new(log) }
-    let(:instrumenter) { FakeInstrumenter.new }
+  let(:sync_producer) { double(:sync_producer, produce: nil, shutdown: nil, deliver_messages: nil) }
+  let(:log) { StringIO.new }
+  let(:logger) { Logger.new(log) }
+  let(:instrumenter) { FakeInstrumenter.new }
 
+  it "logs errors by default" do
+    expect(logger).to receive(:error).with(ArgumentError)
+    expect(logger).to receive(:error).with("I'm not sure what you're doing here.")
+    expect(logger).to receive(:error).with("line1\nline2\nline3")
+
+    error = ArgumentError.new("I'm not sure what you're doing here.")
+    error.set_backtrace(["line1", "line2", "line3"])
+
+    described_class::DEFAULT_ERROR_HANDLER.call(error, logger, nil)
+  end
+
+  it "uses the default error handler when no other error handler is provided" do
+    async_producer = Kafka::AsyncProducer.new(
+      sync_producer: sync_producer,
+      instrumenter: instrumenter,
+      logger: logger,
+    )
+
+    expect(async_producer.instance_variable_get(:@error_handler)).to eq(described_class::DEFAULT_ERROR_HANDLER)
+  end
+
+  it "can use a custom error handler" do
+    error_was_handled = false
+    error_handler = lambda { |_logger, _error, _payload| error_was_handled = true }
+
+    async_producer = Kafka::AsyncProducer.new(
+      sync_producer: sync_producer,
+      instrumenter: instrumenter,
+      logger: logger,
+      error_handler: error_handler,
+    )
+
+    allow(sync_producer).to receive(:buffer_size) { 42 }
+    allow(sync_producer).to receive(:deliver_messages) { raise Kafka::Error, "uh-oh!" }
+    async_producer.produce("hello", topic: "greetings", error_handler: error_handler)
+    async_producer.shutdown
+
+    expect(error_was_handled).to eq(true)
+  end
+
+  describe "#shutdown" do
     let(:async_producer) {
       Kafka::AsyncProducer.new(
         sync_producer: sync_producer,


### PR DESCRIPTION
This is an attempt to solve https://github.com/zendesk/ruby-kafka/issues/312 and https://github.com/zendesk/ruby-kafka/issues/357.

Instead of aborting the process when an error is raised, we can provide an error handler that allows us to do something with it. This lib will already ensure the async producer is running each time we call `#produce`, so with an error handler, there's no need to use `abort_on_exception`.

If no custom error handler is provided, a default error handler is used that will log the error and its backtrace. If you're using a service like honey badger (which is what we use), you can provide your own error handler like the following:

```ruby
error_handler = lambda { |error, _payload| ::Honeybadger.notify(error) }
producer = kafka.async_producer(error_handler: error_handler)
...
```

Now you can receive alerts when an error within your async producer occurs without your app crashing.

Here are a few questions:
1. The structure for the error handler is `lambda { |error|, payload| }` where `payload` may be `nil`. I figured it was worth having if you wanted to extract some information from it when logging errors, but it might not be very clear that the `payload` is not always available. Should I leave it or change it? Thoughts?
2. Since the logger is assigned at the instance level (not library/ class level), I create the error handler in the constructor. Don't love it, but I think it's better than making `logger` a param for the error handler. Thoughts?
3. Future idea: It's a trade-off, but you could add a supervisor thread that ensures the async producer worker thread is running. It's an additional thread per async producer, but it would mean you don't need to wait for someone to call `#produce` before restarting any workers that crashed. Thoughts?

Thanks!