### PR TITLE
automatically_mark_as_processed false causes infinite loop #441

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -57,6 +57,17 @@ module Kafka
 
       # The maximum number of bytes to fetch from a single partition, by topic.
       @max_bytes = {}
+
+      # Hash containing offsets for each topic and partition that has the
+      # automatically_mark_as_processed feature disabled. Offset manager is only active
+      # when everything is suppose to happen automatically. Otherwise we need to keep track of the
+      # offset manually in memory for all the time
+      # The key structure for this equals an array with topic and partition [topic, partition]
+      # The value is equal to the offset of the last message we've received
+      # @note It won't be updated in case user marks message as processed, because for the case
+      #   when user commits message other than last in a batch, this would make ruby-kafka refetch
+      #   some already consumed messages
+      @current_offsets = {}
     end
 
     # Subscribes the consumer to a topic.
@@ -180,7 +191,11 @@ module Kafka
     # @return [nil]
     def each_message(min_bytes: 1, max_wait_time: 1, automatically_mark_as_processed: true)
       consumer_loop do
-        batches = fetch_batches(min_bytes: min_bytes, max_wait_time: max_wait_time)
+        batches = fetch_batches(
+          min_bytes: min_bytes,
+          max_wait_time: max_wait_time,
+          automatically_mark_as_processed: automatically_mark_as_processed
+        )
 
         batches.each do |batch|
           batch.messages.each do |message|
@@ -196,6 +211,7 @@ module Kafka
 
               begin
                 yield message
+                @current_offsets[[message.topic, message.partition]] = message.offset
               rescue => e
                 location = "#{message.topic}/#{message.partition} at offset #{message.offset}"
                 backtrace = e.backtrace.join("\n")
@@ -244,7 +260,11 @@ module Kafka
     # @return [nil]
     def each_batch(min_bytes: 1, max_wait_time: 1, automatically_mark_as_processed: true)
       consumer_loop do
-        batches = fetch_batches(min_bytes: min_bytes, max_wait_time: max_wait_time)
+        batches = fetch_batches(
+          min_bytes: min_bytes,
+          max_wait_time: max_wait_time,
+          automatically_mark_as_processed: automatically_mark_as_processed
+        )
 
         batches.each do |batch|
           unless batch.empty?
@@ -259,6 +279,7 @@ module Kafka
 
               begin
                 yield batch
+                @current_offsets[[batch.topic, batch.partition]] = batch.last_offset
               rescue => e
                 offset_range = (batch.first_offset..batch.last_offset)
                 location = "#{batch.topic}/#{batch.partition} in offset range #{offset_range}"
@@ -370,7 +391,7 @@ module Kafka
       end
     end
 
-    def fetch_batches(min_bytes:, max_wait_time:)
+    def fetch_batches(min_bytes:, max_wait_time:, automatically_mark_as_processed:)
       join_group unless @group.member?
 
       subscribed_partitions = @group.subscribed_partitions
@@ -386,7 +407,20 @@ module Kafka
 
       subscribed_partitions.each do |topic, partitions|
         partitions.each do |partition|
-          offset = @offset_manager.next_offset_for(topic, partition)
+          scope = [topic, partition]
+
+          if automatically_mark_as_processed
+            offset = @offset_manager.next_offset_for(*scope)
+          else
+            # When automatic marking is off, the first poll needs to be based on the last committed
+            # offset from Kafka, that's why we fallback in case of nil (it may not be 0)
+            if @current_offsets[scope]
+              offset = @current_offsets[scope] + 1
+            else
+              offset = @offset_manager.next_offset_for(*scope)
+            end
+          end
+
           max_bytes = @max_bytes.fetch(topic)
 
           if paused?(topic, partition)


### PR DESCRIPTION
This PR aims to solve the problem of lack of offset management for topics without automatic marking. It introduces an in memory offset cache per each partition and topic. Also it supports the failure and will reconsume the whole match for ```each_batch``` and the last message for ```each_message```.