### PR TITLE
Don't raise IOError to the user

### DIFF
--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -107,7 +107,7 @@ module Kafka
 
         response
       end
-    rescue SystemCallError, EOFError => e
+    rescue SystemCallError, EOFError, IOError => e
       close
 
       raise ConnectionError, "Connection error #{e.class}: #{e}"

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -365,6 +365,9 @@ module Kafka
           @logger.error "Leader not available; waiting 1s before retrying"
           @cluster.mark_as_stale!
           sleep 1
+        rescue ConnectionError => e
+          @logger.error "Connection error #{e.class}: #{e.message}"
+          @cluster.mark_as_stale!
         rescue SignalException => e
           @logger.warn "Received signal #{e.message}, shutting down"
           @running = false


### PR DESCRIPTION
Users shouldn't get IOError when we close down the client.

Fixes #484.