### PR TITLE
Fix a bug in Pause

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -162,7 +162,8 @@ module Kafka
     # @param partition [Integer]
     # @return [Boolean] true if the partition is paused, false otherwise.
     def paused?(topic, partition)
-      pause_for(topic, partition).paused?
+      pause = pause_for(topic, partition)
+      pause.paused? && !pause.expired?
     end
 
     # Fetches and enumerates the messages in the topics that the consumer group

--- a/lib/kafka/pause.rb
+++ b/lib/kafka/pause.rb
@@ -47,15 +47,11 @@ module Kafka
       @max_timeout = nil
     end
 
-    # Whether the partition is currently paused.
+    # Whether the partition is currently paused. The pause may have expired, in which
+    # case {#expired?} should be checked as well.
     def paused?
       # This is nil if we're not currently paused.
-      return false if @started_at.nil?
-
-      # If no timeout is set we pause forever.
-      return true if @timeout.nil?
-
-      !expired?
+      !@started_at.nil?
     end
 
     def pause_duration
@@ -68,7 +64,11 @@ module Kafka
 
     # Whether the pause has expired.
     def expired?
-      !@timeout.nil? && @clock.now >= ends_at
+      # We never expire the pause if timeout is nil.
+      return false if @timeout.nil?
+
+      # Have we passed the end of the pause duration?
+      @clock.now >= ends_at
     end
 
     # Resets the pause state, ensuring that the next pause is not exponential.

--- a/spec/pause_spec.rb
+++ b/spec/pause_spec.rb
@@ -1,40 +1,79 @@
 # frozen_string_literal: true
 
+require "ostruct"
+
 describe Kafka::Pause do
+  let(:clock) { OpenStruct.new(now: 30) }
+  let(:pause) { Kafka::Pause.new(clock: clock) }
+
   describe "#paused?" do
-    let(:clock) { double(:clock, now: 30) }
-    let(:pause) { Kafka::Pause.new(clock: clock) }
-
-    it "returns true if no timeout was specified" do
+    it "returns true if we're paused" do
       pause.pause!
-      expect(pause.paused?).to eq true
-    end
-
-    it "returns true if the timeout has not yet passed" do
-      pause.pause!(timeout: 10)
-
-      allow(clock).to receive(:now) { 39 }
 
       expect(pause.paused?).to eq true
     end
 
-    it "returns false if the timeout has passed" do
-      pause.pause!(timeout: 10)
-
-      allow(clock).to receive(:now) { 40 }
-
-      expect(pause.paused?).to eq false
-    end
-
-    it "doubles the timeout when a pause is renewed" do
-      pause.pause!(timeout: 10)
-
+    it "returns false if we're not paused" do
+      pause.pause!
       pause.resume!
 
+      expect(pause.paused?).to eq false
+    end
+  end
+
+  describe "#expired?" do
+    it "returns false if no timeout was specified" do
+      pause.pause!
+      expect(pause.expired?).to eq false
+    end
+
+    it "returns false if the timeout has not yet passed" do
       pause.pause!(timeout: 10)
 
-      allow(clock).to receive(:now) { 50 }
-      expect(pause.paused?).to eq false
+      clock.now = 39
+
+      expect(pause.expired?).to eq false
+    end
+
+    it "returns true if the timeout has passed" do
+      pause.pause!(timeout: 10)
+
+      clock.now = 40
+
+      expect(pause.expired?).to eq true
+    end
+
+    context "with exponential backoff" do
+      it "doubles the timeout with each attempt" do
+        pause.pause!(timeout: 10, exponential_backoff: true)
+        pause.resume!
+        pause.pause!(timeout: 10, exponential_backoff: true)
+        pause.resume!
+        pause.pause!(timeout: 10, exponential_backoff: true)
+
+        expect(pause.expired?).to eq false
+
+        clock.now += 10 + 20 + 40
+
+        expect(pause.expired?).to eq true
+        expect(pause.expired?).to eq true
+      end
+
+      it "never pauses for more than the max timeout" do
+        pause.pause!(timeout: 10, max_timeout: 30, exponential_backoff: true)
+        pause.resume!
+        pause.pause!(timeout: 10, max_timeout: 30, exponential_backoff: true)
+        pause.resume!
+        pause.pause!(timeout: 10, max_timeout: 30, exponential_backoff: true)
+
+        clock.now += 29
+
+        expect(pause.expired?).to eq false
+
+        clock.now += 1
+
+        expect(pause.expired?).to eq true
+      end
     end
   end
 end


### PR DESCRIPTION
`#paused?` should not include the call to `#expired?`, as we need to be able to tell whether a partition is currently in a paused state but needs to be resumed because the pause duration has expired.