### PR TITLE
Give ProcessingErrors a meaningful message, derived from their causal exception

### DIFF
--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -13,7 +13,13 @@ module Kafka
       @partition = partition
       @offset = offset
 
-      super()
+      #
+      # ProcessingErrors are only ever used to wrap exceptions raised
+      # by a consumer whilst processing messages dispatched to it; it
+      # is therefore safe to assume that ProcessingErrors will always
+      # have a meaningful causal exception
+      #
+      super($!.inspect)
     end
   end
 


### PR DESCRIPTION
@dasch - I think there's a wider discussion to be had about the nature and use of `ProcessingErrors` in this gem, but in the meantime I thought it might be useful to make them a tad more useful and user friendly by giving them a meaningful message _(a message derived from the causal "nested" or "wrapped" exception raised by the event consumer)_

So, let's say I have a consumer like this:

```ruby
consumer.each_message do |message|
  raise "BLEGGA"
end
```

... then in a `pry` session for instance, the diff would look like this:

```diff
--- Kafka::ProcessingError: Kafka::ProcessingError
+++ Kafka::ProcessingError: #<RuntimeError: BLEGGA>
from ~/Workarea/misc/ruby-kafka/processing_error.rb:38:in `rescue in <main>'
```

... and when running the consumer as a regular Ruby script, it would look like:

```diff
--- processing_error.rb:38:in `rescue in <main>': Kafka::ProcessingError (Kafka::ProcessingError)
+++ processing_error.rb:38:in `rescue in <main>': #<RuntimeError: BLEGGA> (Kafka::ProcessingError)
	from processing_error.rb:35:in `<main>'
```

So all in all a lot easier to get to the root cause of the problem!

The two places where `ProcessingErrors` are being raised are...

1. [`Kafka::Consumer#each_message`](https://github.com/zendesk/ruby-kafka/blob/master/lib/kafka/consumer.rb#L233-L239)
1. [`Kafka::Consumer#each_batch`](https://github.com/zendesk/ruby-kafka/blob/master/lib/kafka/consumer.rb#L311-L319)

... so the assumption about there always being a causal exception - on which my code change depends - is a valid one.  Note that a further refactor could be to pass the causal exception into the initializer for `ProcessingErrors`, instead of using the `$!` global variable, but I'll only do that once I've gauged your appetite for this change.
