### PR TITLE
Avoid raising IdleConnection from inside the instrument block

### DIFF
--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -89,10 +89,10 @@ module Kafka
         response_size: 0,
       }
 
+      raise IdleConnection if idle?
+
       @instrumenter.instrument("request.connection", notification) do
         open unless open?
-
-        raise IdleConnection if idle?
 
         @correlation_id += 1
 


### PR DESCRIPTION
Idle connections were causing dashboards to light up.