### PR TITLE
Add more instrumentation to allow for more robust lag reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,7 +772,7 @@ All notifications have `group_id` in the payload, referring to the Kafka consume
 * `leave_group.consumer.kafka` is sent whenever a consumer leaves a consumer group. It includes the following payload:
   * `group_id` is the consumer group id.
   
-* `set_offset.consumer.kafka` is sent when a consumer first seeks to an offset. It includes the following payload:
+* `seek.consumer.kafka` is sent when a consumer first seeks to an offset. It includes the following payload:
   * `group_id` is the consumer group id.
   * `topic` is the topic we are seeking in.
   * `partition` is the partition we are seeking in.

--- a/README.md
+++ b/README.md
@@ -771,7 +771,16 @@ All notifications have `group_id` in the payload, referring to the Kafka consume
   
 * `leave_group.consumer.kafka` is sent whenever a consumer leaves a consumer group. It includes the following payload:
   * `group_id` is the consumer group id.
- 
+  
+* `set_offset.consumer.kafka` is sent when a consumer first seeks to an offset. It includes the following payload:
+  * `group_id` is the consumer group id.
+  * `topic` is the topic we are seeking in.
+  * `partition` is the partition we are seeking in.
+  * `offset` is the offset we have seeked to.
+  
+* `heartbeat.consumer.kafka` is sent when a consumer group completes a heartbeat. It includes the following payload:
+  * `group_id` is the consumer group id.
+  * `topic_partitions` is a hash of { topic_name => array of assigned partition IDs }
   
 #### Connection Notifications
 

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -313,6 +313,7 @@ module Kafka
 
       fetcher = Fetcher.new(
         cluster: initialize_cluster,
+        group: group,
         logger: @logger,
         instrumenter: instrumenter,
         max_queue_size: fetcher_max_queue_size

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -476,7 +476,14 @@ module Kafka
         offset = @offset_manager.next_offset_for(topic, partition)
       end
 
-      @fetcher.seek(topic, partition, offset)
+      @instrumenter.instrument('set_offset.consumer',
+                               group_id: @group.group_id,
+                               topic: topic,
+                               partition: partition,
+                               offset: offset) do
+
+        @fetcher.seek(topic, partition, offset)
+      end
     end
 
     def resume_paused_partitions!

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -476,14 +476,7 @@ module Kafka
         offset = @offset_manager.next_offset_for(topic, partition)
       end
 
-      @instrumenter.instrument('set_offset.consumer',
-                               group_id: @group.group_id,
-                               topic: topic,
-                               partition: partition,
-                               offset: offset) do
-
-        @fetcher.seek(topic, partition, offset)
-      end
+      @fetcher.seek(topic, partition, offset)
     end
 
     def resume_paused_partitions!

--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -6,11 +6,12 @@ module Kafka
   class Fetcher
     attr_reader :queue
 
-    def initialize(cluster:, logger:, instrumenter:, max_queue_size:)
+    def initialize(cluster:, logger:, instrumenter:, max_queue_size:, group:)
       @cluster = cluster
       @logger = logger
       @instrumenter = instrumenter
       @max_queue_size = max_queue_size
+      @group = group
 
       @queue = Queue.new
       @commands = Queue.new
@@ -122,6 +123,11 @@ module Kafka
     end
 
     def handle_seek(topic, partition, offset)
+      @instrumenter.instrument('seek.consumer',
+                               group_id: @group.group_id,
+                               topic: topic,
+                               partition: partition,
+                               offset: offset)
       @logger.info "Seeking #{topic}/#{partition} to offset #{offset}"
       @next_offsets[topic][partition] = offset
     end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -102,6 +102,7 @@ describe Kafka::Consumer do
     allow(offset_manager).to receive(:next_offset_for) { 42 }
 
     allow(group).to receive(:subscribe)
+    allow(group).to receive(:group_id)
     allow(group).to receive(:leave)
     allow(group).to receive(:member?) { true }
     allow(group).to receive(:subscribed_partitions) { assigned_partitions }

--- a/spec/fetcher_spec.rb
+++ b/spec/fetcher_spec.rb
@@ -5,12 +5,13 @@ describe Kafka::Fetcher do
   let(:instrumenter) { double(:instrumenter) }
   let(:logger) { Logger.new(StringIO.new) }
   let(:cluster) { double(:cluster) }
-  let(:fetcher) { described_class.new(group: group,
-                                      instrumenter: instrumenter,
-                                      logger: logger,
-                                      cluster: cluster,
-                                      max_queue_size: 1
-                                      )}
+  let(:fetcher) do
+    described_class.new(group: group,
+                        instrumenter: instrumenter,
+                        logger: logger,
+                        cluster: cluster,
+                        max_queue_size: 1)
+  end
 
   before do
     # don't actually start the loop
@@ -28,7 +29,8 @@ describe Kafka::Fetcher do
         group_id: '123',
         topic: 'my-topic',
         partition: 1,
-        offset: 2)
+        offset: 2
+      )
     end
   end
 end

--- a/spec/fetcher_spec.rb
+++ b/spec/fetcher_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe Kafka::Fetcher do
+  let(:group) { double(:group, :group_id => '123') }
+  let(:instrumenter) { double(:instrumenter) }
+  let(:logger) { Logger.new(StringIO.new) }
+  let(:cluster) { double(:cluster) }
+  let(:fetcher) { described_class.new(group: group,
+                                      instrumenter: instrumenter,
+                                      logger: logger,
+                                      cluster: cluster,
+                                      max_queue_size: 1
+                                      )}
+
+  before do
+    # don't actually start the loop
+    thread = double(:thread)
+    allow(thread).to receive(:abort_on_exception=)
+    allow(Thread).to receive(:new).and_return(thread)
+  end
+
+  describe '#handle_seek' do
+    it "should instrument seeks" do
+      allow(instrumenter).to receive(:instrument)
+      fetcher.send(:handle_seek, 'my-topic', 1, 2)
+      expect(instrumenter).to have_received(:instrument).with(
+        'seek.consumer',
+        group_id: '123',
+        topic: 'my-topic',
+        partition: 1,
+        offset: 2)
+    end
+  end
+end


### PR DESCRIPTION
Right now, RubyKafka exposes the lag metric only after consuming a message. There are cases where we want to see the current lag which is not currently supported:
* The consumer does not start up correctly
* The consumer starts up but is stuck on a message (e.g. it's taking too long to process and session timeout continually gets missed)
* The consumer starts up but is failing somewhere before actually getting the message

This PR adds two more places where we can instrument:
* When the consumer first starts up; this will report the current offset so the initial lag can be computed;
* Whenever a heartbeat happens, so we can report if the lag is still where it is (stuck) or has gone up. I know that in the current implementation heartbeat is tied to consuming, but I want to revisit the implementation discussed in #355 to move this to a thread. We're already using threads in our own implementation, so we can have heartbeats separate from the poll loop.

Another advantage of instrumenting heartbeat is that we can throttle the messages we're sending to e.g. DataDog by sending them only once a heartbeat instead of once every message.