### PR TITLE
Create thread when starting fetcher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,8 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
       - image: wurstmeister/kafka:2.11-0.11.0.3
         environment:
+          KAFKA_ADVERTISED_HOST_NAME: localhost
+          KAFKA_ADVERTISED_PORT: 9093
           KAFKA_PORT: 9093
           KAFKA_ZOOKEEPER_CONNECT: localhost:2181
           KAFKA_DELETE_TOPIC_ENABLE: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,3 +145,4 @@ workflows:
       - kafka-0.11
       - kafka-1.0.0
       - kafka-1.1
+      - kafka-2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,38 @@ jobs:
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
+  kafka-2.0:
+    docker:
+      - image: circleci/ruby:2.5.1-node
+        environment:
+          LOG_LEVEL: DEBUG
+      - image: wurstmeister/zookeeper
+      - image: wurstmeister/kafka:2.11-2.0.0
+        environment:
+          KAFKA_ADVERTISED_HOST_NAME: localhost
+          KAFKA_ADVERTISED_PORT: 9092
+          KAFKA_PORT: 9092
+          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+          KAFKA_DELETE_TOPIC_ENABLE: true
+      - image: wurstmeister/kafka:2.11-2.0.0
+        environment:
+          KAFKA_ADVERTISED_HOST_NAME: localhost
+          KAFKA_ADVERTISED_PORT: 9093
+          KAFKA_PORT: 9093
+          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+          KAFKA_DELETE_TOPIC_ENABLE: true
+      - image: wurstmeister/kafka:2.11-2.0.0
+        environment:
+          KAFKA_ADVERTISED_HOST_NAME: localhost
+          KAFKA_ADVERTISED_PORT: 9094
+          KAFKA_PORT: 9094
+          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+          KAFKA_DELETE_TOPIC_ENABLE: true
+    steps:
+      - checkout
+      - run: bundle install --path vendor/bundle
+      - run: bundle exec rspec --profile --tag functional spec/functional
+
 workflows:
   version: 2
   test:

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -110,6 +110,7 @@ module Kafka
     # @return [nil]
     def stop
       @running = false
+      @fetcher.stop
       @cluster.disconnect
     end
 

--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -28,12 +28,6 @@ module Kafka
 
       # The maximum number of bytes to fetch per partition, by topic.
       @max_bytes_per_partition = {}
-
-      @thread = Thread.new do
-        loop while true
-      end
-
-      @thread.abort_on_exception = true
     end
 
     def subscribe(topic, max_bytes_per_partition:)
@@ -49,17 +43,24 @@ module Kafka
     end
 
     def start
-      @commands << [:start, []]
-    end
-
-    def handle_start
       raise "already started" if @running
+
+      @thread = Thread.new do
+        while @running
+          loop
+        end
+        @logger.info "Fetcher thread exited."
+      end
+      @thread.abort_on_exception = true
 
       @running = true
     end
 
     def stop
+      return unless @running
       @commands << [:stop, []]
+      sleep 1
+      puts @thread
     end
 
     def reset
@@ -81,14 +82,14 @@ module Kafka
         queue_size: @queue.size,
       })
 
+      return unless @running
+
       if !@commands.empty?
         cmd, args = @commands.deq
 
         @logger.debug "Handling fetcher command: #{cmd}"
 
         send("handle_#{cmd}", *args)
-      elsif !@running
-        sleep 0.1
       elsif @queue.size < @max_queue_size
         step
       else
@@ -110,6 +111,7 @@ module Kafka
 
     def handle_stop(*)
       @running = false
+      @commands.clear
 
       # After stopping, we need to reconfigure the topics and partitions to fetch
       # from. Otherwise we'd keep fetching from a bunch of partitions we may no

--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -43,7 +43,7 @@ module Kafka
     end
 
     def start
-      raise "already started" if @running
+      return if @running
 
       @thread = Thread.new do
         while @running

--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -59,8 +59,6 @@ module Kafka
     def stop
       return unless @running
       @commands << [:stop, []]
-      sleep 1
-      puts @thread
     end
 
     def reset

--- a/spec/functional/async_producer_spec.rb
+++ b/spec/functional/async_producer_spec.rb
@@ -71,8 +71,6 @@ describe "Producer API", functional: true do
   end
 
   example 'support record headers' do
