### PR TITLE
Produce operation fails on retry

### DIFF
--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -19,7 +19,8 @@ module Kafka
 
     # @return [String]
     def to_s
-      "#{connection} (node_id=#{@node_id.inspect})"
+      #"#{connection} (node_id=#{@node_id.inspect})"
+      "(node_id=#{@node_id.inspect})"
     end
 
     # @return [nil]

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -357,7 +357,14 @@ module Kafka
           @logger.error "Failed to fetch metadata from #{node}: #{e}"
           errors << [node, e]
         ensure
-          broker.disconnect unless broker.nil?
+          begin
+            broker.disconnect unless broker.nil?
+          rescue => e
+            # Failure #2
+            # borker wansn't nil
+            # Connection refused - connect(2) for
+            # And it wasn't trying to connnect to the rest of the seed brokers
+          end
         end
       end
 

--- a/lib/kafka/produce_operation.rb
+++ b/lib/kafka/produce_operation.rb
@@ -100,6 +100,19 @@ module Kafka
 
           handle_response(broker, response) if response
         rescue ConnectionError => e
+          # Failure #1 - broker.to_s on connection
+          # Connection refused - connect(2) for
+          #
+          #  "/Users/michal.wrobel/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/ruby-kafka-0.5.3/lib/kafka/connection.rb:139:in `rescue in open'",
+          #  "/Users/michal.wrobel/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/ruby-kafka-0.5.3/lib/kafka/connection.rb:118:in `open'",
+          #  "/Users/michal.wrobel/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/ruby-kafka-0.5.3/lib/kafka/connection.rb:95:in `block in send_request'",
+          #  "/Users/michal.wrobel/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/ruby-kafka-0.5.3/lib/kafka/instrumenter.rb:21:in `instrument'",
+          #  "/Users/michal.wrobel/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/ruby-kafka-0.5.3/lib/kafka/connection.rb:94:in `send_request'",
+          #  "/Users/michal.wrobel/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/ruby-kafka-0.5.3/lib/kafka/sasl_authenticator.rb:39:in `authenticate!'",
+          #  "/Users/michal.wrobel/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/ruby-kafka-0.5.3/lib/kafka/connection_builder.rb:25:in `build_connection'",
+          #  "/Users/michal.wrobel/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/ruby-kafka-0.5.3/lib/kafka/broker.rb:159:in `connection'",
+          #  "/Users/michal.wrobel/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/ruby-kafka-0.5.3/lib/kafka/broker.rb:22:in `to_s'",
+          #  "/Users/michal.wrobel/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/ruby-kafka-0.5.3/lib/kafka/produce_operation.rb:103:in `rescue in block in send_buffered_messages'",
           @logger.error "Could not connect to broker #{broker}: #{e}"
 
           # Mark the cluster as stale in order to force a cluster metadata refresh.


### PR DESCRIPTION
## What happened:

When rebooting kafka broker, sync producer was failing to retry sending messages. (I assume it only fails for clusters that require authentication)

FYI: This is just an illustration where I found the problems, when I was manually testing that scenario against integration cluster.

This was the first exception I got when producing a message:

```
Kafka::ConnectionError: Connection refused - connect(2) for {}

/gems/ruby-kafka-0.5.2/lib/kafka/connection.rb:139 in rescue in open
/gems/ruby-kafka-0.5.2/lib/kafka/connection.rb:118 in open
/gems/ruby-kafka-0.5.2/lib/kafka/connection.rb:95 in block in send_request
/gems/activesupport-5.1.4/lib/active_support/notifications.rb:168 in instrument
/gems/ruby-kafka-0.5.2/lib/kafka/instrumenter.rb:19 in instrument
/gems/ruby-kafka-0.5.2/lib/kafka/connection.rb:94 in send_request
/gems/ruby-kafka-0.5.2/lib/kafka/sasl_authenticator.rb:39 in authenticate!
/gems/ruby-kafka-0.5.2/lib/kafka/connection_builder.rb:25 in build_connection
/gems/ruby-kafka-0.5.2/lib/kafka/broker.rb:141 in connection
/gems/ruby-kafka-0.5.2/lib/kafka/broker.rb:22 in to_s
/gems/ruby-kafka-0.5.2/lib/kafka/produce_operation.rb:103 in rescue in block in send_buffered_messages
/gems/ruby-kafka-0.5.2/lib/kafka/produce_operation.rb:82 in block in send_buffered_messages
/gems/ruby-kafka-0.5.2/lib/kafka/produce_operation.rb:81 in each
/gems/ruby-kafka-0.5.2/lib/kafka/produce_operation.rb:81 in send_buffered_messages
/gems/ruby-kafka-0.5.2/lib/kafka/produce_operation.rb:47 in block in execute
/gems/activesupport-5.1.4/lib/active_support/notifications.rb:168 in instrument
/gems/ruby-kafka-0.5.2/lib/kafka/instrumenter.rb:19 in instrument
/gems/ruby-kafka-0.5.2/lib/kafka/produce_operation.rb:41 in execute
/gems/ruby-kafka-0.5.2/lib/kafka/producer.rb:303 in block in deliver_messages_with_retries
/gems/ruby-kafka-0.5.2/lib/kafka/producer.rb:291 in loop
/gems/ruby-kafka-0.5.2/lib/kafka/producer.rb:291 in deliver_messages_with_retries
/gems/ruby-kafka-0.5.2/lib/kafka/producer.rb:241 in block in deliver_messages
/gems/activesupport-5.1.4/lib/active_support/notifications.rb:168 in instrument
/gems/ruby-kafka-0.5.2/lib/kafka/instrumenter.rb:19 in instrument
/gems/ruby-kafka-0.5.2/lib/kafka/producer.rb:234 in deliver_messages
```

Initial exception was indicating that the problem was with the
`broker.to_s`, which was failing, and was prohibiting setting stale on the cluster.

Once I "fixed" that, there was also an issue with `cluster.fetch_cluster_info`
method, which was failing on the broker that was being rebooted (`ensure close`).

This PR is only to indicate the problems, and to get some guidance on how to fix it properly. 