### PR TITLE
Push the aggregate message size to Datadog

### DIFF
--- a/lib/kafka/datadog.rb
+++ b/lib/kafka/datadog.rb
@@ -229,7 +229,11 @@ module Kafka
         # This gets us the write rate.
         increment("producer.produce.messages", tags: tags.merge(topic: topic))
 
+        # Information about typical/average/95p message size.
         histogram("producer.produce.message_size", message_size, tags: tags.merge(topic: topic))
+
+        # Aggregate message size.
+        count("producer.produce.message_size.sum", message_size, tags: tags.merge(topic: topic))
 
         # This gets us the avg/max buffer size per producer.
         histogram("producer.buffer.size", buffer_size, tags: tags)


### PR DESCRIPTION
It is nice to track how much data is being produced.