### PR TITLE
Fix Fetcher's message skipping 

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -477,7 +477,7 @@ module Kafka
 
         batches.each do |batch|
           batch.messages.each(&block)
-          unless batch.messages.empty?
+          unless batch.empty?
             offsets[batch.partition] = batch.last_offset + 1
           end
         end

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -477,7 +477,9 @@ module Kafka
 
         batches.each do |batch|
           batch.messages.each(&block)
-          offsets[batch.partition] = batch.last_offset + 1
+          unless batch.messages.empty?
+            offsets[batch.partition] = batch.last_offset + 1
+          end
         end
       end
     end

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -477,9 +477,7 @@ module Kafka
 
         batches.each do |batch|
           batch.messages.each(&block)
-          unless batch.empty?
-            offsets[batch.partition] = batch.last_offset + 1
-          end
+          offsets[batch.partition] = batch.last_offset + 1 unless batch.empty?
         end
       end
     end

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -310,7 +310,9 @@ module Kafka
             @instrumenter.instrument("process_batch.consumer", notification) do
               begin
                 yield batch
-                @current_offsets[batch.topic][batch.partition] = batch.last_offset
+                unless batch.messages.empty?
+                  @current_offsets[batch.topic][batch.partition] = batch.last_offset
+                end
               rescue => e
                 offset_range = (batch.first_offset..batch.last_offset)
                 location = "#{batch.topic}/#{batch.partition} in offset range #{offset_range}"

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -310,9 +310,7 @@ module Kafka
             @instrumenter.instrument("process_batch.consumer", notification) do
               begin
                 yield batch
-                unless batch.empty?
-                  @current_offsets[batch.topic][batch.partition] = batch.last_offset
-                end
+                @current_offsets[batch.topic][batch.partition] = batch.last_offset
               rescue => e
                 offset_range = (batch.first_offset..batch.last_offset)
                 location = "#{batch.topic}/#{batch.partition} in offset range #{offset_range}"

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -310,7 +310,7 @@ module Kafka
             @instrumenter.instrument("process_batch.consumer", notification) do
               begin
                 yield batch
-                unless batch.messages.empty?
+                unless batch.empty?
                   @current_offsets[batch.topic][batch.partition] = batch.last_offset
                 end
               rescue => e

--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -144,9 +144,9 @@ module Kafka
             highwater_mark_offset: batch.highwater_mark_offset,
             message_count: batch.messages.count,
           })
-        end
 
-        @next_offsets[batch.topic][batch.partition] = batch.last_offset + 1
+          @next_offsets[batch.topic][batch.partition] = batch.last_offset + 1
+        end
       end
 
       @queue << [:batches, batches]


### PR DESCRIPTION
In the current Fetcher and Consumer, the current implementation has a bug that leads to the situation where a huge amount of messages are skipped, without being processed. The root cause is that the fetcher doesn't handle the case where a fetched batch is empty. 

In normal scenario, it updates the current offset based on the fetched batch last offset. When the batch is empty, it updates the current offset to the highwater mark offset, which is the end of the queue. The empty batch didn't exist before. However, newer versions of Kafka (after 0.11.0, I guess) do return the empty batches in some cases:
- Control batches of transactional message production
- Throttled fetch request
- Incomplete message sets which exceed the max byte limit
- etc.
My fix is just not to update current offset when the batch is empty. In case there is nothing more to fetch, the consumers just don't update the offset, instead of using the highwater mark offset like current.

Fix https://github.com/zendesk/ruby-kafka/issues/624
Merge merge before https://github.com/zendesk/ruby-kafka/pull/608

Reference: two cases that return empty sets. There would be more cases.
![screen shot 2018-08-07 at 14 24 59](https://user-images.githubusercontent.com/11613517/43760939-bfe35ecc-9a4d-11e8-8dc4-f72c0419e0e6.png)