-    topic = "topic#{SecureRandom.uuid}"
-
     producer = kafka.async_producer(delivery_threshold: 1)
     producer.produce(
       "hello", topic: topic,

--- a/spec/functional/async_producer_spec.rb
+++ b/spec/functional/async_producer_spec.rb
@@ -71,6 +71,8 @@ describe "Producer API", functional: true do
   end
 
   example 'support record headers' do
+    topic = create_random_topic(num_partitions: 1)
+
     producer = kafka.async_producer(delivery_threshold: 1)
     producer.produce(
       "hello", topic: topic,

--- a/spec/functional/async_producer_spec.rb
+++ b/spec/functional/async_producer_spec.rb
@@ -2,7 +2,7 @@
 
 describe "Producer API", functional: true do
   let(:producer) { kafka.async_producer(max_retries: 1, retry_backoff: 0) }
-  let(:topic) { create_random_topic(num_partitions: 3) }
+  let!(:topic) { create_random_topic(num_partitions: 3) }
 
   after do
     producer.shutdown

--- a/spec/functional/idempotent_async_producer_spec.rb
+++ b/spec/functional/idempotent_async_producer_spec.rb
@@ -89,9 +89,9 @@ describe "Idempotent async producer", functional: true do
   end
 
   example "no duplication if one of the brokers are down" do
-    topic = create_random_topic(num_partitions: 100)
+    topic = create_random_topic(num_partitions: 10)
 
-    100.times do |index|
+    10.times do |index|
       producer.produce('Hello', topic: topic, partition: index)
     end
     sleep 2
@@ -108,7 +108,7 @@ describe "Idempotent async producer", functional: true do
       end
     rescue Kafka::DeliveryFailed
     end
-    100.times do |index|
+    10.times do |index|
       producer.produce('Hi', topic: topic, partition: index)
     end
     sleep 2
@@ -116,7 +116,7 @@ describe "Idempotent async producer", functional: true do
     allow_any_instance_of(Kafka::SocketWithTimeout).to receive(:read).and_call_original
     sleep 2
 
-    100.times do |index|
+    10.times do |index|
       records = kafka.fetch_messages(topic: topic, partition: index, offset: :earliest)
       expect(records.length).to eql(2)
       expect(records[0].value).to eql('Hello')

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -59,6 +59,7 @@ describe "Producer API", functional: true do
 
   example "writing to a an explicit partition of a topic that doesn't yet exist" do
     topic = "topic#{SecureRandom.uuid}"
+    create_topic(topic)
 
     producer = kafka.producer(max_retries: 10, retry_backoff: 1)
     producer.produce("hello", topic: topic, partition: 0)
@@ -73,6 +74,7 @@ describe "Producer API", functional: true do
 
   example "writing to a an unspecified partition of a topic that doesn't yet exist" do
     topic = "topic#{SecureRandom.uuid}"
+    create_topic(topic)
 
     producer = kafka.producer(max_retries: 10, retry_backoff: 1)
     producer.produce("hello", topic: topic)
@@ -87,6 +89,7 @@ describe "Producer API", functional: true do
 
   example 'support record headers' do
     topic = "topic#{SecureRandom.uuid}"
+    create_topic(topic)
 
     producer = kafka.producer(max_retries: 10, retry_backoff: 1)
     producer.produce(

--- a/spec/functional/topic_management_spec.rb
+++ b/spec/functional/topic_management_spec.rb
@@ -55,6 +55,7 @@ describe "Topic management API", functional: true do
     end
 
     topic = generate_topic_name
+    kafka.create_topic(topic, num_partitions: 3)
     configs = kafka.describe_topic(topic, %w(retention.ms retention.bytes non_exists))
 
     expect(configs.keys).to eql(%w(retention.ms retention.bytes))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,10 +51,7 @@ end
 
 module SpecHelpers
   def generate_topic_name
-    @@topic_number ||= 0
-    @@topic_number += 1
-
-    "#{RUN_ID}-topic-#{@@topic_number}"
+    "#{RUN_ID}-topic-#{SecureRandom.uuid}"
   end
 
   def create_random_topic(*args)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,7 @@ module SpecHelpers
 
   def create_topic(name, num_partitions: 1, num_replicas: 1)
     kafka.create_topic(name, num_partitions: num_partitions, replication_factor: num_replicas)
+    sleep 0.5
   end
 end
 


### PR DESCRIPTION
When creating a Fetcher instance in consumer, a thread is created to handle the commands and fetch the data in the background. That threads starts the loop right after the Fetcher is *created*. When the fetcher instance stops, that thread is still running in forever-loop. This creates serious thread leaking in some use cases where many instances of consumers are used. Therefore, I moved the thread initialization to `Fetcher#start` and kill the thread naturally when calling `Fetcher#stop`.  This change seems to be safe and more efficient. In the consumer, before starting the consumer loop, the fetcher is started. Right after the consumer loop breaks (interrupting, error, etc.), the fetcher is cleaned up and stopped totally. 

This script demonstrates the thread leaking in previous versions, and fixed in current version.

```ruby
require 'kafka'
topic = 'hello'

begin
  kafka = Kafka.new(
    seed_brokers: ['localhost:9092'],
    client_id: "simple-consumer",
    socket_timeout: 20
  )

  consumer = kafka.consumer(group_id: "firehose")
  consumer.subscribe(topic)

  consumer.each_message do |message|
    #consumer.stop
    raise if rand(0..10) == 5
    puts message.value
  end
rescue => e
  puts e
  consumer.stop
  p Thread.list.count
  retry
end
```

cc @mensfeld @dasch 
P/s: this PR contains some changes to fix flaky tests. They are now stable.