### PR TITLE
Restart the async producer on errors

### DIFF
--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -142,16 +142,10 @@ module Kafka
 
     def ensure_threads_running!
       @worker_thread = nil unless @worker_thread && @worker_thread.alive?
-      @worker_thread ||= start_thread { @worker.run }
+      @worker_thread ||= Thread.new { @worker.run }
 
       @timer_thread = nil unless @timer_thread && @timer_thread.alive?
-      @timer_thread ||= start_thread { @timer.run }
-    end
-
-    def start_thread(&block)
-      thread = Thread.new(&block)
-      thread.abort_on_exception = true
-      thread
+      @timer_thread ||= Thread.new { @timer.run }
     end
 
     def buffer_overflow(topic)
@@ -224,6 +218,9 @@ module Kafka
 
         sleep 10
         retry
+      rescue Exception => e
+        @logger.error "Unexpected Kafka error #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
+        @logger.error "Async producer crashed!"
       ensure
         @producer.shutdown
       end

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -218,6 +218,12 @@ module Kafka
             raise "Unknown operation #{operation.inspect}"
           end
         end
+      rescue Kafka::Error => e
+        @logger.error "Unexpected Kafka error #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
+        @logger.info "Restarting in 10 seconds..."
+
+        sleep 10
+        retry
       ensure
         @producer.shutdown
       end


### PR DESCRIPTION
This is an attempt to fix the cause of #422.

When there's an unexpected Kafka error, we should not crash the host application – that goes against what the async producer is there to do, which is insulate the host from Kafka problems.

Instead, we sleep for 10 seconds before restarting the background worker. This should both ensure that we don't burn crazy amounts of CPU if we run into a loop, but also that the user can look at the logs and take action.