### PR TITLE
Disable SASL over SSL with a new config

### DIFF
--- a/README.md
+++ b/README.md
@@ -926,7 +926,7 @@ Typically, Kafka certificates come in the JKS format, which isn't supported by r
 
 Kafka has support for using SASL to authenticate clients. Currently GSSAPI, SCRAM and PLAIN mechanisms are supported by ruby-kafka.
 
-**NOTE:** In order to use SASL for authentication, you need to configure SSL encryption by passing `ssl_ca_cert` or enabling `ssl_ca_certs_from_system`.
+**NOTE:** With SASL for authentication, it is highly recommended to use SSL encryption. The default behavior of ruby-kafka enforces you to use SSL and you need to configure SSL encryption by passing `ssl_ca_cert` or enabling `ssl_ca_certs_from_system`. However, this strict SSL mode check can be disabled by setting  `sasl_over_ssl` to `false` while initializing the client.
 
 ##### GSSAPI
 In order to authenticate using GSSAPI, set your principal and optionally your keytab when initializing the Kafka client:
@@ -946,14 +946,12 @@ In order to authenticate using PLAIN, you must set your username and password wh
 ```ruby
 kafka = Kafka.new(
   ["kafka1:9092"],
-  ssl_ca_cert: File.read('/etc/openssl/cert.pem'), # Optional but highly recommended
+  ssl_ca_cert: File.read('/etc/openssl/cert.pem'),
   sasl_plain_username: 'username',
   sasl_plain_password: 'password'
   # ...
 )
 ```
-
-**NOTE**: It is __highly__ recommended that you use SSL for encryption when using SASL_PLAIN
 
 ##### SCRAM
 Since 0.11 kafka supports [SCRAM](https://kafka.apache.org/documentation.html#security_sasl_scram). 

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -54,12 +54,15 @@ module Kafka
     #
     # @param sasl_scram_mechanism [String, nil] Scram mechanism, either "sha256" or "sha512"
     #
+    # @param sasl_over_ssl [Boolean] whether to enforce SSL with SASL
+    #
     # @return [Client]
     def initialize(seed_brokers:, client_id: "ruby-kafka", logger: nil, connect_timeout: nil, socket_timeout: nil,
                    ssl_ca_cert_file_path: nil, ssl_ca_cert: nil, ssl_client_cert: nil, ssl_client_cert_key: nil,
                    sasl_gssapi_principal: nil, sasl_gssapi_keytab: nil,
                    sasl_plain_authzid: '', sasl_plain_username: nil, sasl_plain_password: nil,
-                   sasl_scram_username: nil, sasl_scram_password: nil, sasl_scram_mechanism: nil, ssl_ca_certs_from_system: false)
+                   sasl_scram_username: nil, sasl_scram_password: nil, sasl_scram_mechanism: nil,
+                   sasl_over_ssl: true, ssl_ca_certs_from_system: false)
       @logger = logger || Logger.new(nil)
       @instrumenter = Instrumenter.new(client_id: client_id)
       @seed_brokers = normalize_seed_brokers(seed_brokers)
@@ -84,7 +87,7 @@ module Kafka
         logger: @logger
       )
 
-      if sasl_authenticator.enabled? && ssl_context.nil?
+      if sasl_authenticator.enabled? && sasl_over_ssl && ssl_context.nil?
         raise ArgumentError, "SASL authentication requires that SSL is configured"
       end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+describe Kafka::Client do
+  let(:logger) { LOGGER }
+  let(:kafka_brokers) { KAFKA_BROKERS }
+  let(:client_opts) do
+    {
+      seed_brokers: KAFKA_BROKERS,
+      client_id: "test",
+      logger: logger
+    }
+  end
+
+  describe ".new" do
+    context "when SASL SCRAM has been configured without ssl" do
+      before do
+        client_opts.update({
+          sasl_scram_username: "spec_username",
+          sasl_scram_password: "spec_password",
+          sasl_scram_mechanism: "sha256"
+        })
+      end
+      context "when sasl_over_ssl is unspecified" do
+        it "raises ArgumentError due to missing SSL config" do
+          expect {
+            described_class.new(client_opts)
+          }.to raise_error(ArgumentError, /SASL authentication requires that SSL is configured/)
+        end
+      end
+
+      context "when sasl_over_ssl is true" do
+        before { client_opts.update(sasl_over_ssl: true) }
+
+        it "raises ArgumentError due to missing SSL config" do
+          expect {
+            described_class.new(client_opts)
+          }.to raise_error(ArgumentError, /SASL authentication requires that SSL is configured/)
+        end
+      end
+
+      context "when sasl_over_ssl is false" do
+        before { client_opts.update(sasl_over_ssl: false) }
+
+        it "creates a new Kafka::Client object" do
+          expect { described_class.new(client_opts) }.to_not raise_exception
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Although it is highly recommended to use SASL over SSL, by enforcing SSL for SASL, ruby-kafka turns out to be unusable for those who want to not have SSL (eg: private networks) for SASL.

This PR adds a new configuration option `sasl_over_ssl ` while initializing the Kafka::Client. By default, it is set to true and the current behavior of the library will not be changed. 

For those who want to disable the strict SSL mode for SASL, they can do so by providing `sasl_over_ssl: false`. 