### PR TITLE
Add frozen_string_literal comment to all files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/benchmarks/message_encoding.rb
+++ b/benchmarks/message_encoding.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka"
 
 ready "message serialization" do

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "kafka"

--- a/examples/consumer-group.rb
+++ b/examples/consumer-group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
 
 require "kafka"

--- a/examples/firehose-consumer.rb
+++ b/examples/firehose-consumer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
 
 require "kafka"

--- a/examples/firehose-producer.rb
+++ b/examples/firehose-producer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
 
 require "kafka"

--- a/examples/simple-consumer.rb
+++ b/examples/simple-consumer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Consumes lines from a Kafka partition and writes them to STDOUT.
 #
 # You need to define the environment variable KAFKA_BROKERS for this

--- a/examples/simple-producer.rb
+++ b/examples/simple-producer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Reads lines from STDIN, writing them to Kafka.
 #
 # You need to define the environment variable KAFKA_BROKERS for this

--- a/examples/ssl-producer.rb
+++ b/examples/ssl-producer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Reads lines from STDIN, writing them to Kafka.
 
 $LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))

--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/version"
 
 module Kafka

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thread"
 
 module Kafka

--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "logger"
 require "kafka/connection"
 require "kafka/protocol"

--- a/lib/kafka/broker_pool.rb
+++ b/lib/kafka/broker_pool.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/broker"
 
 module Kafka

--- a/lib/kafka/broker_uri.rb
+++ b/lib/kafka/broker_uri.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "uri"
 
 module Kafka

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/ssl_context"
 require "kafka/cluster"
 require "kafka/producer"

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/broker_pool"
 require "set"
 

--- a/lib/kafka/compression.rb
+++ b/lib/kafka/compression.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/snappy_codec"
 require "kafka/gzip_codec"
 require "kafka/lz4_codec"

--- a/lib/kafka/compressor.rb
+++ b/lib/kafka/compressor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/compression"
 
 module Kafka

--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "stringio"
 require "kafka/socket_with_timeout"
 require "kafka/ssl_socket_with_timeout"

--- a/lib/kafka/connection_builder.rb
+++ b/lib/kafka/connection_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   class ConnectionBuilder
     def initialize(client_id:, logger:, instrumenter:, connect_timeout:, socket_timeout:, ssl_context:, sasl_authenticator:)

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/consumer_group"
 require "kafka/offset_manager"
 require "kafka/fetcher"

--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "set"
 require "kafka/round_robin_assignment_strategy"
 

--- a/lib/kafka/datadog.rb
+++ b/lib/kafka/datadog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "datadog/statsd"
 rescue LoadError

--- a/lib/kafka/fetch_operation.rb
+++ b/lib/kafka/fetch_operation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/fetched_batch"
 
 module Kafka

--- a/lib/kafka/fetched_batch.rb
+++ b/lib/kafka/fetched_batch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
 
   # An ordered sequence of messages fetched from a Kafka partition.

--- a/lib/kafka/fetched_message.rb
+++ b/lib/kafka/fetched_message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   class FetchedMessage
     # @return [String] the name of the topic that the message was written to.

--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/fetch_operation"
 
 module Kafka

--- a/lib/kafka/gzip_codec.rb
+++ b/lib/kafka/gzip_codec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   class GzipCodec
     def codec_id

--- a/lib/kafka/heartbeat.rb
+++ b/lib/kafka/heartbeat.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   class Heartbeat
     def initialize(group:, interval:)

--- a/lib/kafka/instrumenter.rb
+++ b/lib/kafka/instrumenter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   class Instrumenter
     NAMESPACE = "kafka"

--- a/lib/kafka/lz4_codec.rb
+++ b/lib/kafka/lz4_codec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   class LZ4Codec
     def codec_id

--- a/lib/kafka/message_buffer.rb
+++ b/lib/kafka/message_buffer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/protocol/message"
 
 module Kafka

--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
 
   # Manages a consumer's position in partitions, figures out where to resume processing

