### PR TITLE
Restrict ActiveSupport to >= 4.0

### DIFF
--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'digest-crc'
+  spec.add_dependency 'activesupport', '>= 4.0'
 
   spec.add_development_dependency "bundler", ">= 1.9.5"
   spec.add_development_dependency "rake", "~> 10.0"
@@ -36,7 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "docker-api"
   spec.add_development_dependency "rspec-benchmark"
-  spec.add_development_dependency "activesupport"
   spec.add_development_dependency "snappy"
   spec.add_development_dependency "extlz4"
   spec.add_development_dependency "colored"


### PR DESCRIPTION
This PR references this issue: https://github.com/zendesk/ruby-kafka/issues/621

Because the the `Datadog` and `Statsd` subscribers both use `active_support/subscriber`, the gem depends on a version of ActiveSupport `>= 4.0`. This PR adds this dependency to the gemspec.