### PR TITLE
Retry another error case in `create_topic`

### DIFF
--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -187,6 +187,11 @@ module Kafka
         sleep 1
 
         retry
+      rescue Kafka::UnknownTopicOrPartition
+        @logger.warn "Topic `#{name}` not yet created, waiting 1s..."
+        sleep 1
+
+        retry
       end
 
       @logger.info "Topic `#{name}` was created"


### PR DESCRIPTION
If UnknownTopicOrPartition is raised we still want to retry. It's probably because the topic has not yet been created.