### PR TITLE
Only seek if partition still belong to group

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -153,7 +153,8 @@ module Kafka
     def resume(topic, partition)
       pause_for(topic, partition).resume!
 
-      seek_to_next(topic, partition)
+      # During re-balancing we might have lost the paused partition. Check if partition is still in group before seek.
+      seek_to_next(topic, partition) if @group.assigned_to?(topic, partition)
     end
 
     # Whether the topic partition is currently paused.

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -247,6 +247,8 @@ describe Kafka::Consumer do
     end
 
     it "does not fetch messages from paused partitions" do
+      allow(group).to receive(:assigned_to?).with('greetings', 42) { true }
+
       assigned_partitions["greetings"] << 42
 
       consumer.pause("greetings", 42)

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -268,6 +268,21 @@ describe Kafka::Consumer do
       expect(fetcher).to have_received(:seek).with("greetings", 42, anything)
     end
 
+    it "does not seek (previously) paused partition when not in group" do
+      allow(group).to receive(:assigned_to?).with('greetings', 42) { false }
+
+      assigned_partitions["greetings"] << 42
+
+      consumer.pause("greetings", 42)
+      consumer.resume("greetings", 42)
+
+      consumer.each_message do |message|
+        consumer.stop
+      end
+
+      expect(fetcher).to_not have_received(:seek).with("greetings", 42, anything)
+    end
+
     it "automatically resumes partitions if a timeout is set" do
       time = Time.now
 


### PR DESCRIPTION
This PR fixes a `KeyError: key not found:...` in the offset manager https://github.com/zendesk/ruby-kafka/blob/master/lib/kafka/offset_manager.rb#L184 during rebalancing.

This happens when a partition is paused in the consumer and a rebalancing occurs in the meanwhile. When the partition pause is over we should verify that it is still assigned to our group before performing a seek. Similar verification is being done here https://github.com/zendesk/ruby-kafka/blob/master/lib/kafka/consumer.rb#L522

#### Risks
Low.