--- a/lib/kafka/partitioner.rb
+++ b/lib/kafka/partitioner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "zlib"
 
 module Kafka

--- a/lib/kafka/pause.rb
+++ b/lib/kafka/pause.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   # Manages the pause state of a partition.
   #

--- a/lib/kafka/pending_message.rb
+++ b/lib/kafka/pending_message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   class PendingMessage
     attr_reader :value, :key, :topic, :partition, :partition_key, :create_time, :bytesize

--- a/lib/kafka/pending_message_queue.rb
+++ b/lib/kafka/pending_message_queue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
 
   class PendingMessageQueue

--- a/lib/kafka/produce_operation.rb
+++ b/lib/kafka/produce_operation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/protocol/message_set"
 
 module Kafka

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "set"
 require "kafka/partitioner"
 require "kafka/message_buffer"

--- a/lib/kafka/protocol.rb
+++ b/lib/kafka/protocol.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
 
   # The protocol layer of the library.

--- a/lib/kafka/protocol/alter_configs_request.rb
+++ b/lib/kafka/protocol/alter_configs_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/alter_configs_response.rb
+++ b/lib/kafka/protocol/alter_configs_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class AlterConfigsResponse

--- a/lib/kafka/protocol/api_versions_request.rb
+++ b/lib/kafka/protocol/api_versions_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/api_versions_response.rb
+++ b/lib/kafka/protocol/api_versions_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/consumer_group_protocol.rb
+++ b/lib/kafka/protocol/consumer_group_protocol.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class ConsumerGroupProtocol

--- a/lib/kafka/protocol/create_partitions_request.rb
+++ b/lib/kafka/protocol/create_partitions_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/create_partitions_response.rb
+++ b/lib/kafka/protocol/create_partitions_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/create_topics_request.rb
+++ b/lib/kafka/protocol/create_topics_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/create_topics_response.rb
+++ b/lib/kafka/protocol/create_topics_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/decoder.rb
+++ b/lib/kafka/protocol/decoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/delete_topics_request.rb
+++ b/lib/kafka/protocol/delete_topics_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/delete_topics_response.rb
+++ b/lib/kafka/protocol/delete_topics_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/describe_configs_request.rb
+++ b/lib/kafka/protocol/describe_configs_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/describe_configs_response.rb
+++ b/lib/kafka/protocol/describe_configs_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class DescribeConfigsResponse

--- a/lib/kafka/protocol/encoder.rb
+++ b/lib/kafka/protocol/encoder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "stringio"
 
 module Kafka

--- a/lib/kafka/protocol/fetch_request.rb
+++ b/lib/kafka/protocol/fetch_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/fetch_response.rb
+++ b/lib/kafka/protocol/fetch_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/protocol/message_set"
 
 module Kafka

--- a/lib/kafka/protocol/group_coordinator_request.rb
+++ b/lib/kafka/protocol/group_coordinator_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class GroupCoordinatorRequest

--- a/lib/kafka/protocol/group_coordinator_response.rb
+++ b/lib/kafka/protocol/group_coordinator_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class GroupCoordinatorResponse

--- a/lib/kafka/protocol/heartbeat_request.rb
+++ b/lib/kafka/protocol/heartbeat_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class HeartbeatRequest

--- a/lib/kafka/protocol/heartbeat_response.rb
+++ b/lib/kafka/protocol/heartbeat_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class HeartbeatResponse

--- a/lib/kafka/protocol/join_group_request.rb
+++ b/lib/kafka/protocol/join_group_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/protocol/consumer_group_protocol"
 
 module Kafka

--- a/lib/kafka/protocol/join_group_response.rb
+++ b/lib/kafka/protocol/join_group_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class JoinGroupResponse

--- a/lib/kafka/protocol/leave_group_request.rb
+++ b/lib/kafka/protocol/leave_group_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class LeaveGroupRequest

--- a/lib/kafka/protocol/leave_group_response.rb
+++ b/lib/kafka/protocol/leave_group_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class LeaveGroupResponse

