### PR TITLE
Commit offsets even if we don't read any new messages

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -216,6 +216,8 @@ module Kafka
 
         # We may not have received any messages, but it's still a good idea to
         # commit offsets if we've processed messages in the last set of batches.
+        # This also ensures the offsets are retained if we haven't read any messages
+        # since the offset retention period has elapsed.
         @offset_manager.commit_offsets_if_necessary
       end
     end
@@ -279,6 +281,12 @@ module Kafka
 
           return if !@running
         end
+
+        # We may not have received any messages, but it's still a good idea to
+        # commit offsets if we've processed messages in the last set of batches.
+        # This also ensures the offsets are retained if we haven't read any messages
+        # since the offset retention period has elapsed.
+        @offset_manager.commit_offsets_if_necessary
       end
     end
 


### PR DESCRIPTION
This is similar to a83fddfcf84e01d2f242452caa8b8a7507493916 which was applied to Consumer#each_message and ensures that offsets are retained even if we don't receive any new messages for longer than the offset retention period. It would be great if this could be backported to the v0.4-stable branch too.