### PR TITLE
 Increase topic partition count API

### DIFF
--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -121,6 +121,12 @@ module Kafka
       send_request(request)
     end
 
+    def create_partitions(**options)
+      request = Protocol::CreatePartitionsRequest.new(**options)
+
+      send_request(request)
+    end
+
     def api_versions
       request = Protocol::ApiVersionsRequest.new
 

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -479,12 +479,10 @@ module Kafka
     # @param num_partitions [Integer] the number of desired partitions for
     # the topic
     # @param timeout [Integer] a duration of time to wait for the new
-    # @param validate_only [Boolean] whether this request is to validate only
-    # without actually execute it
     # partitions to be added.
     # @return [nil]
-    def create_partitions_for(name, num_partitions: 1, timeout: 30, validate_only: false)
-      @cluster.create_partitions_for(name, num_partitions: num_partitions, timeout: timeout, validate_only: validate_only)
+    def create_partitions_for(name, num_partitions: 1, timeout: 30)
+      @cluster.create_partitions_for(name, num_partitions: num_partitions, timeout: timeout)
     end
 
     # Lists all topics in the cluster.

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -545,8 +545,8 @@ module Kafka
     # @param api_key [Integer] API key.
     # @param version [Integer] API version.
     # @return [Boolean]
-    def support_api?(api_key, version = nil)
-      @cluster.support_api?(api_key, version)
+    def supports_api?(api_key, version = nil)
+      @cluster.supports_api?(api_key, version)
     end
 
     def apis

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -473,6 +473,18 @@ module Kafka
       @cluster.delete_topic(name, timeout: timeout)
     end
 
+    # Create partitions for a topic.
+    #
+    # @param name [String] the name of the topic.
+    # @param num_partitions [Integer] the number of desired partitions for
+    # the topic
+    # @param timeout [Integer] a duration of time to wait for the new
+    # partitions to be added.
+    # @return [nil]
+    def create_partitions_for(name, num_partitions: 1, timeout: 30, validate_only: false)
+      @cluster.create_partitions_for(name, num_partitions: num_partitions, timeout: timeout, validate_only: validate_only)
+    end
+
     # Lists all topics in the cluster.
     #
     # @return [Array<String>] the list of topic names.

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -540,6 +540,15 @@ module Kafka
       }.to_h
     end
 
+    # Check whether current cluster supports a specific version or not
+    #
+    # @param api_key [Integer] API key.
+    # @param version [Integer] API version.
+    # @return [Boolean]
+    def support_api?(api_key, version = nil)
+      @cluster.support_api?(api_key, version)
+    end
+
     def apis
       @cluster.apis
     end

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -479,6 +479,8 @@ module Kafka
     # @param num_partitions [Integer] the number of desired partitions for
     # the topic
     # @param timeout [Integer] a duration of time to wait for the new
+    # @param validate_only [Boolean] whether this request is to validate only
+    # without actually execute it
     # partitions to be added.
     # @return [nil]
     def create_partitions_for(name, num_partitions: 1, timeout: 30, validate_only: false)

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -200,10 +200,7 @@ module Kafka
     end
 
     def create_partitions_for(name, num_partitions:, timeout:, validate_only:)
