### PR TITLE
Fix the list topics API

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -467,8 +467,7 @@ module Kafka
     #
     # @return [Array<String>] the list of topic names.
     def topics
-      @cluster.clear_target_topics
-      @cluster.topics
+      @cluster.list_topics
     end
 
     def has_topic?(topic)

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -232,6 +232,12 @@ module Kafka
       cluster_info.topics.map(&:topic_name)
     end
 
+    # Lists all topics in the cluster.
+    def list_topics
+      response = random_broker.fetch_metadata(topics: nil)
+      response.topics.map(&:topic_name)
+    end
+
     def disconnect
       @broker_pool.close
     end

--- a/lib/kafka/protocol/encoder.rb
+++ b/lib/kafka/protocol/encoder.rb
@@ -74,8 +74,13 @@ module Kafka
       # @param array [Array]
       # @return [nil]
       def write_array(array, &block)
-        write_int32(array.size)
-        array.each(&block)
+        if array.nil?
+          # An array can be null, which is different from it being empty.
+          write_int32(-1)
+        else
+          write_int32(array.size)
+          array.each(&block)
+        end
       end
 
       # Writes a string to the IO object.

--- a/spec/functional/client_spec.rb
+++ b/spec/functional/client_spec.rb
@@ -4,11 +4,13 @@ describe "Producer API", functional: true do
   let!(:topic) { create_random_topic(num_partitions: 3) }
 
   example "listing all topics in the cluster" do
+    # Use a clean Kafka instance to avoid hitting caches.
+    kafka = Kafka.new(seed_brokers: KAFKA_BROKERS, logger: LOGGER)
+
+    topics = kafka.topics
+
+    expect(topics).to include topic
     expect(kafka.has_topic?(topic)).to eq true
-
-    topic2 = create_random_topic
-
-    expect(kafka.has_topic?(topic2)).to eq true
   end
 
   example "fetching the partition count for a topic" do


### PR DESCRIPTION
A recent version of Kafka changed its API such that an empty list of topics in the metadata request no longer causes the broker to return *all* topics in the cluster - rather, we need to pass a null value.

Fixes #493.