### PR TITLE
Fix degrading performance problem

### DIFF
--- a/lib/kafka/protocol/record_batch.rb
+++ b/lib/kafka/protocol/record_batch.rb
@@ -189,6 +189,8 @@ module Kafka
           first_sequence: first_sequence,
           max_timestamp: max_timestamp
         )
+      rescue EOFError
+        raise InsufficientDataMessage, 'Partial trailing record detected!'
       end
 
       def mark_control_record

--- a/spec/functional/fetch_spec.rb
+++ b/spec/functional/fetch_spec.rb
@@ -25,4 +25,37 @@ describe "Fetch API", functional: true do
 
     expect(messages).to eq []
   end
+
+  example "Number of fetching requests should be small" do
+    kafka = ::Kafka::Client.new(
+      seed_brokers: ['localhost:9092']
+    )
+    total_messages = 1000
+    message_size = 50
+
+    # Create test data
+    producer = kafka.producer
+    topic = "topic-#{SecureRandom.uuid}"
+    kafka.create_topic(topic, num_partitions: 3)
+
+    total_messages.times do |index|
+      producer.produce('a' * message_size, topic: topic)
+    end
+    producer.deliver_messages
+
+    batch_count = 0
+    ActiveSupport::Notifications.subscribe 'fetch_batch.consumer.kafka' do |*args|
+      batch_count += 1
+    end
+    # Test consuming
+    consumer = kafka.consumer(group_id: SecureRandom.uuid)
+    consumer.subscribe(topic)
+    message_count = 0
+    consumer.each_message do
+      message_count += 1
+      break if message_count == total_messages
+    end
+
+    expect(batch_count).to eql(3)
+  end
 end

