### PR TITLE
Add compatibility with dogstatsd-ruby v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes and additions to the library will be listed here.
 
 ## Unreleased
 
+- Compatibility with dogstatsd-ruby v4.0.0.
+
 ## 0.7.1
 
 - Exactly Once Delivery and Transactional Messaging Support (#608).

--- a/lib/kafka/datadog.rb
+++ b/lib/kafka/datadog.rb
@@ -40,7 +40,7 @@ module Kafka
       end
 
       def host
-        @host ||= ::Datadog::Statsd::DEFAULT_HOST
+        @host ||= default_host
       end
 
       def host=(host)
@@ -49,7 +49,7 @@ module Kafka
       end
 
       def port
-        @port ||= ::Datadog::Statsd::DEFAULT_PORT
+        @port ||= default_port
       end
 
       def port=(port)
@@ -76,6 +76,14 @@ module Kafka
       end
 
       private
+
+      def default_host
+        ::Datadog::Statsd.const_defined?(:Connection) ? ::Datadog::Statsd::Connection::DEFAULT_HOST : ::Datadog::Statsd::DEFAULT_HOST
+      end
+
+      def default_port
+        ::Datadog::Statsd.const_defined?(:Connection) ? ::Datadog::Statsd::Connection::DEFAULT_PORT : ::Datadog::Statsd::DEFAULT_PORT
+      end
 
       def clear
         @statsd && @statsd.close

--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "extlz4"
   spec.add_development_dependency "colored"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
-  spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0", "<4.0.0"
+  spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0", "< 5.0.0"
   spec.add_development_dependency "statsd-ruby"
   spec.add_development_dependency "ruby-prof"
   spec.add_development_dependency "timecop"


### PR DESCRIPTION
dogstatsd-ruby v4.0.0 moved the constants for connection defaults into a new class: https://github.com/DataDog/dogstatsd-ruby/commit/055cda22c6f029a411e86292349a73b4b53a05f2

This change keeps this gem compatible with both the old and new versions of dogstatsd-ruby.

Given that the default values represented here probably are truly constants ('127.0.0.1', 8125), it is tempting to just replicate them here. If you'd prefer that approach let me know, and I'll update this PR.

We're still using v0.6.8, so if this change is accepted I'll also backport it to the v0.6.x branch.