### PR TITLE
Clear current offsets on join group

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -444,6 +444,7 @@ module Kafka
       if old_generation_id && @group.generation_id != old_generation_id + 1
         # We've been out of the group for at least an entire generation, no
         # sense in trying to hold on to offset data
+        clear_current_offsets
         @offset_manager.clear_offsets
       else
         # After rejoining the group we may have been assigned a new set of
@@ -451,6 +452,7 @@ module Kafka
         # having the consumer go back and reprocess messages if it's assigned
         # a partition it used to be assigned to way back. For that reason, we
         # only keep commits for the partitions that we're still assigned.
+        clear_current_offsets(excluding: @group.assigned_partitions)
         @offset_manager.clear_offsets_excluding(@group.assigned_partitions)
       end
 
@@ -536,6 +538,14 @@ module Kafka
 
     def pause_for(topic, partition)
       @pauses[topic][partition]
+    end
+
+    def clear_current_offsets(excluding: {})
+      @current_offsets.each do |topic, partitions|
+        partitions.keep_if do |partition, _|
+          excluding.fetch(topic, []).include?(partition)
+        end
+      end
     end
   end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -90,6 +90,46 @@ describe Kafka::Consumer do
     end
   end
 
+  shared_context 'with partition reassignment' do
+    let(:messages_after_partition_reassignment) {
+      [
+        double(:message, {
+          value: "hello",
+          key: nil,
+          headers: {},
+          topic: "greetings",
+          partition: 1,
+          offset: 10,
+          create_time: Time.now,
+          is_control_record: false
+        })
+      ]
+    }
+
+    let(:batches_after_partition_reassignment) {
+      [
+        Kafka::FetchedBatch.new(
+          topic: "greetings",
+          partition: 1,
+          highwater_mark_offset: 42,
+          messages: messages_after_partition_reassignment,
+        )
+      ]
+    }
+
+    before do
+      @count = 0
+      allow(fetcher).to receive(:poll) {
+        @count += 1
+        if @count == 1
+          [:batches, fetched_batches]
+        else
+          [:batches, batches_after_partition_reassignment]
+        end
+      }
+    end
+  end
+
   before do
     allow(cluster).to receive(:add_target_topics)
     allow(cluster).to receive(:disconnect)
@@ -270,6 +310,63 @@ describe Kafka::Consumer do
 
         expect(offset_manager).to have_received(:commit_offsets_if_necessary).twice
         expect(@yield_count).to eq 1
+      end
+    end
+
+    context 'consumer joins a new group' do
+      include_context 'with partition reassignment'
+
+      let(:group) { double(:group).as_null_object }
+      let(:fetcher) { double(:fetcher).as_null_object }
+      let(:current_offsets) { consumer.instance_variable_get(:@current_offsets) }
+      let(:assigned_partitions) { { 'greetings' => [0] } }
+      let(:reassigned_partitions) { { 'greetings' => [1] } }
+
+      before do
+        allow(heartbeat).to receive(:trigger) do
+          next unless @encounter_rebalance
+          @encounter_rebalance = false
+          raise Kafka::RebalanceInProgress
+        end
+
+        consumer.each_message do |message|
+          consumer.stop
+        end
+
+        allow(group).to receive(:assigned_partitions).and_return(reassigned_partitions)
+        allow(group).to receive(:assigned_to?).with('greetings', 1) { true }
+        allow(group).to receive(:assigned_to?).with('greetings', 0) { false }
+        allow(group).to receive(:generation_id).and_return(*generation_ids)
+
+        @encounter_rebalance = true
+      end
+
+      context 'with subsequent group generations' do
+        let(:generation_ids) { [1, 2] }
+
+        it 'removes local offsets for partitions it is no longer assigned' do
+          expect(offset_manager).to receive(:clear_offsets_excluding).with(reassigned_partitions)
+
+          expect do
+            consumer.each_message do |message|
+              consumer.stop
+            end
+          end.to change { current_offsets['greetings'].keys }.from([0]).to([1])
+        end
+      end
+
+      context 'with group generations further apart' do
+        let(:generation_ids) { [1, 3] }
+
+        it 'clears local offsets' do
+          expect(offset_manager).to receive(:clear_offsets)
+
+          expect do
+            consumer.each_message do |message|
+              consumer.stop
+            end
+          end.to change { current_offsets['greetings'].keys }.from([0]).to([1])
+        end
       end
     end
   end


### PR DESCRIPTION
As is mentioned in a comment in Consumer#join_group, we need to make sure
that a consumer clears its stored offsets once it is no longer subscribed to a partition.

This is managed in the offset manager, however the consumer also keeps the offset
in `@current_offsets`, which is used for seeking when joining a group.

This may lead to a consumer seeking to an offset that is actually already processed once re-subscribing to a partition that it was subscribed to previously.

This attempt at a solution clears `@current_offsets` exactly as is done in the offset manager.

Note: I had a hard time testing the behaviour. My unit test (not included) was quite complex as I did not know how to succinctly tease joining and rejoining a group out of the consumer.
I opted to create a functional spec, however I'd be interested in whether it is possible to not reach into the instances `@group` to check whether it is subscribed to a partition. Also the functional test includes _a lot_ of logging, which is meant to illustrate the behavior and will be removed if this gets accepted.

As we have noticed the issue #611 in our production environment, I'd be interested in whether our analysis of the issue is correct.