--- a/spec/protocol/fetch_response_spec.rb
+++ b/spec/protocol/fetch_response_spec.rb
@@ -1,0 +1,364 @@
+require 'spec_helper'
+
+describe Kafka::Protocol::FetchResponse do
+  let(:headers) do
+    [
+      # Throttle time
+      0x00, 0x00, 0x00, 0x00,
+      # Number of topics
+      0x00, 0x00, 0x00, 0x01,
+      # Topic name: hello
+      0x00, 0x05, 0x68, 0x65, 0x6c, 0x6c, 0x6f,
+      # Number of partitions
+      0x00, 0x00, 0x00, 0x01,
+      # Partition 0
+      0x00, 0x00, 0x00, 0x00,
+      # Error
+      0x00, 0x00,
+      # High Watermark Offset
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      # Last Stable Offset
+      0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00,
+      # Aborted transactions
+      0x00, 0x00, 0x00, 0x00
+    ]
+  end
+
+  let(:first_record) {
+    [
+      # First offset
+      0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+      # Record Batch Size
+      0x0, 0x0, 0x0, 0x43,
+      # Partition Leader Epoch
+      0x0, 0x0, 0x0, 0x0,
+      # Magic byte
+      0x2,
+      # CRC
+      0x0, 0x0, 0x0, 0x0,
+      # Attributes
+      0x0, 0b00000000,
+      # Last offset delta
+      0x0, 0x0, 0x0, 0x3,
+      # First timestamp
+      0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+      # Max timestamp
+      0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0,
+      # Producer ID
+      0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+      # Producer epoch
+      0x0, 0x0,
+      # First sequence
+      0x0, 0x0, 0x0, 0x0,
+      # Number of records
+      0x0, 0x0, 0x0, 0x1,
+      # Size
+      0x22,
+      # Attributes
+      0x1,
+      # Timestamp delta
+      0xd0, 0xf,
+      # Offset delta
+      0x2,
+      # Key
+      0xa,
+      0x68, 0x65, 0x6c, 0x6c, 0x6f,
+      # Value
+      0xa,
+      0x77, 0x6f, 0x72, 0x6c, 0x64,
+      # Header
+      0x0
+    ]
+  }
+
+  let(:second_record) {
+    [
+      # First offset
+      0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+      # Record Batch Size
+      0x0, 0x0, 0x0, 0x43,
+      # Partition Leader Epoch
+      0x0, 0x0, 0x0, 0x0,
+      # Magic byte
+      0x2,
+      # CRC
+      0x0, 0x0, 0x0, 0x0,
+      # Attributes
+      0x0, 0b00000000,
+      # Last offset delta
+      0x0, 0x0, 0x0, 0x3,
+      # First timestamp
+      0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+      # Max timestamp
+      0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0,
+      # Producer ID
+      0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+      # Producer epoch
+      0x0, 0x0,
+      # First sequence
+      0x0, 0x0, 0x0, 0x0,
+      # Number of records
+      0x0, 0x0, 0x0, 0x1,
+      # Size
+      0x22,
+      # Attributes
+      0x1,
+      # Timestamp delta
+      0xd0, 0xf,
+      # Offset delta
+      0x2,
+      # Key
+      0xa,
+      0x68, 0x69, 0x69, 0x69, 0x69,
+      # Value
+      0xa,
+      0x62, 0x79, 0x65, 0x65, 0x65,
+      # Header
+      0x0
+    ]
+  }
+
+  let(:message) {
+    [
+      # Offset
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x13,
+      # CRC
+      0x00, 0x00, 0x00, 0x00,
+      # Magic bytes
+      0x00,
+      # Attributes
+      0x00,
+      # Key
+      0xFF, 0xFF, 0xFF, 0xFF,
+      # Value
+      0x0, 0x0, 0x0, 0x5,
+      0x68, 0x65, 0x6c, 0x6c, 0x6f
+    ]
+  }
+
+  describe '.decode' do
+    describe 'Record Batch format' do
+      context 'single record batch' do
+        let(:response) do
+          [
+            headers,
+            # Record Batch Byte Size
+            0x0, 0x0, 0x0, 0x4f,
+            first_record
+          ].flatten
+        end
+        let(:decoder) do
+          ::Kafka::Protocol::Decoder.from_string(
+            response.pack("C*")
+          )
+        end
+
+        it 'decodes the fetch response' do
+          response = ::Kafka::Protocol::FetchResponse.decode(decoder)
+          expect(response.topics.length).to eql(1)
+          topic = response.topics.first
+
+          expect(topic.partitions.length).to eql(1)
+          partition = topic.partitions.first
+
+          expect(partition.partition).to eql(0)
+          expect(partition.error_code).to eql(0)
+          expect(partition.aborted_transactions).to eql([])
+          expect(partition.messages.length).to eql(1)
+
+          expect(partition.messages.first.key).to eql('hello')
+          expect(partition.messages.first.value).to eql('world')
+        end
+      end
+
+      context 'multiple full record batch' do
+        let(:response) do
+          [
+            headers,
+            # Record Batches Byte Size
+            0x0, 0x0, 0x0, 0x9e,
+            first_record,
+            second_record
+          ].flatten
+        end
+        let(:decoder) do
+          ::Kafka::Protocol::Decoder.from_string(
+            response.pack("C*")
+          )
+        end
+
+        it 'recognizes 2 record batches' do
+          response = ::Kafka::Protocol::FetchResponse.decode(decoder)
+          expect(response.topics.length).to eql(1)
+          topic = response.topics.first
+
+          expect(topic.partitions.length).to eql(1)
+          partition = topic.partitions.first
+
+          expect(partition.partition).to eql(0)
+          expect(partition.error_code).to eql(0)
+          expect(partition.aborted_transactions).to eql([])
+          expect(partition.messages.length).to eql(2)
+
+          expect(partition.messages[0].key).to eql('hello')
+          expect(partition.messages[0].value).to eql('world')
+
+          expect(partition.messages[1].key).to eql('hiiii')
+          expect(partition.messages[1].value).to eql('byeee')
+        end
+      end
+
+      context 'partial record batch' do
+        let(:response) do
+          [
+            headers,
+            # Record Batches Byte Size
+            0x0, 0x0, 0x0, 0xa0,
+            first_record,
+            second_record,
+            0x01, 0x02
+          ].flatten
+        end
+
+        let(:decoder) do
+          ::Kafka::Protocol::Decoder.from_string(
+            response.pack("C*")
+          )
+        end
+
+        it 'ignores the trailing incompleted record' do
+          response = ::Kafka::Protocol::FetchResponse.decode(decoder)
+          expect(response.topics.length).to eql(1)
+          topic = response.topics.first
+
+          expect(topic.partitions.length).to eql(1)
+          partition = topic.partitions.first
+
+          expect(partition.partition).to eql(0)
+          expect(partition.error_code).to eql(0)
+          expect(partition.aborted_transactions).to eql([])
+          expect(partition.messages.length).to eql(2)
+
+          expect(partition.messages[0].key).to eql('hello')
+          expect(partition.messages[0].value).to eql('world')
+
+          expect(partition.messages[1].key).to eql('hiiii')
+          expect(partition.messages[1].value).to eql('byeee')
+        end
+      end
+
+      context 'multiple partitions' do
+        let(:response) do
+          [
+            # Throttle time
+            0x00, 0x00, 0x00, 0x00,
+            # Number of topics
+            0x00, 0x00, 0x00, 0x01,
+            # Topic name: hello
+            0x00, 0x05, 0x68, 0x65, 0x6c, 0x6c, 0x6f,
+            # Number of partitions
+            0x00, 0x00, 0x00, 0x02,
+
+            # Partition 0
+            0x00, 0x00, 0x00, 0x00,
+            # Error
+            0x00, 0x00,
+            # High Watermark Offset
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            # Last Stable Offset
+            0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00,
+            # Aborted transactions
+            0x00, 0x00, 0x00, 0x00,
+            # Record Batches Byte Size
+            0x0, 0x0, 0x0, 0x50,
+            first_record,
+            # Partial record
+            0x1,
+
+            # Partition 1
+            0x00, 0x00, 0x00, 0x01,
+            # Error
+            0x00, 0x00,
+            # High Watermark Offset
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            # Last Stable Offset
+            0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00,
+            # Aborted transactions
+            0x00, 0x00, 0x00, 0x00,
+            # Record Batches Byte Size
+            0x0, 0x0, 0x0, 0x52,
+            second_record,
+            # Partial record
+            0x1, 0x2, 0x3,
+          ].flatten
+        end
+
+        let(:decoder) do
+          ::Kafka::Protocol::Decoder.from_string(
+            response.pack("C*")
+          )
+        end
+
+        it 'decodes completed record batch in both partitions' do
+          response = ::Kafka::Protocol::FetchResponse.decode(decoder)
+          expect(response.topics.length).to eql(1)
+          topic = response.topics.first
+
+          expect(topic.partitions.length).to eql(2)
+          partition = topic.partitions[0]
+
+          expect(partition.partition).to eql(0)
+          expect(partition.error_code).to eql(0)
+          expect(partition.aborted_transactions).to eql([])
+          expect(partition.messages.length).to eql(1)
+
+          expect(partition.messages[0].key).to eql('hello')
+          expect(partition.messages[0].value).to eql('world')
+
+          partition = topic.partitions[1]
+
+          expect(partition.partition).to eql(1)
+          expect(partition.error_code).to eql(0)
+          expect(partition.aborted_transactions).to eql([])
+          expect(partition.messages.length).to eql(1)
+
+          expect(partition.messages[0].key).to eql('hiiii')
+          expect(partition.messages[0].value).to eql('byeee')
+        end
+      end
+    end
+
+    describe 'Legacy MessageSet' do
+      let(:response) do
+        [
+          headers,
+          0x00, 0x00, 0x00, 0x1f,
+          message
+        ].flatten
+      end
+      let(:decoder) do
+        ::Kafka::Protocol::Decoder.from_string(
+          response.pack("C*")
+        )
+      end
+
+      it 'decodes the fetch response' do
+        response = ::Kafka::Protocol::FetchResponse.decode(decoder)
+
+        expect(response.topics.length).to eql(1)
+        topic = response.topics.first
+
+        expect(topic.partitions.length).to eql(1)
+        partition = topic.partitions[0]
+
+        expect(partition.partition).to eql(0)
+        expect(partition.error_code).to eql(0)
+        expect(partition.aborted_transactions).to eql([])
+        expect(partition.messages.length).to eql(1)
+        expect(partition.messages.first).to be_a(::Kafka::Protocol::Message)
+        expect(partition.messages[0].value).to eql('hello')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR is to fix the problem mentioned in https://github.com/zendesk/ruby-kafka/pull/548. New record batch format meets a serious problem with the performance. The client fires tons of fetch requests to Kafka, instead of working by batch. The main cause of this issue: FetchResponse doesn't handle the case that multiple record batches are tied together. This makes the client not aware of the number of record batches. In that case, we'll need to read to EOF and decode each record batch next to each.

