### PR TITLE
Mark the consumer as not member of the group when leaving

### DIFF
--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -56,6 +56,9 @@ module Kafka
     def leave
       @logger.info "Leaving group `#{@group_id}`"
 
+      # Having a generation id indicates that we're a member of the group.
+      @generation_id = nil
+
       @instrumenter.instrument("leave_group.consumer", group_id: @group_id) do
         coordinator.leave_group(group_id: @group_id, member_id: @member_id)
       end


### PR DESCRIPTION
Calling `member?` on a group after calling `leave` would return `true` rather than `false`, which caused double processing under some circumstances.