### PR TITLE
Add list groups API

### DIFF
--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -146,6 +146,12 @@ module Kafka
       send_request(request)
     end
 
+    def list_groups
+      request = Protocol::ListGroupsRequest.new
+
+      send_request(request)
+    end
+
     def api_versions
       request = Protocol::ApiVersionsRequest.new
 

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -559,6 +559,13 @@ module Kafka
       @cluster.list_topics
     end
 
+    # Lists all consumer groups in the cluster
+    #
+    # @return [Array<String>] the list of group ids
+    def groups
+      @cluster.list_groups
+    end
+
     def has_topic?(topic)
       @cluster.clear_target_topics
       @cluster.add_target_topics([topic])

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -337,6 +337,15 @@ module Kafka
       end.map(&:topic_name)
     end
 
+    def list_groups
+      refresh_metadata_if_necessary!
+      cluster_info.brokers.map do |broker|
+        response = connect_to_broker(broker.node_id).list_groups
+        Protocol.handle_error(response.error_code)
+        response.groups.map(&:group_id)
+      end.flatten.uniq
+    end
+
     def disconnect
       @broker_pool.close
     end

--- a/lib/kafka/protocol.rb
+++ b/lib/kafka/protocol.rb
@@ -25,6 +25,7 @@ module Kafka
     HEARTBEAT_API = 12
     LEAVE_GROUP_API = 13
     SYNC_GROUP_API = 14
+    LIST_GROUPS_API = 16
     SASL_HANDSHAKE_API = 17
     API_VERSIONS_API = 18
     CREATE_TOPICS_API = 19
@@ -177,3 +178,5 @@ require "kafka/protocol/alter_configs_request"
 require "kafka/protocol/alter_configs_response"
 require "kafka/protocol/create_partitions_request"
 require "kafka/protocol/create_partitions_response"
+require "kafka/protocol/list_groups_request"
+require "kafka/protocol/list_groups_response"

--- a/lib/kafka/protocol/list_groups_request.rb
+++ b/lib/kafka/protocol/list_groups_request.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Kafka
+  module Protocol
+    class ListGroupsRequest
+      def api_key
+        LIST_GROUPS_API
+      end
+
+      def api_version
+        0
+      end
+
+      def response_class
+        Protocol::ListGroupsResponse
+      end
+
+      def encode(encoder)
+        # noop
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/list_groups_response.rb
+++ b/lib/kafka/protocol/list_groups_response.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Kafka
+  module Protocol
+    class ListGroupsResponse
+      class GroupEntry
+        attr_reader :group_id, :protocol_type
+
+        def initialize(group_id:, protocol_type:)
+          @group_id = group_id
+          @protocol_type = protocol_type
+        end
+      end
+
+      attr_reader :error_code, :groups
+
+      def initialize(error_code:, groups:)
+        @error_code = error_code
+        @groups = groups
+      end
+
+      def self.decode(decoder)
+        error_code = decoder.int16
+        groups = decoder.array do
+          GroupEntry.new(
+            group_id: decoder.string,
+            protocol_type: decoder.string
+          )
+        end
+
+        new(error_code: error_code, groups: groups)
+      end
+    end
+  end
+end

--- a/spec/functional/client_spec.rb
+++ b/spec/functional/client_spec.rb
@@ -22,6 +22,20 @@ describe "Producer API", functional: true do
     expect(kafka.has_topic?(deleted_topic)).to eq false
   end
 
+  example "listing consumer groups working in the cluster" do
+    kafka = Kafka.new(KAFKA_BROKERS, logger: LOGGER)
+
+    group_id = "consumer-group-#{rand(1000)}"
+    kafka.deliver_message('test', topic: topic)
+    consumer = kafka.consumer(group_id: group_id)
+    consumer.subscribe(topic)
+    consumer.each_message do |msg|
+      consumer.stop
+    end
+
+    expect(kafka.groups).to include(group_id)
+  end
+
   example "fetching the partition count for a topic" do
     expect(kafka.partitions_for(topic)).to eq 3
   end


### PR DESCRIPTION
Adds the `ListGroups` api request and response.

See the [docs](https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-ListGroupsRequest)