### PR TITLE
Fix consuming duplication due to redundant messages returned from Kafka

### DIFF
--- a/lib/kafka/fetch_operation.rb
+++ b/lib/kafka/fetch_operation.rb
@@ -100,6 +100,7 @@ module Kafka
             Kafka::FetchedBatchGenerator.new(
               fetched_topic.name,
               fetched_partition,
+              topics.fetch(fetched_topic.name).fetch(fetched_partition.partition).fetch(:fetch_offset),
               logger: @logger
             ).generate
           end

--- a/lib/kafka/fetched_batch_generator.rb
+++ b/lib/kafka/fetched_batch_generator.rb
@@ -7,10 +7,11 @@ module Kafka
     COMMITTED_TRANSACTION_SIGNAL = "\x00\x00\x00\x01".freeze
     ABORTED_TRANSACTION_SIGNAL = "\x00\x00\x00\x00".freeze
 
-    def initialize(topic, fetched_partition, logger:)
+    def initialize(topic, fetched_partition, offset, logger:)
       @topic = topic
       @fetched_partition = fetched_partition
       @logger = logger
+      @offset = offset
     end
 
     def generate

--- a/lib/kafka/fetched_batch_generator.rb
+++ b/lib/kafka/fetched_batch_generator.rb
@@ -41,11 +41,13 @@ module Kafka
       messages = @fetched_partition.messages.flat_map do |message_set|
         message_set.messages.map do |message|
           last_offset = message.offset if last_offset.nil? || last_offset < message.offset
-          FetchedMessage.new(
-            message: message,
-            topic: @topic,
-            partition: @fetched_partition.partition
-          )
+          if message.offset >= @offset
+            FetchedMessage.new(
+              message: message,
+              topic: @topic,
+              partition: @fetched_partition.partition
+            )
+          end
         end
       end
       FetchedBatch.new(
@@ -83,7 +85,7 @@ module Kafka
         end
 
         record_batch.records.each do |record|
-          unless record.is_control_record
+          if !record.is_control_record && record.offset >= @offset
             records << FetchedMessage.new(
               message: record,
               topic: @topic,

--- a/spec/fetched_batch_generator_spec.rb
+++ b/spec/fetched_batch_generator_spec.rb
@@ -3,9 +3,6 @@
 describe Kafka::FetchedBatchGenerator do
   let(:logger) { LOGGER }
   let(:generator) { described_class.new('Hello', fetched_partition, 0, logger: logger) }
-  let(:message_1) { Kafka::Protocol::Message.new(value: 'Hello') }
-  let(:message_2) { Kafka::Protocol::Message.new(value: 'World') }
-  let(:message_3) { Kafka::Protocol::Message.new(value: 'Bye') }
 
   context 'empty partition' do
     let(:fetched_partition) do
@@ -40,13 +37,22 @@ describe Kafka::FetchedBatchGenerator do
         messages: [
           Kafka::Protocol::MessageSet.new(
             messages: [
-              message_1,
-              message_2
+              Kafka::Protocol::Message.new(
+                value: 'Hello',
+                offset: 0
+              ),
+              Kafka::Protocol::Message.new(
+                value: 'World',
+                offset: 1
+              )
             ]
           ),
           Kafka::Protocol::MessageSet.new(
             messages: [
-              message_3
+              Kafka::Protocol::Message.new(
+                value: 'Bye',
+                offset: 2
+              )
             ]
           )
         ]
@@ -61,9 +67,27 @@ describe Kafka::FetchedBatchGenerator do
 
       expect(batch.messages.length).to eql(3)
 
-      expect_fetched_message_eql(batch.messages[0], 'Hello', 0, message_1)
-      expect_fetched_message_eql(batch.messages[1], 'Hello', 0, message_2)
-      expect_fetched_message_eql(batch.messages[2], 'Hello', 0, message_3)
+      expect_fetched_message_eql(
+        batch.messages[0], 'Hello', 0,
+        Kafka::Protocol::Message.new(
+          value: 'Hello',
+          offset: 0
+        )
+      )
+      expect_fetched_message_eql(
+        batch.messages[1], 'Hello', 0,
+        Kafka::Protocol::Message.new(
+          value: 'World',
+          offset: 1
+        )
+      )
+      expect_fetched_message_eql(
+        batch.messages[2], 'Hello', 0,
+        Kafka::Protocol::Message.new(
+          value: 'Bye',
+          offset: 2
+        )
+      )
     end
   end
 
@@ -420,7 +444,7 @@ describe Kafka::FetchedBatchGenerator do
         batch = generator.generate
         expect(batch.topic).to eql('Hello')
         expect(batch.partition).to eql(0)
-        expect(batch.last_offset).to eql(9)
+        expect(batch.last_offset).to eql(11)
         expect(batch.highwater_mark_offset).to eql(1)
 
         expect(batch.messages.length).to eql(2)
@@ -439,7 +463,6 @@ def expect_fetched_message_eql(fetched_message, topic, partition, message)
   expect(fetched_message.value).to eql(message.value)
   expect(fetched_message.key).to eql(message.key)
   expect(fetched_message.offset).to eql(message.offset)
-  expect(fetched_message.create_time).to eql(message.create_time)
 
   if message.is_a?(Kafka::Protocol::Record)
     expect(fetched_message.headers).to eql(message.headers)

--- a/spec/functional/compression_spec.rb
+++ b/spec/functional/compression_spec.rb
@@ -53,6 +53,6 @@ describe "Compression", functional: true do
 
   def fetch_last_offset
     last_message = kafka.fetch_messages(topic: topic, partition: 0, offset: 0).last
-    last_message ? last_message.offset : 0
+    last_message ? last_message.offset : -1
   end
 end


### PR DESCRIPTION
When the clients send the requests to Kafka to fetch the records, say topic Hello, partition 0, from offset 3, it is expected that Kafka would return the records from offset 3 only. Surprisingly, it also returns **all the records** in the same record batch. The client doesn't handle this case for now and causes the processing duplication.

This PR is to reject out-of-scope records in fetch operation.

Fix https://github.com/zendesk/ruby-kafka/issues/635