### PR TITLE
Support record headers

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -109,6 +109,7 @@ module Kafka
     #
     # @param value [String, nil] the message value.
     # @param key [String, nil] the message key.
+    # @param headers [Hash<String, String>] the headers for the message.
     # @param topic [String] the topic that the message should be written to.
     # @param partition [Integer, nil] the partition that the message should be written
     #   to, or `nil` if either `partition_key` is passed or the partition should be
@@ -118,16 +119,17 @@ module Kafka
     # @param retries [Integer] the number of times to retry the delivery before giving
     #   up.
     # @return [nil]
-    def deliver_message(value, key: nil, topic:, partition: nil, partition_key: nil, retries: 1)
+    def deliver_message(value, key: nil, headers: {}, topic:, partition: nil, partition_key: nil, retries: 1)
       create_time = Time.now
 
       message = PendingMessage.new(
-        value,
-        key,
-        topic,
-        partition,
-        partition_key,
-        create_time,
+        value: value,
+        key: key,
+        headers: headers,
+        topic: topic,
+        partition: partition,
+        partition_key: partition_key,
+        create_time: create_time
       )
 
       if partition.nil?

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -142,6 +142,7 @@ module Kafka
       buffer.write(
         value: message.value,
         key: message.key,
+        headers: message.headers,
         topic: message.topic,
         partition: partition,
         create_time: message.create_time,

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -37,6 +37,7 @@ module Kafka
   #       puts message.topic
   #       puts message.partition
   #       puts message.key
+  #       puts message.headers
   #       puts message.value
   #       puts message.offset
   #     end
@@ -213,6 +214,7 @@ module Kafka
               create_time: message.create_time,
               key: message.key,
               value: message.value,
+              headers: message.headers
             }
 
             # Instrument an event immediately so that subscribers don't have to wait until

--- a/lib/kafka/fetched_message.rb
+++ b/lib/kafka/fetched_message.rb
@@ -34,6 +34,11 @@ module Kafka
       @message.create_time
     end
 
+    # @return [Hash<String, String>] the headers of the message.
+    def headers
+      @message.headers
+    end
+
     # @return [Boolean] whether this record is a control record
     def is_control_record
       @message.is_control_record

--- a/lib/kafka/message_buffer.rb
+++ b/lib/kafka/message_buffer.rb
@@ -16,8 +16,8 @@ module Kafka
       @bytesize = 0
     end
 
-    def write(value:, key:, topic:, partition:, create_time: Time.now)
-      message = Protocol::Record.new(key: key, value: value, create_time: create_time)
+    def write(value:, key:, topic:, partition:, create_time: Time.now, headers: {})
+      message = Protocol::Record.new(key: key, value: value, create_time: create_time, headers: headers)
 
       buffer_for(topic, partition) << message
 

--- a/lib/kafka/pending_message.rb
+++ b/lib/kafka/pending_message.rb
@@ -2,11 +2,12 @@
 
 module Kafka
   class PendingMessage
-    attr_reader :value, :key, :topic, :partition, :partition_key, :create_time, :bytesize
+    attr_reader :value, :key, :headers, :topic, :partition, :partition_key, :create_time, :bytesize
 
-    def initialize(value, key, topic, partition, partition_key, create_time)
+    def initialize(value:, key:, headers: {}, topic:, partition:, partition_key:, create_time:)
       @value = value
       @key = key
+      @headers = headers
       @topic = topic
       @partition = partition
       @partition_key = partition_key
@@ -18,6 +19,7 @@ module Kafka
       @value == other.value &&
         @key == other.key &&
         @topic == other.topic &&
