### PR TITLE
Alter topic configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A Ruby client library for [Apache Kafka](http://kafka.apache.org/), a distribute
     9. [Security](#security)
         1. [Encryption and Authentication using SSL](#encryption-and-authentication-using-ssl)
         2. [Authentication using SASL](#authentication-using-sasl)
+    10. [Topic management](#topic-management)
 4. [Design](#design)
     1. [Producer Design](#producer-design)
     2. [Asynchronous Producer Design](#asynchronous-producer-design)
@@ -965,6 +966,81 @@ kafka = Kafka.new(
   # ...
 )
 ```
+
+### Topic management
+
+Beside the main functionalities, ruby-kafka supports some interfaces to support topic management. The list of topic configurations could be found at [Kafka documentation](https://kafka.apache.org/documentation/#topicconfigs)
+
+#### List all topics
+
+Return an array of topic names.
+
+```ruby
+kafka = Kafka.new(["kafka:9092"])
+kafka.topics
+# => ["topic1", "topic2", "topic3"]
+```
+
+#### Create a topic
+
+```ruby
+kafka = Kafka.new(["kafka:9092"])
+kafka.create_topic('topic')
+# => true
+```
+
+By default, the new topic has 1 partition, replication factor 1 and default configs from the brokers. Those configurations are customizable:
+
+```ruby
+kafka = Kafka.new(["kafka:9092"])
+kafka.create_topic(
+    'topic',
+    num_partitions: 3,
+    replication_factor: 2,
+    config: {
+      'max.message.bytes' => 100000
+    }
+)
+# => true
+```
+
+#### Create more partitions for a topic
+
+After a topic is created, you can increase the number of partitions for the topic. The new number of partitions must be creater than the current one.
+
+```ruby
+kafka = Kafka.new(["kafka:9092"])
+kafka.create_partitions_for('topic', num_partitions: 10)
+# => true
+```
+
+#### Fetch a topic configurations (alpha feature)
+
+```ruby
+kafka = Kafka.new(["kafka:9092"])
+kafka.describe_topic('topic', ['max.message.bytes', 'retention.ms'])
+# => {"max.message.bytes"=>"100000", "retention.ms"=>"604800000"}
+```
+
+#### Alter a topic (alpha feature)
+
+Update the topic configurations. **NOTE**: This feature is for advanced usage. If you misconfigure something, there would be some unexpected behaviors.
+
+```ruby
+kafka = Kafka.new(["kafka:9092"])
+kafka.alter_topic('topic', 'max.message.bytes' => 100000, 'retention.ms' => 604800000)
+# => true
+```
+
+#### Delete a topic
+
+```ruby
+kafka = Kafka.new(["kafka:9092"])
+kafka.delete_topic('topic')
+# => true
+```
+
+After a topic is marked deleted, Kafka only hides it from clients. It would take a while before a topic is completely deleted.
 
 ## Design
 

--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -132,6 +132,12 @@ module Kafka
       send_request(request)
     end
 
+    def alter_configs(**options)
+      request = Protocol::AlterConfigsRequest.new(**options)
+
+      send_request(request)
+    end
+
     def create_partitions(**options)
       request = Protocol::CreatePartitionsRequest.new(**options)
 

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -520,6 +520,26 @@ module Kafka
       @cluster.describe_topic(name, configs)
     end
 
+    # Alter the configuration of a topic.
+    #
+    # Change the topic configuration. Configuration names
+    # refer to [Kafka's topic-level configs](https://kafka.apache.org/documentation/#topicconfigs).
+    #
+    # @note This is an alpha level API and is subject to change.
+    #
+    # @example Describing the cleanup policy config of a topic
+    #   kafka = Kafka.new(["kafka1:9092"])
+    #   kafka.alter_topic("my-topic", "cleanup.policy" => "delete",
+    #   "max.message.byte" => "100000")
+    #
+    # @param name [String] the name of the topic.
+    # @param configs [Hash<String, String>] hash of desired config names
+    # name values.
+    # @return [nil]
+    def alter_topic(name, configs = {})
+      @cluster.alter_topic(name, configs)
+    end
+
     # Create partitions for a topic.
     #
     # @param name [String] the name of the topic.

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -235,6 +235,23 @@ module Kafka
       end
     end
 
+    def alter_topic(name, configs = {})
+      options = {
+        resources: [[Kafka::Protocol::RESOURCE_TYPE_TOPIC, name, configs]]
+      }
+      broker = controller_broker
+
+      @logger.info "Fetching topic `#{name}`'s configs using controller broker #{broker}"
+
+      response = broker.alter_configs(**options)
+
+      response.resources.each do |resource|
+        Protocol.handle_error(resource.error_code, resource.error_message)
+      end
+
+      nil
+    end
+
     def create_partitions_for(name, num_partitions:, timeout:)
       options = {
         topics: [[name, num_partitions, nil]],

--- a/lib/kafka/protocol.rb
+++ b/lib/kafka/protocol.rb
@@ -28,6 +28,7 @@ module Kafka
     CREATE_TOPICS_API = 19
     DELETE_TOPICS_API = 20
     DESCRIBE_CONFIGS_API = 32
+    ALTER_CONFIGS_API = 33
     CREATE_PARTITIONS_API = 37
 
     # A mapping from numeric API keys to symbolic API names.
@@ -170,5 +171,7 @@ require "kafka/protocol/delete_topics_request"
 require "kafka/protocol/delete_topics_response"
 require "kafka/protocol/describe_configs_request"
 require "kafka/protocol/describe_configs_response"
+require "kafka/protocol/alter_configs_request"
+require "kafka/protocol/alter_configs_response"
 require "kafka/protocol/create_partitions_request"
 require "kafka/protocol/create_partitions_response"

--- a/lib/kafka/protocol/alter_configs_request.rb
+++ b/lib/kafka/protocol/alter_configs_request.rb
@@ -1,0 +1,38 @@
+module Kafka
+  module Protocol
+
+    class AlterConfigsRequest
+      def initialize(resources:)
+        @resources = resources
+      end
+
+      def api_key
+        ALTER_CONFIGS_API
+      end
+
+      def api_version
+        0
+      end
+
+      def response_class
+        Protocol::AlterConfigsResponse
+      end
+
+      def encode(encoder)
+        encoder.write_array(@resources) do |type, name, configs|
+          encoder.write_int8(type)
+          encoder.write_string(name)
+
+          configs = configs.to_a
+          encoder.write_array(configs) do |config_name, config_value|
+            encoder.write_string(config_name)
+            encoder.write_string(config_value)
+          end
+        end
+        # validate_only. We'll skip this feature.
+        encoder.write_boolean(false)
+      end
+    end
+
+  end
+end

--- a/lib/kafka/protocol/alter_configs_request.rb
+++ b/lib/kafka/protocol/alter_configs_request.rb
@@ -25,6 +25,10 @@ module Kafka
 
           configs = configs.to_a
           encoder.write_array(configs) do |config_name, config_value|
+            # Config value is nullable. In other cases, we must write the
+            # stringified value.
+            config_value = config_value.to_s unless config_value.nil?
+
             encoder.write_string(config_name)
             encoder.write_string(config_value)
           end

--- a/lib/kafka/protocol/alter_configs_response.rb
+++ b/lib/kafka/protocol/alter_configs_response.rb
@@ -1,0 +1,47 @@
+module Kafka
+  module Protocol
+    class AlterConfigsResponse
+      class ResourceDescription
+        attr_reader :name, :type, :error_code, :error_message
+
+        def initialize(name:, type:, error_code:, error_message:)
+          @name = name
+          @type = type
+          @error_code = error_code
+          @error_message = error_message
+        end
+      end
+
+      attr_reader :resources
+
+      def initialize(throttle_time_ms:, resources:)
+        @throttle_time_ms = throttle_time_ms
+        @resources = resources
+      end
+
+      def self.decode(decoder)
+        throttle_time_ms = decoder.int32
+        resources = decoder.array do
+          error_code = decoder.int16
+          error_message = decoder.string
+
+          resource_type = decoder.int8
+          if Kafka::Protocol::RESOURCE_TYPES[resource_type].nil?
+            raise Kafka::ProtocolError, "Resource type not supported: #{resource_type}"
+          end
+          resource_name = decoder.string
+
+          ResourceDescription.new(
+            type: RESOURCE_TYPES[resource_type],
+            name: resource_name,
+            error_code: error_code,
+            error_message: error_message
+          )
+        end
+
+        new(throttle_time_ms: throttle_time_ms, resources: resources)
+      end
+    end
+
+  end
+end

--- a/lib/kafka/protocol/create_topics_request.rb
+++ b/lib/kafka/protocol/create_topics_request.rb
@@ -27,8 +27,8 @@ module Kafka
           # Replica assignments. We don't care.
           encoder.write_array([])
 
-          # Config entries. We don't care.
           encoder.write_array(config.fetch(:config)) do |config_name, config_value|
+            config_value = config_value.to_s unless config_value.nil?
             encoder.write_string(config_name)
             encoder.write_string(config_value)
           end

--- a/spec/functional/topic_management_spec.rb
+++ b/spec/functional/topic_management_spec.rb
@@ -69,7 +69,7 @@ describe "Topic management API", functional: true do
     kafka.create_topic(topic, num_partitions: 3)
     kafka.alter_topic(
       topic,
-      'retention.ms' => '1234567',
+      'retention.ms' => 1234567,
       'max.message.bytes' => '987654'
     )
 

--- a/spec/functional/topic_management_spec.rb
+++ b/spec/functional/topic_management_spec.rb
@@ -49,7 +49,7 @@ describe "Topic management API", functional: true do
 
   example "describe a topic" do
     unless kafka.supports_api?(Kafka::Protocol::DESCRIBE_CONFIGS_API)
-      skip("This Kafka version not support ")
+      skip("This Kafka version not support DescribeConfig API")
     end
 
     topic = generate_topic_name
@@ -58,5 +58,23 @@ describe "Topic management API", functional: true do
     expect(configs.keys).to eql(%w(retention.ms retention.bytes))
     expect(configs['retention.ms']).to be_a(String)
     expect(configs['retention.bytes']).to be_a(String)
+  end
+
+  example "alter a topic configuration" do
+    unless kafka.supports_api?(Kafka::Protocol::ALTER_CONFIGS_API)
+      skip("This Kafka version not support AlterTopic API")
+    end
+
+    topic = generate_topic_name
+    kafka.create_topic(topic, num_partitions: 3)
+    kafka.alter_topic(
+      topic,
+      'retention.ms' => '1234567',
+      'max.message.bytes' => '987654'
+    )
+
+    configs = kafka.describe_topic(topic, %w(retention.ms max.message.bytes))
+    expect(configs['retention.ms']).to eql('1234567')
+    expect(configs['max.message.bytes']).to eql('987654')
   end
 end

--- a/spec/functional/topic_management_spec.rb
+++ b/spec/functional/topic_management_spec.rb
@@ -62,7 +62,7 @@ describe "Topic management API", functional: true do
 
   example "alter a topic configuration" do
     unless kafka.supports_api?(Kafka::Protocol::ALTER_CONFIGS_API)
-      skip("This Kafka version not support AlterTopic API")
+      skip("This Kafka version not support AlterConfig API")
     end
 
     topic = generate_topic_name


### PR DESCRIPTION
This PR enables the ability to update a topic's configurations via AlterConfigs API. Suggested by https://github.com/zendesk/ruby-kafka/issues/559. The usage of this API:

```ruby
kafka = Kafka.new("kafka:9092")
kafka.alter_topic("hello", 'max.message.bytes' => 1234567, 'retention.ms' => '1234567')
```