### PR TITLE
Handle case where broker address changes but node_id does not

### DIFF
--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -10,6 +10,10 @@ module Kafka
       @logger = logger
     end
 
+    def address_match?(host, port)
+      @connection.address_match?(host, port)
+    end
+
     # @return [String]
     def to_s
       "#{@connection} (node_id=#{@node_id.inspect})"

--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -9,7 +9,16 @@ module Kafka
     end
 
     def connect(host, port, node_id: nil)
-      return @brokers.fetch(node_id) if @brokers.key?(node_id)
+
+      if @brokers.key?(node_id)
+        broker = @brokers.fetch(node_id)
+        if broker.address_match?(host, port)
+          return broker
+        else
+          broker.disconnect
+          @brokers[node_id] = nil
+        end
+      end
 
       broker = Broker.new(
         connection: @connection_builder.build_connection(host, port),

--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -9,7 +9,6 @@ module Kafka
     end
 
     def connect(host, port, node_id: nil)
-
       if @brokers.key?(node_id)
         broker = @brokers.fetch(node_id)
         return broker if broker.address_match?(host, port)

--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -12,12 +12,9 @@ module Kafka
 
       if @brokers.key?(node_id)
         broker = @brokers.fetch(node_id)
-        if broker.address_match?(host, port)
-          return broker
-        else
-          broker.disconnect
-          @brokers[node_id] = nil
-        end
+        return broker if broker.address_match?(host, port)
+        broker.disconnect
+        @brokers[node_id] = nil
       end
 
       broker = Broker.new(

--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -59,6 +59,10 @@ module Kafka
       @sasl_authenticator = sasl_authenticator
     end
 
+    def address_match?(host, port)
+      @host == host && @port == port
+    end
+
     def to_s
       "#{@host}:#{@port}"
     end

--- a/spec/broker_pool_spec.rb
+++ b/spec/broker_pool_spec.rb
@@ -1,0 +1,126 @@
+describe Kafka::BrokerPool do
+  let(:connection_builder) { double('connection_builder') }
+  let(:connection) { double('connection') }
+  let(:logger) { LOGGER }
+  let(:broker_pool) do
+    described_class.new(
+      connection_builder: connection_builder,
+      logger: logger,
+    )
+  end
+  let(:broker) { double('broker') }
+  let(:host) { "localhost" }
+  let(:port) { 9092 }
+  let(:node_id) { 0 }
+
+  before do
+    allow(Kafka::Broker).to receive(:new).and_call_original
+    allow(connection_builder).to receive(:build_connection).with(host, port) { connection }
+  end
+
+  describe "#connect" do
+    it "creates a new broker everytime it is called with node_id nil" do
+      # Call without node_id the first time.
+      allow(Kafka::Broker).to receive(:new).once.with({
+        connection: connection,
+        node_id: nil,
+        logger: logger
+      }) { broker }
+      expect(broker_pool.connect(host, port)).to eq(broker)
+
+      # Call without node_id the second time returns new broker.
+      second_broker = double()
+      allow(Kafka::Broker).to receive(:new).once.with({
+        connection: connection,
+        node_id: nil,
+        logger: logger
+      }) { second_broker }
+      expect(broker_pool.connect(host, port)).to eq(second_broker)
+    end
+
+    it "creates a new broker the first time it is called with a particular node_id" do
+      allow(Kafka::Broker).to receive(:new).once.with({
+        connection: connection,
+        node_id: node_id,
+        logger: logger
+      }) { broker }
+
+      expect(broker_pool.connect(host, port, node_id: node_id)).to eq(broker)
+    end
+
+    it "does not create a new broker if address & node_id match" do
+      allow(broker).to receive(:address_match?).with(host, port) { true }
+      allow(Kafka::Broker).to receive(:new).once.with({
+        connection: connection,
+        node_id: node_id,
+        logger: logger
+      }) { broker }
+
+      expect(broker_pool.connect(host, port, node_id: node_id)).to eq(broker)
+      expect(broker_pool.connect(host, port, node_id: node_id)).to eq(broker)
+    end
+
+    it "disconnects existing broker if new broker address does not match pre-existing broker address for a given node_id" do
+      allow(broker).to receive(:address_match?).with("#{host}1", "#{port}1") { false }
+      allow(broker).to receive(:disconnect).once
+      allow(Kafka::Broker).to receive(:new).once.with({
+        connection: connection,
+        node_id: node_id,
+        logger: logger
+      }) { broker }
+      expect(broker_pool.connect(host, port, node_id: node_id)).to eq(broker)
+
+      new_host = "#{host}1"
+      new_port = "#{port}1"
+      allow(connection_builder).to receive(:build_connection).with(new_host, new_port) { connection }
+      allow(Kafka::Broker).to receive(:new).once.with({
+        connection: connection,
+        node_id: node_id,
+        logger: logger
+      })
+
+      broker_pool.connect(new_host, new_port, node_id: node_id)
+
+      expect(broker).to have_received(:disconnect)
+    end
+
+    it "creates a new broker if address does not match pre-existing broker address for a given node_id" do
+      allow(broker).to receive(:address_match?).with("#{host}1", "#{port}1") { false }
+      allow(broker).to receive(:disconnect).once
+      allow(Kafka::Broker).to receive(:new).once.with({
+        connection: connection,
+        node_id: node_id,
+        logger: logger
+      }) { broker }
+
+      new_host = "#{host}1"
+      new_port = "#{port}1"
+      allow(connection_builder).to receive(:build_connection).with(new_host, new_port) { connection }
+      second_broker = double()
+      allow(Kafka::Broker).to receive(:new).once.with({
+        connection: connection,
+        node_id: node_id,
+        logger: logger
+      }) { second_broker }
+
+      actual_broker = broker_pool.connect(new_host, new_port, node_id: node_id)
+
+      expect(actual_broker).to eq(second_broker)
+    end
+  end
+
+  describe "#close" do
+    it "disconnects all broker connections" do
+      broker1 = broker_pool.connect(host, port, node_id: node_id)
+      allow(connection_builder).to receive(:build_connection).with("new.host", port) { connection }
+      broker2 = broker_pool.connect("new.host", port, node_id: 1)
+      allow(broker1).to receive(:disconnect)
+      allow(broker2).to receive(:disconnect)
+
+      broker_pool.close
+
+      expect(broker1).to have_received(:disconnect)
+      expect(broker2).to have_received(:disconnect)
+    end
+  end
+end

--- a/spec/broker_spec.rb
+++ b/spec/broker_spec.rb
@@ -19,6 +19,19 @@ describe Kafka::Broker do
     end
   end
 
+  describe "#address_match?" do
+    it "delegates to @connection" do
+      host = "test_host"
+      port = 333
+      connection = instance_double(Kafka::Connection)
+      allow(connection).to receive(:address_match?).with(host, port) { true }
+
+      broker = Kafka::Broker.new(connection: connection, logger: logger)
+
+      expect(broker.address_match?(host, port)).to be_truthy
+    end
+  end
+
   describe "#metadata" do
     it "fetches cluster metadata" do
       response = Kafka::Protocol::MetadataResponse.new(brokers: [], topics: [])


### PR DESCRIPTION
This is a continuation/retry of https://github.com/zendesk/ruby-kafka/pull/291 I had some time to dig in and, hopefully, the approach here is a bit more targeted. The idea is, if the host and/or port does not match what the broker_pool has in memory, there's no chance that connections will work and the in-memory broker information needs to be evicted. We're running this in production right now and have successfully pulled and replaced brokers without causing consumers to crash and/or enter into endless connection error loops. Let me know if there's anything else I can provide/tweak to help get this on its way upstream :)

Also, there's a bonus tweak in `lib/kafka/cluster.rb` :) When testing consumer resiliency I ran in to the situation where the coordinator was updated after the response with the old coordinator id came back. I added a single refresh + retry and never saw this happen again.
