### PR TITLE
Handle messages that exceed the maximum read size

### DIFF
--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -21,6 +21,10 @@ module Kafka
   class NoPartitionsToFetchFrom < Error
   end
 
+  # A message in a partition is larger than the maximum we've asked for.
+  class MessageTooLargeToRead < Error
+  end
+
   # Subclasses of this exception class map to an error code described in the
   # Kafka protocol specification.
   #

--- a/lib/kafka/protocol/message_set.rb
+++ b/lib/kafka/protocol/message_set.rb
@@ -37,7 +37,13 @@ module Kafka
               fetched_messages << message
             end
           rescue EOFError
-            # We tried to decode a partial message; just skip it.
+            if fetched_messages.empty?
+              # If the first message in the set is truncated, it's likely because the
+              # message is larger than the maximum size that we have asked for.
+              raise MessageTooLargeToRead
+            else
+              # We tried to decode a partial message at the end of the set; just skip it.
+            end
           end
         end
 

--- a/spec/protocol/message_set_spec.rb
+++ b/spec/protocol/message_set_spec.rb
@@ -1,0 +1,22 @@
+describe Kafka::Protocol::Message do
+  include Kafka::Protocol
+
+  it "decodes message sets" do
+    message1 = Kafka::Protocol::Message.new(value: "hello")
+    message2 = Kafka::Protocol::Message.new(value: "good-day")
+
+    message_set = Kafka::Protocol::MessageSet.new(messages: [message1, message2])
+
+    data = StringIO.new
+    encoder = Kafka::Protocol::Encoder.new(data)
+
+    message_set.encode(encoder)
+
+    data.rewind
+
+    decoder = Kafka::Protocol::Decoder.new(data)
+    new_message_set = Kafka::Protocol::MessageSet.decode(decoder)
+
+    expect(new_message_set).to eq message_set
+  end
+end

--- a/spec/protocol/message_set_spec.rb
+++ b/spec/protocol/message_set_spec.rb
@@ -17,6 +17,46 @@ describe Kafka::Protocol::Message do
     decoder = Kafka::Protocol::Decoder.new(data)
     new_message_set = Kafka::Protocol::MessageSet.decode(decoder)
 
-    expect(new_message_set).to eq message_set
+    expect(new_message_set.messages).to eq [message1, message2]
+  end
+
+  it "skips the last message if it has been truncated" do
+    message1 = Kafka::Protocol::Message.new(value: "hello")
+    message2 = Kafka::Protocol::Message.new(value: "good-day")
+
+    message_set = Kafka::Protocol::MessageSet.new(messages: [message1, message2])
+
+    data = StringIO.new
+    encoder = Kafka::Protocol::Encoder.new(data)
+
+    message_set.encode(encoder)
+
+    data.rewind
+    data.truncate(data.size - 1)
+
+    decoder = Kafka::Protocol::Decoder.new(data)
+    new_message_set = Kafka::Protocol::MessageSet.decode(decoder)
+
+    expect(new_message_set.messages).to eq [message1]
+  end
+
+  it "raises MessageTooLargeToRead if the first message in the set has been truncated" do
+    message = Kafka::Protocol::Message.new(value: "hello")
+
+    message_set = Kafka::Protocol::MessageSet.new(messages: [message])
+
+    data = StringIO.new
+    encoder = Kafka::Protocol::Encoder.new(data)
+
+    message_set.encode(encoder)
+
+    data.rewind
+    data.truncate(data.size - 1)
+
+    decoder = Kafka::Protocol::Decoder.new(data)
+
+    expect {
+      Kafka::Protocol::MessageSet.decode(decoder)
+    }.to raise_exception(Kafka::MessageTooLargeToRead)
   end
 end


### PR DESCRIPTION
When the client specifies a maximum number of bytes to read from a partition and the first message in the partition exceeds that, the broker will truncate the message set to match the client's maximum. This means that the client is unable to decode any messages.

Rather than infinitely keep asking for messages just to have a truncated message returned, we not raise MessageTooLargeToRead.

Fixes #429.