### PR TITLE
Delayed message processing offset manager bug

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -203,7 +203,9 @@ module Kafka
       consumer_loop do
         batches = fetch_batches
 
-        batches.each do |batch|
+        # make sure any old batches, fetched prior to the completion of a consumer group sync,
+        # are only processed if the batches are from brokers for which this broker is still responsible.
+        batches.select { |batch| @group.subscribed_partitions[batch.topic].include?(batch.partition) }.each do |batch|
           batch.messages.each do |message|
             notification = {
               topic: message.topic,
@@ -287,7 +289,9 @@ module Kafka
       consumer_loop do
         batches = fetch_batches
 
-        batches.each do |batch|
+        # make sure any old batches, fetched prior to the completion of a consumer group sync,
+        # are only processed if the batches are from brokers for which this broker is still responsible.
+        batches.select { |batch| @group.subscribed_partitions[batch.topic].include?(batch.partition) }.each do |batch|
           unless batch.empty?
             notification = {
               topic: batch.topic,


### PR DESCRIPTION
After upgrading from `v0.5.5` to `v0.6.3`, we experienced consumer offsets regressing on multiple occasions, which had very negative effects for our consumers and downstream systems.  It seems the root cause of these regressions comes from the `Fetcher` dequeuing batches which were originally enqueued _before_ a consumer balance synchronization operation finishes.

Because each consumer instance keeps track of its own offsets, committing them to remote kafka brokers after batches have been processed, offset contention can occur if and when multiple consumer instances are committing offsets for a single partition.  While the lead kafka broker for a specific partition will only be delivering messages to the _correctly assigned_ consumer instance, if a second consumer instance continues committing (stale) offsets values, the kafka cluster is vulnerable to initializing any new consumers for the partition with the wrong value after a deployment or recovery event.  Imagine the assigned consumer committing offsets for a partition with sequential values of 10, 20, 30, 40 then 50, reflecting the offset of the last message processed, while concurrently, an orphaned consumer which has bad data in its offset manager continues updating the brokers with offsets of 10, 10, 10, 10 and 10.  These commit messages from the two consumers are interleaved when received by the brokers, and thus, the broker alternates between storing the correct offset and the stale, incorrect offset.

How does this happen?

The `Fetcher` fetches message batches, and enqueues them for later processing.  Before the consumer group is able to process a batch, the partition balancing synchronization completes, assigning new partitions to the broker.  At this point, the offset manager clears any cached offsets, which in many circumstances makes sure that only offsets from the newly assigned partitions get stored and processed.  However, after the new partitions have been assigned, an old message batch from a partition which the broker is no longer responsible for can be dequeued and processed, at which point the offset manager now stores offsets of the partition the consumer instance is no longer responsible for.  Even though all message batches for the old partition fetched from the brokers _after_ the consumer balance sync event will go to a different broker, as expected, the old batches enqueued before the sync event cause problems.

The follow is an example including some debugging logging I added to investigate.  I have removed logging which doesn't pertain to this bug illustration:
```
I, [2018-05-25T13:29:35.864008 #38454]  INFO -- : Partitions assigned for `election`: 4, 1
D, [2018-05-25T13:29:35.864034 #38454]  DEBUG -- : ***Joining group - clear offsets excluding
D, [2018-05-25T13:29:35.864064 #38454]  DEBUG -- : ***Clearing offsets excluding {"election"=>[4, 1]}
D, [2018-05-25T13:29:35.864088 #38454]  DEBUG -- : ***Clearing offsets excluding: processed_offsets before [{"election"=>{5=>831}}]
D, [2018-05-25T13:29:35.864111 #38454]  DEBUG -- : ***Clearing offsets excluding: processed_offsets after [{"election"=>{}}]
...
D, [2018-05-25T13:29:36.443657 #38454] DEBUG -- : *** fetch_from_partition at 2018-05-25 13:29:36 -0400 - partition [4] - offset [758]
D, [2018-05-25T13:29:36.443688 #38454] DEBUG -- : *** fetch_from_partition at 2018-05-25 13:29:36 -0400 - partition [1] - offset [781]
D, [2018-05-25T13:29:36.443704 #38454] DEBUG -- : *** execute fetch_from_partition at 2018-05-25 13:29:36 -0400
D, [2018-05-25T13:29:36.443801 #38454] DEBUG -- : Sending fetch API request 11 to kafka_broker:9092
D, [2018-05-25T13:29:36.443953 #38454] DEBUG -- : Waiting for response 11 from kafka_broker:9092
D, [2018-05-25T13:29:36.445994 #38454] DEBUG -- : Received response 11 from kafka_broker:9092
D, [2018-05-25T13:29:36.446058 #38454] DEBUG -- : Fetching batches
D, [2018-05-25T13:29:36.446082 #38454] DEBUG -- : *** fetch_from_partition at 2018-05-25 13:29:36 -0400 - partition [4] - offset [759]
D, [2018-05-25T13:29:36.446101 #38454] DEBUG -- : *** fetch_from_partition at 2018-05-25 13:29:36 -0400 - partition [1] - offset [782]
D, [2018-05-25T13:29:36.446113 #38454] DEBUG -- : *** execute fetch_from_partition at 2018-05-25 13:29:36 -0400
...
```
At this point we see that partitions 1 and 4 for the topic `election` have been assigned to the consumer, and are being fetched (and thus enqueued).  We now start process these messages and updating the offsets.  All of this is as expected:
```
D, [2018-05-25T13:29:37.869693 #38454] DEBUG -- : Marking election/4:758 as processed
D, [2018-05-25T13:29:37.869806 #38454] DEBUG -- : Marking election/1:781 as processed
...
```
Later on, there is another consumer balance sync, and partitions 2 and 6 are assigned:
```
I, [2018-05-25T13:29:45.906939 #38454]  INFO -- : Partitions assigned for `election`: 2, 6
D, [2018-05-25T13:29:45.906962 #38454]  DEBUG -- : ***Joining group - clear offsets excluding
D, [2018-05-25T13:29:45.906981 #38454]  DEBUG -- : ***Clearing offsets excluding {"election"=>[2, 6]}
D, [2018-05-25T13:29:45.907121 #38454]  DEBUG -- : ***Clearing offsets excluding: processed_offsets before [{"election"=>{1=>785, 4=>776}}]
D, [2018-05-25T13:29:45.907155 #38454]  DEBUG -- : ***Clearing offsets excluding: processed_offsets after [{"election"=>{}}]
```
Again we clear the offset manager, which we can verify in the last line of the above logs.  However, now messages enqueued before the sync event from partition 1 are still being processed after this most recent sync event.  I've added logging to show the state of the offset manager before each message is processed:
```
D, [2018-05-25T13:29:45.909772 #38454] DEBUG -- : ***mark_as_processed. processed_offsets: [{"election"=>{}}]
D, [2018-05-25T13:29:45.909782 #38454] DEBUG -- : Marking election/1:785 as processed
D, [2018-05-25T13:29:45.909862 #38454] DEBUG -- : ***mark_as_processed. processed_offsets: [{"election"=>{1=>786}}]
D, [2018-05-25T13:29:45.909869 #38454] DEBUG -- : Marking election/1:786 as processed
D, [2018-05-25T13:29:45.909967 #38454] DEBUG -- : ***mark_as_processed. processed_offsets: [{"election"=>{1=>787}}]
D, [2018-05-25T13:29:45.909993 #38454] DEBUG -- : Marking election/1:787 as processed
D, [2018-05-25T13:29:45.910065 #38454] DEBUG -- : ***mark_as_processed. processed_offsets: [{"election"=>{1=>788}}]
D, [2018-05-25T13:29:45.910072 #38454] DEBUG -- : Marking election/1:788 as processed
```
At this point, the consumer is no longer responsible for partition 1, but has processed 4 old messages from it, and stored this offset in the offset manager.  Now we continue, correctly, to fetch and process batches from partitions 2 and 6:
```
D, [2018-05-25T13:29:46.559394 #38454] DEBUG -- : *** fetch_from_partition at 2018-05-25 13:29:46 -0400 - partition [2] - offset [779]
D, [2018-05-25T13:29:46.559407 #38454] DEBUG -- : *** fetch_from_partition at 2018-05-25 13:29:46 -0400 - partition [6] - offset [778]
D, [2018-05-25T13:29:46.559417 #38454] DEBUG -- : *** execute fetch_from_partition at 2018-05-25 13:29:46 -0400
...
D, [2018-05-25T13:29:47.914215 #38454] DEBUG -- : ***mark_as_processed. processed_offsets: [{"election"=>{1=>789}}]
D, [2018-05-25T13:29:47.914233 #38454] DEBUG -- : Marking election/2:779 as processed
D, [2018-05-25T13:29:49.919015 #38454] DEBUG -- : ***mark_as_processed. processed_offsets: [{"election"=>{1=>789, 2=>780}}]
D, [2018-05-25T13:29:49.919033 #38454] DEBUG -- : Marking election/2:780 as processed
```
No matter what happens now, those four old messages from partition 1 have corrupted the offset manager until the next consumer balance sync event, even though another consumer is correctly processing messages from partition 1 and committing correct offsets back to the broker.

What is the fix?

The simplest correction is to discard any batches from partitions which the consumer is not currently assigned when batches are being dequeued and processed.

I've opened this PR to merge into the `v0.6-stable` branch in hopes that it can help teams like ours which want to upgrade to `v0.6.x` rather than the unstable `v0.7.x`, or to help anyone who already is on version 6 and could benefit from closing the loophole here.  I am open to discussion of all sorts on this PR, including the best way to get it into the code base.