### PR TITLE
More consistent heartbeat API with non-optional trigger

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -235,7 +235,7 @@ module Kafka
             mark_message_as_processed(message) if automatically_mark_as_processed
             @offset_manager.commit_offsets_if_necessary
 
-            @heartbeat.send_if_necessary
+            @heartbeat.trigger
 
             return if !@running
           end
@@ -330,7 +330,7 @@ module Kafka
 
           @offset_manager.commit_offsets_if_necessary
 
-          @heartbeat.send_if_necessary
+          @heartbeat.trigger
 
           return if !@running
         end
@@ -366,8 +366,12 @@ module Kafka
       @offset_manager.mark_as_processed(message.topic, message.partition, message.offset)
     end
 
-    def send_heartbeat_if_necessary
-      @heartbeat.send_if_necessary
+    def trigger_heartbeat
+      @heartbeat.trigger
+    end
+
+    def trigger_heartbeat!
+      @heartbeat.trigger!
     end
 
     private
@@ -492,7 +496,7 @@ module Kafka
 
       join_group unless @group.member?
 
-      @heartbeat.send_if_necessary
+      @heartbeat.trigger
 
       resume_paused_partitions!
 

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -374,6 +374,10 @@ module Kafka
       @heartbeat.trigger!
     end
 
+    # Aliases for the external API compatibility
+    alias send_heartbeat_if_necessary trigger_heartbeat
+    alias send_heartbeat trigger_heartbeat!
+
     private
 
     def consumer_loop

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -235,7 +235,7 @@ module Kafka
             mark_message_as_processed(message) if automatically_mark_as_processed
             @offset_manager.commit_offsets_if_necessary
 
-            @heartbeat.trigger
+            trigger_heartbeat
 
             return if !@running
           end
@@ -330,7 +330,7 @@ module Kafka
 
           @offset_manager.commit_offsets_if_necessary
 
-          @heartbeat.trigger
+          trigger_heartbeat
 
           return if !@running
         end
@@ -496,7 +496,7 @@ module Kafka
 
       join_group unless @group.member?
 
-      @heartbeat.trigger
+      trigger_heartbeat
 
       resume_paused_partitions!
 

--- a/lib/kafka/heartbeat.rb
+++ b/lib/kafka/heartbeat.rb
@@ -8,11 +8,13 @@ module Kafka
       @last_heartbeat = Time.now
     end
 
-    def send_if_necessary
-      if Time.now > @last_heartbeat + @interval
-        @group.heartbeat
-        @last_heartbeat = Time.now
-      end
+    def trigger!
+      @group.heartbeat
+      @last_heartbeat = Time.now
+    end
+
+    def trigger
+      trigger! if Time.now > @last_heartbeat + @interval
     end
   end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -287,4 +287,16 @@ describe Kafka::Consumer do
       consumer.trigger_heartbeat!
     end
   end
+
+  describe '#send_heartbeat_if_necessary' do
+    subject(:method_original_name) { consumer.method(:send_heartbeat_if_necessary).original_name }
+
+    it { expect(method_original_name).to eq(:trigger_heartbeat) }
+  end
+
+  describe '#send_heartbeat' do
+    subject(:method_original_name) { consumer.method(:send_heartbeat).original_name }
+
+    it { expect(method_original_name).to eq(:trigger_heartbeat!) }
+  end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -67,7 +67,7 @@ describe Kafka::Consumer do
     allow(group).to receive(:member?) { true }
     allow(group).to receive(:subscribed_partitions) { assigned_partitions }
 
-    allow(heartbeat).to receive(:send_if_necessary)
+    allow(heartbeat).to receive(:trigger)
 
     allow(fetcher).to receive(:data?) { fetched_batches.any? }
     allow(fetcher).to receive(:poll) { [:batches, fetched_batches] }
@@ -274,10 +274,17 @@ describe Kafka::Consumer do
     end
   end
 
-  describe "#send_heartbeat_if_necessary" do
+  describe "#trigger_heartbeat" do
     it "sends heartbeat if necessary" do
-      expect(heartbeat).to receive(:send_if_necessary)
-      consumer.send_heartbeat_if_necessary
+      expect(heartbeat).to receive(:trigger)
+      consumer.trigger_heartbeat
+    end
+  end
+
+  describe "#trigger_heartbeat!" do
+    it "always sends heartbeat" do
+      expect(heartbeat).to receive(:trigger!)
+      consumer.trigger_heartbeat!
     end
   end
 end


### PR DESCRIPTION
This PR provides following functionalities:
- Allows to use both "forceful" and "optional" version of the heartbeat trigger
- Provides that functionality on a consumer level via `trigger_heartbeat` and `trigger_heartbeat!`
- Fixes internal heartbeat usage so all the usages are via the heartbeat method. In case of further refactor, less places to change are needed

The bang/non-bang naming convention is based on the proposed improvement for racecar (https://github.com/zendesk/racecar/issues/61).

The naming was changed not to conflict with Ruby core method`#send`.