### PR TITLE
Update README.md for max_queue_size key change

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Note that there's a maximum buffer size; by default, it's set to 1,000 messages 
 
 ```ruby
 producer = kafka.producer(
-  max_buffer_size: 5_000,           # Allow at most 5K messages to be buffered.
+  max_queue_size: 5_000,           # Allow at most 5K messages to be buffered.
   max_buffer_bytesize: 100_000_000, # Allow at most 100MB to be buffered.
   ...
 )


### PR DESCRIPTION
The key is not max_buffer_size but rather max_queue_size. This reflects the change in the README.md file.