-      partitions = partitions_for(name)
-      all_brokers = cluster_info.brokers.map(&:node_id)
-      assignments = (1..num_partitions - partitions.count).map { all_brokers }
-
+      assignments = nil
       options = {
         topics: [[name, num_partitions, assignments]],
         timeout: timeout,

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -210,12 +210,10 @@ module Kafka
       @logger.info "Topic `#{name}` was deleted"
     end
 
-    def create_partitions_for(name, num_partitions:, timeout:, validate_only:)
-      assignments = nil
+    def create_partitions_for(name, num_partitions:, timeout:)
       options = {
-        topics: [[name, num_partitions, assignments]],
-        timeout: timeout,
-        validate_only: validate_only
+        topics: [[name, num_partitions, nil]],
+        timeout: timeout
       }
 
       broker = controller_broker

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -53,6 +53,17 @@ module Kafka
       apis.find {|api| api.api_key == api_key }
     end
 
+    def support_api?(api_key, version = nil)
+      info = api_info(api_key)
+      if info.nil?
+        return false
+      elsif version.nil?
+        return true
+      else
+        return (info.min_version..info.max_version).include?(version)
+      end
+    end
+
     def apis
       @apis ||=
         begin

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -53,7 +53,7 @@ module Kafka
       apis.find {|api| api.api_key == api_key }
     end
 
-    def support_api?(api_key, version = nil)
+    def supports_api?(api_key, version = nil)
       info = api_info(api_key)
       if info.nil?
         return false

--- a/lib/kafka/protocol.rb
+++ b/lib/kafka/protocol.rb
@@ -27,6 +27,7 @@ module Kafka
     API_VERSIONS_API = 18
     CREATE_TOPICS_API = 19
     DELETE_TOPICS_API = 20
+    CREATE_PARTITIONS_API = 37
 
     # A mapping from numeric API keys to symbolic API names.
     APIS = {
@@ -45,6 +46,7 @@ module Kafka
       API_VERSIONS_API => :api_versions,
       CREATE_TOPICS_API => :create_topics,
       DELETE_TOPICS_API => :delete_topics,
+      CREATE_PARTITIONS_API => :create_partitions
     }
 
     # A mapping from numeric error codes to exception classes.
@@ -95,13 +97,13 @@ module Kafka
     # @param error_code Integer
     # @raise [ProtocolError]
     # @return [nil]
-    def self.handle_error(error_code)
+    def self.handle_error(error_code, error_message = nil)
       if error_code == 0
         # No errors, yay!
       elsif error = ERRORS[error_code]
-        raise error
+        raise error, error_message
       else
-        raise UnknownError, "Unknown error with code #{error_code}"
+        raise UnknownError, "Unknown error with code #{error_code} #{error_message}"
       end
     end
 
@@ -145,3 +147,5 @@ require "kafka/protocol/create_topics_request"
 require "kafka/protocol/create_topics_response"
 require "kafka/protocol/delete_topics_request"
 require "kafka/protocol/delete_topics_response"
+require "kafka/protocol/create_partitions_request"
+require "kafka/protocol/create_partitions_response"

--- a/lib/kafka/protocol/create_partitions_request.rb
+++ b/lib/kafka/protocol/create_partitions_request.rb
@@ -2,8 +2,8 @@ module Kafka
   module Protocol
 
     class CreatePartitionsRequest
-      def initialize(topics:, timeout:, validate_only:)
-        @topics, @timeout, @validate_only = topics, timeout, validate_only
+      def initialize(topics:, timeout:)
+        @topics, @timeout = topics, timeout
       end
 
       def api_key
@@ -30,7 +30,9 @@ module Kafka
         end
         # Timeout is in ms.
         encoder.write_int32(@timeout * 1000)
-        encoder.write_boolean(@validate_only)
+        # validate_only. There isn't any use case for this in real life. So
+        # let's ignore it for now
+        encoder.write_boolean(false)
       end
     end
 

--- a/lib/kafka/protocol/create_partitions_request.rb
+++ b/lib/kafka/protocol/create_partitions_request.rb
@@ -1,0 +1,38 @@
+module Kafka
+  module Protocol
+
+    class CreatePartitionsRequest
+      def initialize(topics:, timeout:, validate_only:)
+        @topics, @timeout, @validate_only = topics, timeout, validate_only
+      end
+
+      def api_key
+        CREATE_PARTITIONS_API
+      end
+
+      def api_version
+        0
+      end
+
+      def response_class
+        Protocol::CreatePartitionsResponse
+      end
+
+      def encode(encoder)
+        encoder.write_array(@topics) do |topic, count, assignments|
+          encoder.write_string(topic)
+          encoder.write_int32(count)
+          encoder.write_array(assignments) do |assignment|
+            encoder.write_array(assignment) do |broker|
+              encoder.write_int32(broker)
+            end
+          end
+        end
+        # Timeout is in ms.
+        encoder.write_int32(@timeout * 1000)
+        encoder.write_boolean(false)
+      end
+    end
+
+  end
+end

--- a/lib/kafka/protocol/create_partitions_request.rb
+++ b/lib/kafka/protocol/create_partitions_request.rb
@@ -30,7 +30,7 @@ module Kafka
         end
         # Timeout is in ms.
         encoder.write_int32(@timeout * 1000)
-        encoder.write_boolean(false)
+        encoder.write_boolean(@validate_only)
       end
     end
 

--- a/lib/kafka/protocol/create_partitions_response.rb
+++ b/lib/kafka/protocol/create_partitions_response.rb
@@ -1,0 +1,26 @@
+module Kafka
+  module Protocol
+
+    class CreatePartitionsResponse
+      attr_reader :errors
+
+      def initialize(throttle_time_ms:, errors:)
+        @throttle_time_ms = throttle_time_ms
+        @errors = errors
+      end
+
+      def self.decode(decoder)
+        throttle_time_ms = decoder.int32
+        errors = decoder.array do
+          topic = decoder.string
+          error_code = decoder.int16
+          error_message = decoder.string
+          [topic, error_code, error_message]
+        end
+
+        new(throttle_time_ms: throttle_time_ms, errors: errors)
+      end
+    end
+
+  end
+end

--- a/lib/kafka/protocol/encoder.rb
+++ b/lib/kafka/protocol/encoder.rb
@@ -30,7 +30,7 @@ module Kafka
       # @param boolean [Boolean]
       # @return [nil]
       def write_boolean(boolean)
-        write(boolean ? write_int8(1) : write_int8(0))
+        boolean ? write_int8(1) : write_int8(0)
       end
 
       # Writes an 8-bit integer to the IO object.

--- a/lib/kafka/protocol/encoder.rb
+++ b/lib/kafka/protocol/encoder.rb
@@ -30,7 +30,6 @@ module Kafka
       # @param boolean [Boolean]
       # @return [nil]
       def write_boolean(boolean)
-        # Note: 0x1 is represented by 1 byte when being written into the socket
         write(boolean ? write_int8(1) : write_int8(0))
       end
 

--- a/lib/kafka/protocol/encoder.rb
+++ b/lib/kafka/protocol/encoder.rb
@@ -30,7 +30,8 @@ module Kafka
       # @param boolean [Boolean]
       # @return [nil]
       def write_boolean(boolean)
-        write(boolean ? 0x1 : 0x0)
+        # Note: 0x1 is represented by 1 byte when being written into the socket
+        write(boolean ? write_int8(1) : write_int8(0))
       end
 
       # Writes an 8-bit integer to the IO object.

--- a/spec/functional/api_versions_spec.rb
+++ b/spec/functional/api_versions_spec.rb
@@ -7,10 +7,10 @@ describe "API Versions API", functional: true do
   end
 
   example "checks cluster API support" do
-    expect(kafka.support_api?(Kafka::Protocol::PRODUCE_API)).to eql(true)
-    expect(kafka.support_api?(Kafka::Protocol::PRODUCE_API, 0)).to eql(true)
-    expect(kafka.support_api?(Kafka::Protocol::PRODUCE_API, 100)).to eql(false)
-    expect(kafka.support_api?(100)).to eql(false)
-    expect(kafka.support_api?(100, 100)).to eql(false)
+    expect(kafka.supports_api?(Kafka::Protocol::PRODUCE_API)).to eql(true)
+    expect(kafka.supports_api?(Kafka::Protocol::PRODUCE_API, 0)).to eql(true)
+    expect(kafka.supports_api?(Kafka::Protocol::PRODUCE_API, 100)).to eql(false)
+    expect(kafka.supports_api?(100)).to eql(false)
+    expect(kafka.supports_api?(100, 100)).to eql(false)
   end
 end

--- a/spec/functional/api_versions_spec.rb
+++ b/spec/functional/api_versions_spec.rb
@@ -5,4 +5,12 @@ describe "API Versions API", functional: true do
     expect(produce_api.min_version).to eq 0
     expect(produce_api.max_version).to be >= 2
   end
+
+  example "checks cluster API support" do
+    expect(kafka.support_api?(Kafka::Protocol::PRODUCE_API)).to eql(true)
+    expect(kafka.support_api?(Kafka::Protocol::PRODUCE_API, 0)).to eql(true)
+    expect(kafka.support_api?(Kafka::Protocol::PRODUCE_API, 100)).to eql(false)
+    expect(kafka.support_api?(100)).to eql(false)
+    expect(kafka.support_api?(100, 100)).to eql(false)
+  end
 end

--- a/spec/functional/topic_management_spec.rb
+++ b/spec/functional/topic_management_spec.rb
@@ -32,17 +32,4 @@ describe "Topic management API", functional: true do
     kafka.create_partitions_for(topic, num_partitions: 10)
     expect(kafka.partitions_for(topic)).to eq 10
   end
-
-  example "validate partition creation" do
-    unless kafka.supports_api?(Kafka::Protocol::CREATE_PARTITIONS_API)
-      skip("This Kafka version not support ")
-    end
-    topic = generate_topic_name
-
-    kafka.create_topic(topic, num_partitions: 3)
-    expect(kafka.partitions_for(topic)).to eq 3
-
-    kafka.create_partitions_for(topic, num_partitions: 10, validate_only: true)
-    expect(kafka.partitions_for(topic)).to eq 3
-  end
 end

--- a/spec/functional/topic_management_spec.rb
+++ b/spec/functional/topic_management_spec.rb
@@ -21,7 +21,7 @@ describe "Topic management API", functional: true do
   end
 
   example "create partitions" do
-    unless kafka.support_api?(Kafka::Protocol::CREATE_PARTITIONS_API)
+    unless kafka.supports_api?(Kafka::Protocol::CREATE_PARTITIONS_API)
       skip("This Kafka version not support ")
     end
     topic = generate_topic_name
@@ -34,7 +34,7 @@ describe "Topic management API", functional: true do
   end
 
   example "validate partition creation" do
-    unless kafka.support_api?(Kafka::Protocol::CREATE_PARTITIONS_API)
+    unless kafka.supports_api?(Kafka::Protocol::CREATE_PARTITIONS_API)
       skip("This Kafka version not support ")
     end
     topic = generate_topic_name

--- a/spec/functional/topic_management_spec.rb
+++ b/spec/functional/topic_management_spec.rb
@@ -21,6 +21,9 @@ describe "Topic management API", functional: true do
   end
 
   example "create partitions" do
+    unless kafka.support_api?(Kafka::Protocol::CREATE_PARTITIONS_API)
+      skip("This Kafka version not support ")
+    end
     topic = generate_topic_name
 
     kafka.create_topic(topic, num_partitions: 3)
@@ -31,6 +34,9 @@ describe "Topic management API", functional: true do
   end
 
   example "validate partition creation" do
+    unless kafka.support_api?(Kafka::Protocol::CREATE_PARTITIONS_API)
+      skip("This Kafka version not support ")
+    end
     topic = generate_topic_name
 
     kafka.create_topic(topic, num_partitions: 3)

--- a/spec/functional/topic_management_spec.rb
+++ b/spec/functional/topic_management_spec.rb
@@ -19,4 +19,24 @@ describe "Topic management API", functional: true do
     kafka.delete_topic(topic)
     expect(kafka.has_topic?(topic)).to eql(false)
   end
+
+  example "create partitions" do
+    topic = generate_topic_name
+
+    kafka.create_topic(topic, num_partitions: 3)
+    expect(kafka.partitions_for(topic)).to eq 3
+
+    kafka.create_partitions_for(topic, num_partitions: 10)
+    expect(kafka.partitions_for(topic)).to eq 10
+  end
+
+  example "validate partition creation" do
+    topic = generate_topic_name
+
+    kafka.create_topic(topic, num_partitions: 3)
+    expect(kafka.partitions_for(topic)).to eq 3
+
+    kafka.create_partitions_for(topic, num_partitions: 10, validate_only: true)
+    expect(kafka.partitions_for(topic)).to eq 3
+  end
 end


### PR DESCRIPTION
### Proposed usage
```ruby
client.create_partitions_for("topic", num_partitions: 10)
```
This API is available after Kafka 1.0.0. The API is implemented based on [official documentation](https://kafka.apache.org/protocol#The_Messages_CreatePartitions). Currently, the interface doesn't support custom partition assignments because I don't think it aligns with the goal of the gem.  