### PR TITLE
Reduce CPU loads when producing messages to many topics

### DIFF
--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -40,7 +40,7 @@ module Kafka
     # @param topics [Array<String>]
     # @return [nil]
     def add_target_topics(topics)
-      new_topics = Set.new(topics) - @target_topics
+      new_topics = Set.new(topics).delete_if {|o| @target_topics.include? o }
 
       unless new_topics.empty?
         @logger.info "New topics added to target list: #{new_topics.to_a.join(', ')}"

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -40,14 +40,17 @@ module Kafka
     # @param topics [Array<String>]
     # @return [nil]
     def add_target_topics(topics)
-      new_topics = Set.new(topics).delete_if {|o| @target_topics.include? o }
+      topics = Set.new(topics)
+      unless topics.subset?(@target_topics)
+        new_topics = topics - @target_topics
 
-      unless new_topics.empty?
-        @logger.info "New topics added to target list: #{new_topics.to_a.join(', ')}"
+        unless new_topics.empty?
+          @logger.info "New topics added to target list: #{new_topics.to_a.join(', ')}"
 
-        @target_topics.merge(new_topics)
+          @target_topics.merge(new_topics)
 
-        refresh_metadata!
+          refresh_metadata!
+        end
       end
     end
 


### PR DESCRIPTION
Hi, we got high CPU loads when producing messages to 1000+ topics.
I was profiling the process with stackprof, the worst method is `Set#delete`.

In `Kafka::Cluster.add_target_topics`, `Set#-` calls `Set#delete` as many as the size of the target topics for each producing messages.
When the target topics grows large, `Set#delete` calls many times unnecessary.

This PR replace it to `Set#delete_if`. New topics are smaller than the target topics in most cases.
In our workload, this reduces CPU loads by 20-30%.

#### Benchmark
Version of Ruby: 2.5.1
```ruby
require 'benchmark'
require 'set'

MAX_TOPICS = 20
TRIALS = 10000

# Create random topic
cl = [('a'..'z'), ('A'..'Z'), ('0'..'9')].map { |i| i.to_a }.flatten
topics = -> { (0..rand(MAX_TOPICS)).map{ (0..1).map { cl[rand(cl.length)] }.join }}

Benchmark.bmbm do |bm|
  bm.report("Set#-") {
    target = Set.new
    TRIALS.times {
      new_target = Set.new(topics.call()) - target
      unless new_target.empty?
        target.merge(new_target)
      end
    }
  }
  bm.report("Set#delete_if") {
    target = Set.new
    TRIALS.times {
      new_target = Set.new(topics.call()).delete_if {|o| target.include? o }
      unless new_target.empty?
        target.merge(new_target)
      end
    }
  }
end
```

```
Rehearsal -------------------------------------------------
Set#-           7.186627   0.021582   7.208209 (  7.241689)
Set#delete_if   0.317339   0.001717   0.319056 (  0.322371)
---------------------------------------- total: 7.527265sec

                    user     system      total        real
Set#-           7.226655   0.018350   7.245005 (  7.278916)
Set#delete_if   0.295705   0.000805   0.296510 (  0.297109)
```