### PR TITLE
Exponential backoff for pauses

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -123,12 +123,22 @@ module Kafka
     #
     # @param topic [String]
     # @param partition [Integer]
-    # @param timeout [Integer] the number of seconds to pause the partition for,
+    # @param timeout [nil, Integer] the number of seconds to pause the partition for,
     #   or `nil` if the partition should not be automatically resumed.
+    # @param max_timeout [nil, Integer] the maximum number of seconds to pause for,
+    #   or `nil` if no maximum should be enforced.
     # @param exponential_backoff [Boolean] whether to enable exponential backoff.
     # @return [nil]
-    def pause(topic, partition, timeout: nil, exponential_backoff: false)
-      pause_for(topic, partition).pause!(timeout: timeout, exponential_backoff: exponential_backoff)
+    def pause(topic, partition, timeout: nil, max_timeout: nil, exponential_backoff: false)
+      if max_timeout && !exponential_backoff
+        raise ArgumentError, "`max_timeout` only makes sense when `exponential_backoff` is enabled"
+      end
+
+      pause_for(topic, partition).pause!(
+        timeout: timeout,
+        max_timeout: max_timeout,
+        exponential_backoff: exponential_backoff,
+      )
     end
 
     # Resume processing of a topic partition.

--- a/lib/kafka/pause.rb
+++ b/lib/kafka/pause.rb
@@ -1,0 +1,73 @@
+module Kafka
+  # Manages the pause state of a partition.
+  #
+  # The processing of messages in a partition can be paused, e.g. if there was
+  # an exception during processing. This could be caused by a downstream service
+  # not being available. A typical way of solving such an issue is to back off
+  # for a little while and then try again. In order to do that, _pause_ the
+  # partition.
+  class Pause
+    def initialize(clock: Time)
+      @clock = clock
+      @started_at = nil
+      @pauses = 0
+      @timeout = nil
+      @exponential_backoff = false
+    end
+
+    # Mark the partition as paused.
+    #
+    # If exponential backoff is enabled, each subsequent pause of a partition will
+    # cause a doubling of the actual timeout, i.e. for pause number _n_, the actual
+    # timeout will be _2^n * timeout_.
+    #
+    # Only when {#reset!} is called is this state cleared.
+    #
+    # @param timeout [nil, Integer] if specified, the partition will automatically
+    #   resume after this many seconds.
+    # @param exponential_backoff [Boolean] whether to enable exponential timeouts.
+    def pause!(timeout: nil, exponential_backoff: false)
+      @started_at = @clock.now
+      @timeout = timeout
+      @exponential_backoff = exponential_backoff
+      @pauses += 1
+    end
+
+    # Resumes the partition.
+    #
+    # The number of pauses is still retained, and if the partition is paused again
+    # it may be with an exponential backoff.
+    def resume!
+      @started_at = nil
+      @timeout = nil
+    end
+
+    # Whether the partition is currently paused.
+    def paused?
+      # This is nil if we're not currently paused.
+      return false if @started_at.nil?
+
+      # If no timeout is set we pause forever.
+      return true if @timeout.nil?
+
+      !expired?
+    end
+
+    # Whether the pause has expired.
+    def expired?
+      !@timeout.nil? && @clock.now >= ends_at
+    end
+
+    # Resets the pause state, ensuring that the next pause is not exponential.
+    def reset!
+      @pauses = 0
+    end
+
+    private
+
+    def ends_at
+      backoff_factor = @exponential_backoff ? 2**(@pauses - 1) : 1
+      @started_at + (backoff_factor * @timeout)
+    end
+  end
+end

--- a/spec/pause_spec.rb
+++ b/spec/pause_spec.rb
@@ -1,0 +1,38 @@
+describe Kafka::Pause do
+  describe "#paused?" do
+    let(:clock) { double(:clock, now: 30) }
+    let(:pause) { Kafka::Pause.new(clock: clock) }
+
+    it "returns true if no timeout was specified" do
+      pause.pause!
+      expect(pause.paused?).to eq true
+    end
+
+    it "returns true if the timeout has not yet passed" do
+      pause.pause!(timeout: 10)
+
+      allow(clock).to receive(:now) { 39 }
+
+      expect(pause.paused?).to eq true
+    end
+
+    it "returns false if the timeout has passed" do
+      pause.pause!(timeout: 10)
+
+      allow(clock).to receive(:now) { 40 }
+
+      expect(pause.paused?).to eq false
+    end
+
+    it "doubles the timeout when a pause is renewed" do
+      pause.pause!(timeout: 10)
+
+      pause.resume!
+
+      pause.pause!(timeout: 10)
+
+      allow(clock).to receive(:now) { 50 }
+      expect(pause.paused?).to eq false
+    end
+  end
+end


### PR DESCRIPTION
When enabled, exponential backoff will cause the pause timeout to double each time a partition is paused, until a message from the partition has been successfully processed, at which time the backoff is reset. It's possible to set a max timeout, above which we'll never pause a partition.

This will allow configuring a low initial timeout but still avoid overwhelming downstream services.

Example usage:

```ruby
begin
  consumer.each_message do |message|
    ...
  end
rescue Kafka::ProcessingError => e
  # Pause for 1s initially, then double to 2s, 4s, etc., all the way up to 64s, but not higher.
  consumer.pause(e.topic, e.partition, timeout: 1, max_timeout: 64, exponential_backoff: true)
end
```