### PR TITLE
Use JoinGroupResponse metadata for assigning topics as leader

### DIFF
--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -118,6 +118,7 @@ module Kafka
           group_id: @group_id,
           session_timeout: @session_timeout,
           member_id: @member_id,
+          topics: @topics
         )
 
         Protocol.handle_error(response.error_code)
@@ -149,8 +150,7 @@ module Kafka
         @logger.info "Chosen as leader of group `#{@group_id}`"
 
         group_assignment = @assignment_strategy.assign(
-          members: @members.keys,
-          topics: @topics,
+          members: @members,
         )
       end
 

--- a/lib/kafka/protocol/consumer_group_protocol.rb
+++ b/lib/kafka/protocol/consumer_group_protocol.rb
@@ -1,6 +1,9 @@
 module Kafka
   module Protocol
     class ConsumerGroupProtocol
+
+      attr_accessor :version, :topics, :user_data
+
       def initialize(version: 0, topics:, user_data: nil)
         @version = version
         @topics = topics
@@ -11,6 +14,10 @@ module Kafka
         encoder.write_int16(@version)
         encoder.write_array(@topics) {|topic| encoder.write_string(topic) }
         encoder.write_bytes(@user_data)
+      end
+
+      def self.decode(decoder)
+        ConsumerGroupProtocol.new(version: decoder.int16, topics: decoder.array { decoder.string }, user_data: decoder.bytes)
       end
     end
   end

--- a/lib/kafka/protocol/join_group_request.rb
+++ b/lib/kafka/protocol/join_group_request.rb
@@ -11,7 +11,7 @@ module Kafka
         @member_id = member_id || ""
         @protocol_type = PROTOCOL_TYPE
         @group_protocols = {
-          "standard" => ConsumerGroupProtocol.new(topics: ["test-messages"]),
+          "standard" => ConsumerGroupProtocol.new(topics: topics),
         }
       end
 

--- a/lib/kafka/protocol/join_group_response.rb
+++ b/lib/kafka/protocol/join_group_response.rb
@@ -23,7 +23,7 @@ module Kafka
           group_protocol: decoder.string,
           leader_id: decoder.string,
           member_id: decoder.string,
-          members: Hash[decoder.array { [decoder.string, decoder.bytes] }],
+          members: Hash[decoder.array { [decoder.string, ConsumerGroupProtocol.decode(Decoder.new(StringIO.new(decoder.bytes)))] }],
         )
       end
     end

--- a/spec/protocol/consumer_group_protocol_spec.rb
+++ b/spec/protocol/consumer_group_protocol_spec.rb
@@ -1,0 +1,20 @@
+describe Kafka::Protocol::ConsumerGroupProtocol do
+  it "encodes and decodes" do
+    group = Kafka::Protocol::ConsumerGroupProtocol.new(
+      version: 1,
+      topics: ["test"],
+      user_data: "foobar"
+    )
+
+    io = StringIO.new
+    encoder = Kafka::Protocol::Encoder.new(io)
+    group.encode(encoder)
+    data = StringIO.new(io.string)
+    decoder = Kafka::Protocol::Decoder.new(data)
+
+    group2 = Kafka::Protocol::ConsumerGroupProtocol.decode(decoder)
+    expect(group.version).to eq(group2.version)
+    expect(group.topics).to eq(group2.topics)
+    expect(group.user_data).to eq(group2.user_data)
+  end
+end

--- a/spec/round_robin_assignment_strategy_spec.rb
+++ b/spec/round_robin_assignment_strategy_spec.rb
@@ -3,13 +3,12 @@ describe Kafka::RoundRobinAssignmentStrategy do
     cluster = double(:cluster)
     strategy = described_class.new(cluster: cluster)
 
-    members = (0...10).map {|i| "member#{i}" }
-    topics = ["greetings"]
+    members = Hash[*(0...10).map {|i| ["member#{i}", Kafka::Protocol::ConsumerGroupProtocol.new(:topics => ["greetings"])]}.flatten]
     partitions = (0...30).map {|i| double(:"partition#{i}", partition_id: i) }
 
     allow(cluster).to receive(:partitions_for) { partitions }
 
-    assignments = strategy.assign(members: members, topics: topics)
+    assignments = strategy.assign(members: members)
 
     partitions.each do |partition|
       member = assignments.values.find {|assignment|
@@ -19,6 +18,25 @@ describe Kafka::RoundRobinAssignmentStrategy do
       }
 
       expect(member).to_not be_nil
+    end
+  end
+
+  it "assigns by desired topic" do
+    cluster = double(:cluster)
+    strategy = described_class.new(cluster: cluster)
+
+    members = Hash[*(0...10).map {|i| ["member#{i}", Kafka::Protocol::ConsumerGroupProtocol.new(:topics => ["topic#{i % 2}"])] }.flatten]
+    partitions = (0...30).map {|i| double(:"partition#{i}", partition_id: i) }
+
+    allow(cluster).to receive(:partitions_for) { partitions }
+
+    assignments = strategy.assign(members: members)
+
+    assignments.each do |member, assignment|
+      i_value = member[6].to_i
+      assignment.topics.each_key do |topic_name|
+        expect(i_value % 2).to eq(topic_name[5].to_i), "expected #{member} to not have #{topic_name}"
+      end
     end
   end
 end


### PR DESCRIPTION
I observed in a production environment that when you have two processes in the same consumer group but each is subscribed to different topics that the leader will 

- Only assign members to topics that it is subscribed to itself.
- Other members that are not subscribed to the topics they are assigned do not seem to process from those partitions.

Sidestepping this issue is possible by using distinct consumer groups and keeping topic subscriptions consistent within the consumer group, however this is not the behavior observed when using the Java client. From an operational point of view it seems like unexpected behavior. 

Per the [Apache Kafka Protocol Guide](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol) it certainly appears the intention of the metadata is to include the consumer's subscribed topics (which is currently boilerplated with `test-messages`) - so we can take the result of the join group response returned to our leader node and construct a mapping of members to topics and use that to inform our assignment. This pull request should achieve that by:

- Taking the unused `topics` argument and replacing the placeholder in `JoinGroupRequest`
- Adding decoding to the `ConsumerGroupProtocol`
- Deserializing the `ConsumerGroupProtocol` in the `JoinGroupResponse`
- Have the consumer group pass the topics to the initializer of `JoinGroupRequest`
- Updating the assignment strategy to take member objects instead of just member IDs, and interrogating them to get the topic listing in order to produce an accurate consumer topic map. 