### PR TITLE
Change highwater mark semantics

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -208,7 +208,7 @@ module Kafka
                 topic: message.topic,
                 partition: message.partition,
                 offset: message.offset,
-                offset_lag: batch.highwater_mark_offset - message.offset - 1,
+                offset_lag: batch.highwater_mark_offset - message.offset,
                 create_time: message.create_time,
                 key: message.key,
                 value: message.value,

--- a/lib/kafka/fetched_batch.rb
+++ b/lib/kafka/fetched_batch.rb
@@ -35,7 +35,7 @@ module Kafka
 
     def last_offset
       if empty?
-        highwater_mark_offset - 1
+        highwater_mark_offset
       else
         messages.last.offset
       end
@@ -45,7 +45,7 @@ module Kafka
       if empty?
         0
       else
-        (highwater_mark_offset - 1) - last_offset
+        highwater_mark_offset - last_offset
       end
     end
   end

--- a/spec/fetched_batch_spec.rb
+++ b/spec/fetched_batch_spec.rb
@@ -18,7 +18,7 @@ describe Kafka::FetchedBatch do
         fetched_batch = described_class.new(
           topic: 'foo',
           partition: 0,
-          highwater_mark_offset: 10, # offset of *next* message
+          highwater_mark_offset: 9,
           messages: [message]
         )
         expect(fetched_batch.offset_lag).to eq 0
@@ -31,7 +31,7 @@ describe Kafka::FetchedBatch do
         fetched_batch = described_class.new(
           topic: 'foo',
           partition: 0,
-          highwater_mark_offset: 12, # offset of *next* message
+          highwater_mark_offset: 11,
           messages: [message]
         )
         expect(fetched_batch.offset_lag).to eq 2


### PR DESCRIPTION
It seems that Kafka has changed the meaning of the highwater mark. Before, it indicated the *next* offset that would be written to, but now it seems to indicate the *last* offset that has already been written.