### PR TITLE
Allow setting Kafka::Datadog.statsd

### DIFF
--- a/lib/kafka/datadog.rb
+++ b/lib/kafka/datadog.rb
@@ -32,6 +32,10 @@ module Kafka
         @statsd ||= ::Datadog::Statsd.new(host, port, namespace: namespace, tags: tags)
       end
 
+      def statsd=(statsd)
+        @statsd = statsd
+      end
+
       def host
         @host ||= ::Datadog::Statsd::DEFAULT_HOST
       end


### PR DESCRIPTION
This PR adds a `Kafka::Datadog.statsd` setter so you can re-use an existing dogstatsd client.

I ended up going this route after many attempts to configure `Kafka::Datadog` via the host and port setters. For some reason my already setup dogstatsd client could communicate with the ddagent but no matter what I tried the dogstatsd client `Kafka::Datadog` instantiated wouldn't.

Testing a theory I tried `Kafka::Datadog.instance_variable_set :@statsd, App.statsd` and tested and sure enough metrics started flowing through to Datadog.