In addition, there is a case which is not handled properly. Each record batch can contain in-completed series of bytes due to new max byte option in Fetch API v4. Those byte sequences doesn't provide any value and we just need to simply ignore them.

I had some benchmarks, to test out *raw fetching speed*:

- Before the fix:

```
Kafka version: 0.7.0.alpha2
 - 1000000 messages, 20 bytes each message
=> 152.63421600003494 seconds
 - 1000000 messages, 100 bytes each message
=> 244.34417100000428 seconds
 - 1000000 messages, 250 bytes each message
=> 300.691599996574 seconds
 - 1000000 messages, 500 bytes each message
=> 321.691599996574
```

- After the fix:

```
Kafka version: 0.7.0.alpha2
 - 1000000 messages, 20 bytes each message
=> 52.63421600003494 seconds
 - 1000000 messages, 100 bytes each message
=> 44.34417100000428 seconds
 - 1000000 messages, 250 bytes each message
=> 43.64991599996574 seconds
 - 1000000 messages, 500 bytes each message
=> 43.933405000017956 seconds
```

Comparing to other versions:

```
Kafka version: 0.6.0.beta2
 - 1000000 messages, 20 bytes each message
=> 43.417863000009675 seconds
 - 1000000 messages, 100 bytes each message
=> 41.23134899995057 seconds
 - 1000000 messages, 250 bytes each message
=> 38.98760399996536 seconds
 - 1000000 messages, 500 bytes each message
=> 40.007947999984026 seconds

Kafka version: 0.5.5
 - 1000000 messages, 20 bytes each message
=> 39.97198299999582 seconds
 - 1000000 messages, 100 bytes each message
=> 37.00100899999961 seconds
 - 1000000 messages, 250 bytes each message
=> 36.51904599997215 seconds
 - 1000000 messages, 500 bytes each message
=> 37.17629799997667 seconds
```

This is just raw fetching speed, which indicates the overhead of the fetching operation. The speed of new record batch is slightly slower than the previous version. In real case scenarios, there are other more important factors, which makes this overhead not significant to the overall consuming speed. But I'll try to optimize more.