### PR TITLE
Add a statsd= method in the datadog integration

### DIFF
--- a/lib/kafka/datadog.rb
+++ b/lib/kafka/datadog.rb
@@ -32,6 +32,11 @@ module Kafka
         @statsd ||= ::Datadog::Statsd.new(host, port, namespace: namespace, tags: tags)
       end
 
+      def statsd=(statsd)
+        clear
+        @statsd = statsd
+      end
+
       def host
         @host ||= ::Datadog::Statsd::DEFAULT_HOST
       end


### PR DESCRIPTION
If an application has a configured statsd client from elsewhere for publishing Datadog stats, allows it to be used for Kafka stats too.