--- a/lib/kafka/protocol/list_offset_request.rb
+++ b/lib/kafka/protocol/list_offset_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     # A request to list the available offsets for a set of topics/partitions.

--- a/lib/kafka/protocol/list_offset_response.rb
+++ b/lib/kafka/protocol/list_offset_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/member_assignment.rb
+++ b/lib/kafka/protocol/member_assignment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class MemberAssignment

--- a/lib/kafka/protocol/message.rb
+++ b/lib/kafka/protocol/message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "stringio"
 require "zlib"
 

--- a/lib/kafka/protocol/message_set.rb
+++ b/lib/kafka/protocol/message_set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class MessageSet

--- a/lib/kafka/protocol/metadata_request.rb
+++ b/lib/kafka/protocol/metadata_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class MetadataRequest

--- a/lib/kafka/protocol/metadata_response.rb
+++ b/lib/kafka/protocol/metadata_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/offset_commit_request.rb
+++ b/lib/kafka/protocol/offset_commit_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class OffsetCommitRequest

--- a/lib/kafka/protocol/offset_commit_response.rb
+++ b/lib/kafka/protocol/offset_commit_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class OffsetCommitResponse

--- a/lib/kafka/protocol/offset_fetch_request.rb
+++ b/lib/kafka/protocol/offset_fetch_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class OffsetFetchRequest

--- a/lib/kafka/protocol/offset_fetch_response.rb
+++ b/lib/kafka/protocol/offset_fetch_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class OffsetFetchResponse

--- a/lib/kafka/protocol/produce_request.rb
+++ b/lib/kafka/protocol/produce_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "stringio"
 
 module Kafka

--- a/lib/kafka/protocol/produce_response.rb
+++ b/lib/kafka/protocol/produce_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class ProduceResponse

--- a/lib/kafka/protocol/request_message.rb
+++ b/lib/kafka/protocol/request_message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class RequestMessage

--- a/lib/kafka/protocol/sasl_handshake_request.rb
+++ b/lib/kafka/protocol/sasl_handshake_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/sasl_handshake_response.rb
+++ b/lib/kafka/protocol/sasl_handshake_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
 

--- a/lib/kafka/protocol/sync_group_request.rb
+++ b/lib/kafka/protocol/sync_group_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Protocol
     class SyncGroupRequest

--- a/lib/kafka/protocol/sync_group_response.rb
+++ b/lib/kafka/protocol/sync_group_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/protocol/member_assignment"
 
 module Kafka

--- a/lib/kafka/round_robin_assignment_strategy.rb
+++ b/lib/kafka/round_robin_assignment_strategy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/protocol/member_assignment"
 
 module Kafka

--- a/lib/kafka/sasl/gssapi.rb
+++ b/lib/kafka/sasl/gssapi.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Sasl
     class Gssapi

--- a/lib/kafka/sasl/plain.rb
+++ b/lib/kafka/sasl/plain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   module Sasl
     class Plain

--- a/lib/kafka/sasl/scram.rb
+++ b/lib/kafka/sasl/scram.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'securerandom'
 require 'base64'
 

--- a/lib/kafka/sasl_authenticator.rb
+++ b/lib/kafka/sasl_authenticator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'kafka/sasl/plain'
 require 'kafka/sasl/gssapi'
 require 'kafka/sasl/scram'

--- a/lib/kafka/snappy_codec.rb
+++ b/lib/kafka/snappy_codec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   class SnappyCodec
     def codec_id

--- a/lib/kafka/socket_with_timeout.rb
+++ b/lib/kafka/socket_with_timeout.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "socket"
 
 module Kafka

--- a/lib/kafka/ssl_context.rb
+++ b/lib/kafka/ssl_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "openssl"
 
 module Kafka

--- a/lib/kafka/ssl_socket_with_timeout.rb
+++ b/lib/kafka/ssl_socket_with_timeout.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "socket"
 
 module Kafka

