### PR TITLE
Consumers should send heartbeats when no messages are available

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -217,6 +217,8 @@ module Kafka
         # We may not have received any messages, but it's still a good idea to
         # commit offsets if we've processed messages in the last set of batches.
         @offset_manager.commit_offsets_if_necessary
+
+        @heartbeat.send_if_necessary
       end
     end
 
@@ -279,6 +281,8 @@ module Kafka
 
           return if !@running
         end
+
+        @heartbeat.send_if_necessary
       end
     end
 


### PR DESCRIPTION
This PR updates consumers to send heartbeats even if there are no messages available on the server. Previously consumers would get kicked out of the consumer group if no data became available on the server before the session timeout.