### PR TITLE
Shut down the consumer more quickly

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -433,6 +433,9 @@ module Kafka
     end
 
     def fetch_batches(min_bytes:, max_bytes:, max_wait_time:, automatically_mark_as_processed:)
+      # Return early if the consumer has been stopped.
+      return [] if !@running
+
       join_group unless @group.member?
 
       subscribed_partitions = @group.subscribed_partitions


### PR DESCRIPTION
The retry logic would sometimes cause the consumer to be stuck in a fetch loop even when it's supposed to be shutting down.