### PR TITLE
Refresh cluster info on fetch error (v0.6.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Changes and additions to the library will be listed here.
 
 ## Unreleased
 
+- Refresh cluster info on fetch error.
+
+## v0.6.8
+
+- Fix Fetcher's message skipping.
+- Refresh cluster metadata after topic re-assignment.
+
+## v0.6.7
+
+- Fix bug in `ConsumerGroup#assigned_to?`.
+
+## v0.6.6
+
+- Handle case where consumer doesn't know about the topic (#597).
+
 ## v0.6.5
 
 - Fix bug related to partition assignment.

--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "extlz4"
   spec.add_development_dependency "colored"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
-  spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0"
+  spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0", "< 4.0.0"
   spec.add_development_dependency "statsd-ruby"
   spec.add_development_dependency "ruby-prof"
   spec.add_development_dependency "timecop"


### PR DESCRIPTION
Cherry picked https://github.com/zendesk/ruby-kafka/pull/641

Also, updated and backfilled change log based on commits on the v0.6-stable branch.

I'm also planning to open PRs to backport: https://github.com/zendesk/ruby-kafka/pull/644 and https://github.com/zendesk/ruby-kafka/pull/634