### PR TITLE
Fix seek to default offset behavior

### DIFF
--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -66,7 +66,9 @@ module Kafka
       # Remove any cached offset, in case things have changed broker-side.
       clear_resolved_offset(topic)
 
-      seek_to(topic, partition, -1)
+      offset = resolve_offset(topic, partition)
+
+      seek_to(topic, partition, offset)
     end
 
     # Move the consumer's position in the partition to the specified offset.


### PR DESCRIPTION
After seeking a partition to its default offset, a consumer would try to commit -1 as the offset for the partition. This makes sure that we resolve the symbolic default offset to a physical offset number before committing.

Fixes #478.