### PR TITLE
Add instrumenter and logger when async message delivery fails

### DIFF
--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -241,8 +241,10 @@ module Kafka
 
       def deliver_messages
         @producer.deliver_messages
-      rescue DeliveryFailed, ConnectionError
-        # Failed to deliver messages -- nothing to do but try again later.
+      rescue DeliveryFailed, ConnectionError => e
+        # Failed to deliver messages -- nothing to do but log and try again later.
+        @logger.error("Failed to asynchronously deliver messages: #{e.message}")
+        @instrumenter.instrument("error.async_producer", { error: e })
       end
 
       def threshold_reached?


### PR DESCRIPTION
I was wondering if there was a way to make async message delivery failures more accessible and came up with this approach. Now, when a `DeliveryFailed` or `ConnectionError` is raised after calling `deliver_messages` on the synchronous producer, it will logged to the console and instrumented so the user can learn what's causing message delivery to fail.

Do you think it's a good add? I personally think :+1: but interested in your feedback. Thanks! :) 