--- a/lib/kafka/statsd.rb
+++ b/lib/kafka/statsd.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require "statsd"
 rescue LoadError

--- a/lib/kafka/version.rb
+++ b/lib/kafka/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Kafka
   VERSION = "0.6.0.beta4"
 end

--- a/lib/ruby-kafka.rb
+++ b/lib/ruby-kafka.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Needed because the gem is registered as `ruby-kafka`.
 
 require "kafka"

--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)

--- a/spec/async_producer_spec.rb
+++ b/spec/async_producer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FakeInstrumenter
   Metric = Struct.new(:name, :payload)
 

--- a/spec/broker_pool_spec.rb
+++ b/spec/broker_pool_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::BrokerPool do
   let(:connection_builder) { double('connection_builder') }
   let(:connection) { double('connection') }

--- a/spec/broker_spec.rb
+++ b/spec/broker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/protocol/message"
 
 describe Kafka::Broker do

--- a/spec/broker_uri_spec.rb
+++ b/spec/broker_uri_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::BrokerUri do
   it "accepts valid seed brokers URIs" do
     expect(Kafka::BrokerUri.parse("kafka://hello").to_s).to eq "kafka://hello:9092"

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::Cluster do
   describe "#get_leader" do
     let(:broker) { double(:broker) }

--- a/spec/compression_spec.rb
+++ b/spec/compression_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::Compression do
   Kafka::Compression.codecs.each do |codec_name|
     describe codec_name.to_s do

--- a/spec/compressor_spec.rb
+++ b/spec/compressor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::Compressor do
   describe ".compress" do
     let(:instrumenter) { Kafka::Instrumenter.new(client_id: "test") }

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fake_server'
 
 describe Kafka::Connection do

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "timecop"
 
 describe Kafka::Consumer do

--- a/spec/datadog_spec.rb
+++ b/spec/datadog_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/datadog"
 require "fake_datadog_agent"
 

--- a/spec/fake_broker.rb
+++ b/spec/fake_broker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FakeBroker
   def initialize
     @messages = {}

--- a/spec/fake_datadog_agent.rb
+++ b/spec/fake_datadog_agent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "socket"
 
 class FakeDatadogAgent

--- a/spec/fake_server.rb
+++ b/spec/fake_server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FakeServer
   SUPPORTED_MECHANISMS = ['PLAIN', 'SCRAM-SHA-256', 'SCRAM-SHA-512']
 

--- a/spec/fake_statsd_agent.rb
+++ b/spec/fake_statsd_agent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "socket"
 
 class FakeStatsdAgent

--- a/spec/fetched_batch_spec.rb
+++ b/spec/fetched_batch_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::FetchedBatch do
   describe "#offset_lag" do
     context "empty batch" do

--- a/spec/functional/api_versions_spec.rb
+++ b/spec/functional/api_versions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "API Versions API", functional: true do
   example "getting the API versions that are supported by the Kafka brokers" do
     produce_api = kafka.apis.find {|v| v.api_key == 0 }

--- a/spec/functional/async_producer_spec.rb
+++ b/spec/functional/async_producer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "Producer API", functional: true do
   let(:producer) { kafka.async_producer(max_retries: 1, retry_backoff: 0) }
   let(:topic) { create_random_topic(num_partitions: 3) }

--- a/spec/functional/batch_consumer_spec.rb
+++ b/spec/functional/batch_consumer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "Batch Consumer API", functional: true do
   example "consuming messages using the batch API" do
     num_partitions = 15

--- a/spec/functional/client_spec.rb
+++ b/spec/functional/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "timecop"
 
 describe "Producer API", functional: true do

--- a/spec/functional/compression_spec.rb
+++ b/spec/functional/compression_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "snappy"
 
 describe "Compression", functional: true do

--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "Consumer API", functional: true do
   let(:offset_retention_time) { 30 }
 

--- a/spec/functional/datadog_spec.rb
+++ b/spec/functional/datadog_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/datadog"
 require "socket"
 require "fake_datadog_agent"

