### PR TITLE
Change default max_wait_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,14 +654,15 @@ In order to optimize for low latency, you want to process a message as soon as p
 There are three values that can be tuned in order to balance these two concerns.
 
 * `min_bytes` is the minimum number of bytes to return from a single message fetch. By setting this to a high value you can increase the processing throughput. The default value is one byte.
-* `max_wait_time` is the maximum number of seconds to wait before returning data from a single message fetch. By setting this high you also increase the processing throughput – and by setting it low you set a bound on latency. This configuration overrides `min_bytes`, so you'll _always_ get data back within the time specified. The default value is five seconds. If you want to have at most one second of latency, set `max_wait_time` to 1.
+* `max_wait_time` is the maximum number of seconds to wait before returning data from a single message fetch. By setting this high you also increase the processing throughput – and by setting it low you set a bound on latency. This configuration overrides `min_bytes`, so you'll _always_ get data back within the time specified. The default value is one second. If you want to have at most five seconds of latency, set `max_wait_time` to 5. You should make sure `max_wait_time` * num brokers + `heartbeat_interval` is less than `session_timeout`.
 * `max_bytes_per_partition` is the maximum amount of data a broker will return for a single partition when fetching new messages. The default is 1MB, but increasing this number may lead to better throughtput since you'll need to fetch less frequently. Setting it to a lower value is not recommended unless you have so many partitions that it's causing network and latency issues to transfer a fetch response from a broker to a client. Setting the number too high may result in instability, so be careful.
 
 The first two settings can be passed to either `#each_message` or `#each_batch`, e.g.
 
 ```ruby
-# Waits for data for up to 30 seconds, preferring to fetch at least 5KB at a time.
-consumer.each_message(min_bytes: 1024 * 5, max_wait_time: 30) do |message|
+# Waits for data for up to 5 seconds on each broker, preferring to fetch at least 5KB at a time.
+# This can wait up to num brokers * 5 seconds.
+consumer.each_message(min_bytes: 1024 * 5, max_wait_time: 5) do |message|
   # ...
 end
 ```

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -165,10 +165,10 @@ module Kafka
     # at the last committed offsets.
     #
     # @param min_bytes [Integer] the minimum number of bytes to read before
-    #   returning messages from the server; if `max_wait_time` is reached, this
+    #   returning messages from each broker; if `max_wait_time` is reached, this
     #   is ignored.
     # @param max_wait_time [Integer, Float] the maximum duration of time to wait before
-    #   returning messages from the server, in seconds.
+    #   returning messages from each broker, in seconds.
     # @param automatically_mark_as_processed [Boolean] whether to automatically
     #   mark a message as successfully processed when the block returns
     #   without an exception. Once marked successful, the offsets of processed
@@ -178,7 +178,7 @@ module Kafka
     #   The original exception will be returned by calling `#cause` on the
     #   {Kafka::ProcessingError} instance.
     # @return [nil]
-    def each_message(min_bytes: 1, max_wait_time: 5, automatically_mark_as_processed: true)
+    def each_message(min_bytes: 1, max_wait_time: 1, automatically_mark_as_processed: true)
       consumer_loop do
         batches = fetch_batches(min_bytes: min_bytes, max_wait_time: max_wait_time)
 
@@ -232,17 +232,17 @@ module Kafka
     # at the last committed offsets.
     #
     # @param min_bytes [Integer] the minimum number of bytes to read before
-    #   returning messages from the server; if `max_wait_time` is reached, this
+    #   returning messages from each broker; if `max_wait_time` is reached, this
     #   is ignored.
     # @param max_wait_time [Integer, Float] the maximum duration of time to wait before
-    #   returning messages from the server, in seconds.
+    #   returning messages from each broker, in seconds.
     # @param automatically_mark_as_processed [Boolean] whether to automatically
     #   mark a batch's messages as successfully processed when the block returns
     #   without an exception. Once marked successful, the offsets of processed
     #   messages can be committed to Kafka.
     # @yieldparam batch [Kafka::FetchedBatch] a message batch fetched from Kafka.
     # @return [nil]
-    def each_batch(min_bytes: 1, max_wait_time: 5, automatically_mark_as_processed: true)
+    def each_batch(min_bytes: 1, max_wait_time: 1, automatically_mark_as_processed: true)
       consumer_loop do
         batches = fetch_batches(min_bytes: min_bytes, max_wait_time: max_wait_time)
 


### PR DESCRIPTION
As discussed in ##433, this PR changes the default `max_wait_time` to 1 second to avoid session timeouts in clusters with less than 20 brokers. It also updates the doc to make it clearer that this setting applies per broker.