+        @headers == other.headers &&
         @partition == other.partition &&
         @partition_key == other.partition_key &&
         @create_time == other.create_time &&

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -356,6 +356,7 @@ module Kafka
           @buffer.write(
             value: message.value,
             key: message.key,
+            headers: message.headers,
             topic: message.topic,
             partition: partition,
             create_time: message.create_time,

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -172,6 +172,7 @@ module Kafka
     #
     # @param value [String] the message data.
     # @param key [String] the message key.
+    # @param headers [Hash<String, String>] the headers for the message.
     # @param topic [String] the topic that the message should be written to.
     # @param partition [Integer] the partition that the message should be written to.
     # @param partition_key [String] the key that should be used to assign a partition.
@@ -179,14 +180,15 @@ module Kafka
     #
     # @raise [BufferOverflow] if the maximum buffer size has been reached.
     # @return [nil]
-    def produce(value, key: nil, topic:, partition: nil, partition_key: nil, create_time: Time.now)
+    def produce(value, key: nil, headers: {}, topic:, partition: nil, partition_key: nil, create_time: Time.now)
       message = PendingMessage.new(
-        value && value.to_s,
-        key && key.to_s,
-        topic.to_s,
-        partition && Integer(partition),
-        partition_key && partition_key.to_s,
-        create_time,
+        value: value && value.to_s,
+        key: key && key.to_s,
+        headers: headers,
+        topic: topic.to_s,
+        partition: partition && Integer(partition),
+        partition_key: partition_key && partition_key.to_s,
+        create_time: create_time
       )
 
       if buffer_size >= @max_buffer_size
@@ -390,12 +392,13 @@ module Kafka
       @buffer.each do |topic, partition, messages_for_partition|
         messages_for_partition.each do |message|
           messages << PendingMessage.new(
-            message.value,
-            message.key,
-            topic,
-            partition,
-            nil,
-            message.create_time
+            value: message.value,
+            key: message.key,
+            headers: message.headers,
+            topic: topic,
+            partition: partition,
+            partition_key: nil,
+            create_time: message.create_time
           )
         end
       end

--- a/lib/kafka/protocol/record.rb
+++ b/lib/kafka/protocol/record.rb
@@ -40,8 +40,8 @@ module Kafka
         record_encoder.write_varint_bytes(@value)
 
         record_encoder.write_varint_array(@headers.to_a) do |header_key, header_value|
-          record_encoder.write_varint_string(header_key)
-          record_encoder.write_varint_bytes(header_value)
+          record_encoder.write_varint_string(header_key.to_s)
+          record_encoder.write_varint_bytes(header_value.to_s)
         end
 
         encoder.write_varint_bytes(record_buffer.string)

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -32,6 +32,7 @@ describe Kafka::Consumer do
       double(:message, {
         value: "hello",
         key: nil,
+        headers: {},
         topic: "greetings",
         partition: 0,
         offset: 13,
@@ -81,6 +82,7 @@ describe Kafka::Consumer do
         double(:message, {
           value: "hello",
           key: nil,
+          headers: {},
           topic: "greetings",
           partition: 0,
           offset: 13,
@@ -218,6 +220,7 @@ describe Kafka::Consumer do
         double(:message, {
           value: "hello",
           key: nil,
+          headers: {},
           topic: "greetings",
           partition: 0,
           offset: 13,

--- a/spec/functional/async_producer_spec.rb
+++ b/spec/functional/async_producer_spec.rb
@@ -69,4 +69,25 @@ describe "Producer API", functional: true do
 
     producer.shutdown
   end
+
+  example 'support record headers' do
+    topic = "topic#{rand(1000)}"
+
+    producer = kafka.async_producer(delivery_threshold: 1)
+    producer.produce(
+      "hello", topic: topic,
+      headers: { hello: 'World', 'greeting' => 'is great', bye: 1, love: nil }
+    )
+
+    sleep 0.2
+    messages = kafka.fetch_messages(topic: topic, partition: 0, offset: 0)
+
+    expect(messages[0].value).to eq "hello"
+    expect(messages[0].headers).to eql(
+      'hello' => 'World',
+      'greeting' => 'is great',
+      'bye' => '1',
+      'love' => ''
+    )
+  end
 end

--- a/spec/functional/client_spec.rb
+++ b/spec/functional/client_spec.rb
@@ -117,13 +117,16 @@ describe "Producer API", functional: true do
 
     expect {
       Timecop.freeze(now) do
-        kafka.deliver_message("yolo", topic: topic, key: "xoxo", partition: 0)
+        kafka.deliver_message("yolo", topic: topic, key: "xoxo", partition: 0, headers: { hello: 'World' })
       end
     }.to raise_exception(Kafka::DeliveryFailed) {|exception|
       expect(exception.failed_messages).to eq [
         Kafka::PendingMessage.new(
           value: "yolo",
           key: "xoxo",
+          headers: {
+            hello: "World",
+          },
           topic: topic,
           partition: 0,
           partition_key: nil,
@@ -178,5 +181,25 @@ describe "Producer API", functional: true do
 
     expect(offsets[topic][0]).to eq 1
     expect(offsets[topic][1]).to eq 1
+  end
+
+  example 'support record headers' do
+    topic = create_random_topic(num_partitions: 1, num_replicas: 1)
+
+    kafka.deliver_message(
+      "hello", topic: topic,
+      headers: { hello: 'World', 'greeting' => 'is great', bye: 1, love: nil }
+    )
+
+    sleep 0.2
+    messages = kafka.fetch_messages(topic: topic, partition: 0, offset: 0)
+
+    expect(messages[0].value).to eq "hello"
+    expect(messages[0].headers).to eql(
+      'hello' => 'World',
+      'greeting' => 'is great',
+      'bye' => '1',
+      'love' => ''
+    )
   end
 end

--- a/spec/functional/client_spec.rb
+++ b/spec/functional/client_spec.rb
@@ -120,7 +120,16 @@ describe "Producer API", functional: true do
         kafka.deliver_message("yolo", topic: topic, key: "xoxo", partition: 0)
       end
     }.to raise_exception(Kafka::DeliveryFailed) {|exception|
-      expect(exception.failed_messages).to eq [Kafka::PendingMessage.new("yolo", "xoxo", topic, 0, nil, now)]
+      expect(exception.failed_messages).to eq [
+        Kafka::PendingMessage.new(
+          value: "yolo",
+          key: "xoxo",
+          topic: topic,
+          partition: 0,
+          partition_key: nil,
+          create_time: now
+        )
+      ]
     }
   end
 

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -88,7 +88,6 @@ describe "Producer API", functional: true do
   example 'support record headers' do
     topic = "topic#{rand(1000)}"
 
-
     producer = kafka.producer(max_retries: 10, retry_backoff: 1)
     producer.produce(
       "hello", topic: topic,

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -84,4 +84,46 @@ describe "Producer API", functional: true do
 
     expect(messages.last.value).to eq "hello"
   end
+
+  example 'support record headers' do
+    topic = "topic#{rand(1000)}"
+
+
+    producer = kafka.producer(max_retries: 10, retry_backoff: 1)
+    producer.produce(
+      "hello", topic: topic,
+      headers: { hello: 'World', 'greeting' => 'is great', bye: 1, love: nil }
+    )
+    producer.produce(
+      "hello2", topic: topic,
+      headers: { 'other' => 'headers' }
+    )
+    producer.produce("hello3", topic: topic, headers: {})
+    producer.produce("hello4", topic: topic)
+
+    producer.deliver_messages
+
+    expect(producer.buffer_size).to eq 0
+
+    messages = kafka.fetch_messages(topic: topic, partition: 0, offset: 0)
+
+    expect(messages[0].value).to eq "hello"
+    expect(messages[0].headers).to eql(
+      'hello' => 'World',
+      'greeting' => 'is great',
+      'bye' => '1',
+      'love' => ''
+    )
+
+    expect(messages[1].value).to eq "hello2"
+    expect(messages[1].headers).to eql(
+      'other' => 'headers'
+    )
+
+    expect(messages[2].value).to eq "hello3"
+    expect(messages[2].headers).to eql({})
+
+    expect(messages[3].value).to eq "hello4"
+    expect(messages[3].headers).to eql({})
+  end
 end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -136,13 +136,16 @@ describe Kafka::Producer do
     it "handles when a partition temporarily doesn't have a leader" do
       broker1.mark_partition_with_error(topic: "greetings", partition: 0, error_code: 5)
 
-      producer.produce("hello1", topic: "greetings", partition: 0)
+      producer.produce("hello1", topic: "greetings", partition: 0, headers: { hello: 'World' })
 
       expect { producer.deliver_messages }.to raise_error(Kafka::DeliveryFailed) {|exception|
         expect(exception.failed_messages).to eq [
           Kafka::PendingMessage.new(
             value: "hello1",
             key: nil,
+            headers: {
+              hello: 'World'
+            },
             topic: "greetings",
             partition: 0,
             partition_key: nil,
@@ -184,12 +187,15 @@ describe Kafka::Producer do
     it "handles when there's a connection error when fetching topic metadata" do
       allow(cluster).to receive(:get_leader).and_raise(Kafka::ConnectionError)
 
-      producer.produce("hello1", topic: "greetings", partition: 0)
+      producer.produce("hello1", topic: "greetings", partition: 0, headers: {hello: 'World'})
 
       expect { producer.deliver_messages }.to raise_error(Kafka::DeliveryFailed) {|exception|
           expect(exception.failed_messages).to eq [Kafka::PendingMessage.new(
             value: "hello1",
             key: nil,
+            headers: {
+              hello: 'World'
+            },
             topic: "greetings",
             partition: 0,
             partition_key: nil,
@@ -212,13 +218,16 @@ describe Kafka::Producer do
     it "handles when there's a connection error when refreshing cluster metadata" do
       allow(cluster).to receive(:refresh_metadata_if_necessary!).and_raise(Kafka::ConnectionError)
 
-      producer.produce("hello1", topic: "greetings", partition: 0)
+      producer.produce("hello1", topic: "greetings", partition: 0, headers: {hello: 'World'})
 
       expect { producer.deliver_messages }.to raise_error(Kafka::DeliveryFailed) {|exception|
         expect(exception.failed_messages).to eq [
           Kafka::PendingMessage.new(
             value: "hello1",
             key: nil,
+            headers: {
+              hello: 'World'
+            },
             topic: "greetings",
             partition: 0,
             partition_key: nil,

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -139,7 +139,16 @@ describe Kafka::Producer do
       producer.produce("hello1", topic: "greetings", partition: 0)
 
       expect { producer.deliver_messages }.to raise_error(Kafka::DeliveryFailed) {|exception|
-        expect(exception.failed_messages).to eq [Kafka::PendingMessage.new("hello1", nil, "greetings", 0, nil, now)]
+        expect(exception.failed_messages).to eq [
+          Kafka::PendingMessage.new(
+            value: "hello1",
+            key: nil,
+            topic: "greetings",
+            partition: 0,
+            partition_key: nil,
+            create_time: now
+          )
+        ]
       }
 
       # The producer was not able to write the message, but it's still buffered.
@@ -178,7 +187,15 @@ describe Kafka::Producer do
       producer.produce("hello1", topic: "greetings", partition: 0)
 
       expect { producer.deliver_messages }.to raise_error(Kafka::DeliveryFailed) {|exception|
-        expect(exception.failed_messages).to eq [Kafka::PendingMessage.new("hello1", nil, "greetings", 0, nil, now)]
+          expect(exception.failed_messages).to eq [Kafka::PendingMessage.new(
+            value: "hello1",
+            key: nil,
+            topic: "greetings",
+            partition: 0,
+            partition_key: nil,
+            create_time: now
+          )
+        ]
       }
 
       # The producer was not able to write the message, but it's still buffered.
@@ -198,7 +215,16 @@ describe Kafka::Producer do
       producer.produce("hello1", topic: "greetings", partition: 0)
 
       expect { producer.deliver_messages }.to raise_error(Kafka::DeliveryFailed) {|exception|
-        expect(exception.failed_messages).to eq [Kafka::PendingMessage.new("hello1", nil, "greetings", 0, nil, now)]
+        expect(exception.failed_messages).to eq [
+          Kafka::PendingMessage.new(
+            value: "hello1",
+            key: nil,
+            topic: "greetings",
+            partition: 0,
+            partition_key: nil,
+            create_time: now
+          )
+        ]
       }
 
       # The producer was not able to write the message, but it's still buffered.

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -187,10 +187,11 @@ describe Kafka::Producer do
     it "handles when there's a connection error when fetching topic metadata" do
       allow(cluster).to receive(:get_leader).and_raise(Kafka::ConnectionError)
 
-      producer.produce("hello1", topic: "greetings", partition: 0, headers: {hello: 'World'})
+      producer.produce("hello1", topic: "greetings", partition: 0, headers: { hello: 'World' })
 
       expect { producer.deliver_messages }.to raise_error(Kafka::DeliveryFailed) {|exception|
-          expect(exception.failed_messages).to eq [Kafka::PendingMessage.new(
+        expect(exception.failed_messages).to eq([
+          Kafka::PendingMessage.new(
             value: "hello1",
             key: nil,
             headers: {
@@ -201,7 +202,7 @@ describe Kafka::Producer do
             partition_key: nil,
             create_time: now
           )
-        ]
+        ])
       }
 
       # The producer was not able to write the message, but it's still buffered.
@@ -218,7 +219,7 @@ describe Kafka::Producer do
     it "handles when there's a connection error when refreshing cluster metadata" do
       allow(cluster).to receive(:refresh_metadata_if_necessary!).and_raise(Kafka::ConnectionError)
 
-      producer.produce("hello1", topic: "greetings", partition: 0, headers: {hello: 'World'})
+      producer.produce("hello1", topic: "greetings", partition: 0, headers: { hello: 'World' })
 
       expect { producer.deliver_messages }.to raise_error(Kafka::DeliveryFailed) {|exception|
         expect(exception.failed_messages).to eq [


### PR DESCRIPTION
From Kafka 0.11.0, the new record batch format supports optional `headers` field for each message. This helps a lot in tracing, monitoring, as well as other stuff since it allows us to attach the metadata without messing up the main message content. The previous record batch implement PR already supports this field in record batch encoding / decoding. This PR is to implement the interfaces for the outsider to make use of this feature. The interfaces are available in `Kafka::Client` and `Kafka::Producer` and `Kafka::AsyncProducer`.

```ruby
kafka.deliver_message(
   'hello', topic: 'world', headers: { 'TracingID' => 'a1234', 'SpanID' => '4567' }
)
producer = kafka.producer
producer.produce(
  'hello', topic: 'world', headers: { 'TracingID' => 'a1234', 'SpanID' => '4567' }
)
```

The consumer could access record headers via:

```
consumer.each_message do |message|
  puts message.headers
end
```

cc @mensfeld 