### PR TITLE
Fix offsets for messages within MessageSet

### DIFF
--- a/lib/kafka/protocol/message.rb
+++ b/lib/kafka/protocol/message.rb
@@ -57,11 +57,12 @@ module Kafka
         data = codec.decompress(value)
         message_set_decoder = Decoder.from_string(data)
         message_set = MessageSet.decode(message_set_decoder)
+        base_offset = offset - message_set.size + 1
 
         # The contained messages need to have their offset corrected.
         messages = message_set.messages.each_with_index.map do |message, i|
           Message.new(
-            offset: offset + i,
+            offset: base_offset + i,
             value: message.value,
             key: message.key,
             create_time: message.create_time,

--- a/spec/compressor_spec.rb
+++ b/spec/compressor_spec.rb
@@ -22,7 +22,7 @@ describe Kafka::Compressor do
       # When decoding a compressed message, the offsets are calculated relative to that
       # of the container message. The broker will set the offset in normal operation,
       # but at the client-side we set it to -1.
-      expect(messages.map(&:offset)).to eq [-1, 0]
+      expect(messages.map(&:offset)).to eq [-2, -1]
     end
 
     it "only compresses the messages if there are at least the configured threshold" do


### PR DESCRIPTION
* MessageSet holds the offset of the last message which means
  we need to take into account the size of the MessageSet to
  set the Message offset properly