### PR TITLE
Pass batch to each_message as a second optional argument

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -223,7 +223,7 @@ module Kafka
 
             @instrumenter.instrument("process_message.consumer", notification) do
               begin
-                yield message unless message.is_control_record
+                yield(message, batch) unless message.is_control_record
                 @current_offsets[message.topic][message.partition] = message.offset
               rescue => e
                 location = "#{message.topic}/#{message.partition} at offset #{message.offset}"


### PR DESCRIPTION
I have a particular case, where I need to track `highwater_mark_offset` and `first_offset` for batches consumed with `each_message`. This change will allow me to reach this data easily by reaching to the second (optional) argument of the `#each_message` method.

I also believe that it will also allow for unification of the API, so the same information is available using both `each_batch` and `each_message`.

This change does not break the current API nor does it require any changes from anyone (second argument when not used will be ignored).

It will also allow me to unify the API for Karafka `Metadata` object that I want to provide for both ways of processing messages.