--- a/spec/functional/fetch_spec.rb
+++ b/spec/functional/fetch_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "Fetch API", functional: true do
   example "fetching from a non-existing topic when auto-create is enabled" do
     topic = "rand#{rand(1000)}"

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "Producer API", functional: true do
   let(:producer) { kafka.producer(max_retries: 3, retry_backoff: 1) }
 

--- a/spec/functional/statsd_spec.rb
+++ b/spec/functional/statsd_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "kafka/statsd"
 require "socket"
 require "fake_statsd_agent"

--- a/spec/functional/topic_management_spec.rb
+++ b/spec/functional/topic_management_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "Topic management API", functional: true do
   example "creating topics" do
     topic = generate_topic_name

--- a/spec/fuzz/consumer_group_spec.rb
+++ b/spec/fuzz/consumer_group_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "Consumer groups", fuzz: true do
   let(:logger) { LOGGER }
   let(:num_messages) { 10_000 }

--- a/spec/message_buffer_spec.rb
+++ b/spec/message_buffer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::MessageBuffer do
   let(:buffer) { Kafka::MessageBuffer.new }
 

--- a/spec/offset_manager_spec.rb
+++ b/spec/offset_manager_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'timecop'
 
 describe Kafka::OffsetManager do

--- a/spec/partitioner_spec.rb
+++ b/spec/partitioner_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::Partitioner, "#partition_for_key" do
   let(:partitioner) { Kafka::Partitioner }
   let(:message) { double(:message, key: nil, partition_key: "yolo") }

--- a/spec/pause_spec.rb
+++ b/spec/pause_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::Pause do
   describe "#paused?" do
     let(:clock) { double(:clock, now: 30) }

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "fake_broker"
 require "timecop"
 

--- a/spec/protocol/decoder_spec.rb
+++ b/spec/protocol/decoder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::Protocol::Decoder do
   describe "#read" do
     it "reads the specified number of bytes" do

--- a/spec/protocol/message_set_spec.rb
+++ b/spec/protocol/message_set_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::Protocol::Message do
   include Kafka::Protocol
 

--- a/spec/protocol/message_spec.rb
+++ b/spec/protocol/message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::Protocol::Message do
   it "encodes and decodes messages" do
     message = Kafka::Protocol::Message.new(

--- a/spec/protocol/sasl_handshake_request_spec.rb
+++ b/spec/protocol/sasl_handshake_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::Protocol::SaslHandshakeRequest do
   describe "#api_key" do
     let(:request) { Kafka::Protocol::SaslHandshakeRequest.new('GSSAPI') }

--- a/spec/round_robin_assignment_strategy_spec.rb
+++ b/spec/round_robin_assignment_strategy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::RoundRobinAssignmentStrategy do
   it "assigns all partitions" do
     cluster = double(:cluster)

--- a/spec/sasl_authenticator_spec.rb
+++ b/spec/sasl_authenticator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fake_server'
 
 describe Kafka::SaslAuthenticator do

--- a/spec/socket_with_timeout_spec.rb
+++ b/spec/socket_with_timeout_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::SocketWithTimeout, ".open" do
   it "times out if the server doesn't accept the connection within the timeout" do
     host = "172.16.0.0" # this address is non-routable!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "active_support/notifications"
 require "kafka"

--- a/spec/ssl_context_spec.rb
+++ b/spec/ssl_context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::SslContext do
   it "raises ArgumentError if a client cert but no client cert key is passed" do
     expect {

--- a/spec/ssl_socket_with_timeout_spec.rb
+++ b/spec/ssl_socket_with_timeout_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Kafka::SSLSocketWithTimeout, ".open" do
   it "times out if the server doesn't accept the connection within the timeout" do
     host = "172.16.0.0" # this address is non-routable!


### PR DESCRIPTION
Comment added to all files using:

```bash
rubocop --only Style/FrozenStringLiteralComment --auto-correct
```

(updated to add blank line after comments)