### PR TITLE
support PLAINTEXT and SSL for scheme

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -14,7 +14,7 @@ require "kafka/sasl_authenticator"
 
 module Kafka
   class Client
-    URI_SCHEMES = ["kafka", "kafka+ssl"]
+    URI_SCHEMES = ["kafka", "kafka+ssl", "plaintext", "ssl"]
 
     # Initializes a new Kafka client.
     #
@@ -647,6 +647,12 @@ module Kafka
         connection = "kafka://" + connection unless connection =~ /:\/\//
         uri = URI.parse(connection)
         uri.port ||= 9092 # Default Kafka port.
+        case uri.scheme
+        when 'plaintext'
+          uri.scheme = 'kafka'
+        when 'ssl'
+          uri.scheme = 'kafka+ssl'
+        end
 
         unless URI_SCHEMES.include?(uri.scheme)
           raise Kafka::Error, "invalid protocol `#{uri.scheme}` in `#{connection}`"

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -8,6 +8,14 @@ describe Kafka::Client do
       Kafka::Client.new(seed_brokers: ["kafka+ssl://kafka"])
     }.not_to raise_exception
 
+    expect(
+      Kafka::Client.new(seed_brokers: ["PLAINTEXT://kafka"]).instance_variable_get(:@seed_brokers).first.scheme
+    ).to eq 'kafka'
+
+    expect(
+      Kafka::Client.new(seed_brokers: ["SSL://kafka"]).instance_variable_get(:@seed_brokers).first.scheme
+    ).to eq 'kafka+ssl'
+
     expect {
       Kafka::Client.new(seed_brokers: ["http://kafka"])
     }.to raise_exception(Kafka::Error, "invalid protocol `http` in `http://kafka`")


### PR DESCRIPTION
Hi,

I would like to reuse zookeeper's cluster information as kafka's connection information.

