### PR TITLE
Report the time lag when consuming messages

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -209,6 +209,7 @@ module Kafka
                 partition: message.partition,
                 offset: message.offset,
                 offset_lag: batch.highwater_mark_offset - message.offset - 1,
+                create_time: message.create_time,
                 key: message.key,
                 value: message.value,
               )


### PR DESCRIPTION
Since Kafka 0.10, messages have a timestamp that we can use to report the end-to-end lag.