### PR TITLE
Enhance pause mechanism

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -360,7 +360,6 @@ module Kafka
       offset_manager = OffsetManager.new(
         cluster: cluster,
         group: group,
-        fetcher: fetcher,
         logger: @logger,
         commit_interval: offset_commit_interval,
         commit_threshold: offset_commit_threshold,

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -340,6 +340,8 @@ module Kafka
       # The Kafka protocol expects the retention time to be in ms.
       retention_time = (offset_retention_time && offset_retention_time * 1_000) || -1
 
+      pause_manager = PauseManager.new
+
       group = ConsumerGroup.new(
         cluster: cluster,
         logger: @logger,
@@ -354,7 +356,8 @@ module Kafka
         group: group,
         logger: @logger,
         instrumenter: instrumenter,
-        max_queue_size: fetcher_max_queue_size
+        max_queue_size: fetcher_max_queue_size,
+        pause_manager: pause_manager,
       )
 
       offset_manager = OffsetManager.new(
@@ -380,6 +383,7 @@ module Kafka
         fetcher: fetcher,
         session_timeout: session_timeout,
         heartbeat: heartbeat,
+        pause_manager: pause_manager,
       )
     end
 

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -541,7 +541,8 @@ module Kafka
     rescue OffsetOutOfRange => e
       @logger.error "Invalid offset #{e.offset} for #{e.topic}/#{e.partition}, resetting to default offset"
 
-      @offset_manager.seek_to_default(e.topic, e.partition)
+      offset = @offset_manager.seek_to_default(e.topic, e.partition)
+      @fetcher.seek(topic, partition, offset)
 
       retry
     rescue ConnectionError => e

--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -6,12 +6,13 @@ module Kafka
   class Fetcher
     attr_reader :queue
 
-    def initialize(cluster:, logger:, instrumenter:, max_queue_size:, group:)
+    def initialize(cluster:, logger:, instrumenter:, max_queue_size:, group:, pause_manager:)
       @cluster = cluster
       @logger = logger
       @instrumenter = instrumenter
       @max_queue_size = max_queue_size
       @group = group
+      @pause_manager = pause_manager
 
       @queue = Queue.new
       @commands = Queue.new

--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -168,7 +168,6 @@ module Kafka
         @next_offsets[batch.topic][batch.partition] = batch.last_offset + 1 unless batch.unknown_last_offset?
       end
 
-
       @queue << [:batches, batches]
     rescue Kafka::NoPartitionsToFetchFrom
       @logger.warn "No partitions to fetch from, sleeping for 1s"

--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "kafka/fetch_operation"
+require "kafka/locked_queue"
 
 module Kafka
   class Fetcher
@@ -14,7 +15,7 @@ module Kafka
       @group = group
       @pause_manager = pause_manager
 
-      @queue = Queue.new
+      @queue = LockedQueue.new
       @commands = Queue.new
       @next_offsets = Hash.new { |h, k| h[k] = {} }
 

--- a/lib/kafka/locked_queue.rb
+++ b/lib/kafka/locked_queue.rb
@@ -1,0 +1,47 @@
+module Kafka
+  class LockedQueue
+    def initialize
+      @array = []
+      @mutex = Mutex.new
+      @resource = ConditionVariable.new
+    end
+
+    def <<(item)
+      @mutex.synchronize do
+        @array << item
+        @resource.signal
+      end
+    end
+
+    def empty?
+      size == 0
+    end
+
+    def size
+      @mutex.synchronize do
+        @array.length
+      end
+    end
+
+    def clear
+      @mutex.synchronize do
+        @array = []
+      end
+    end
+
+    def map!(&block)
+      @mutex.synchronize do
+        @array.map!(&block)
+      end
+    end
+
+    def deq
+      @mutex.synchronize do
+        if @array.empty?
+          @resource.wait(@mutex)
+        end
+        @array.shift
+      end
+    end
+  end
+end

--- a/lib/kafka/locked_queue.rb
+++ b/lib/kafka/locked_queue.rb
@@ -1,4 +1,9 @@
+# frozen_string_literal: true
+
 module Kafka
+  # This is a pre-implementation of Ruby's built-in Queue data structure, with
+  # simpler interface and usage, while adding the support for data modification.
+  # The best use case applies for 1 producer thread and multi consumer thread.
   class LockedQueue
     def initialize
       @array = []

--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -9,10 +9,9 @@ module Kafka
     # The default broker setting for offsets.retention.minutes is 1440.
     DEFAULT_RETENTION_TIME = 1440 * 60
 
-    def initialize(cluster:, group:, fetcher:, logger:, commit_interval:, commit_threshold:, offset_retention_time:)
+    def initialize(cluster:, group:, logger:, commit_interval:, commit_threshold:, offset_retention_time:)
       @cluster = cluster
       @group = group
-      @fetcher = fetcher
       @logger = logger
       @commit_interval = commit_interval
       @commit_threshold = commit_threshold
@@ -70,8 +69,9 @@ module Kafka
       clear_resolved_offset(topic)
 
       offset = resolve_offset(topic, partition)
-
       seek_to(topic, partition, offset)
+
+      offset
     end
 
     # Move the consumer's position in the partition to the specified offset.
@@ -83,8 +83,6 @@ module Kafka
     def seek_to(topic, partition, offset)
       @processed_offsets[topic] ||= {}
       @processed_offsets[topic][partition] = offset
-
-      @fetcher.seek(topic, partition, offset)
     end
 
     # Return the next offset that should be fetched for the specified partition.

--- a/lib/kafka/pause_manager.rb
+++ b/lib/kafka/pause_manager.rb
@@ -3,6 +3,8 @@
 require "kafka/pause"
 
 module Kafka
+  # PauseManager acts as an abstract layer to manage the pause states of
+  # multiple partitions.
   class PauseManager
     def initialize
       @pauses = Hash.new {|h, k|
@@ -12,7 +14,7 @@ module Kafka
       }
     end
 
-    def pause!(topic, partition, timeout:, max_timeout:, exponential_backoff:)
+    def pause!(topic, partition, timeout: nil, max_timeout: nil, exponential_backoff: nil)
       pause_for(topic, partition).pause!(
         timeout: timeout,
         max_timeout: max_timeout,

--- a/lib/kafka/pause_manager.rb
+++ b/lib/kafka/pause_manager.rb
@@ -20,7 +20,7 @@ module Kafka
       )
     end
 
-    def pause?(topic, partition)
+    def paused?(topic, partition)
       pause = pause_for(topic, partition)
       pause.paused? && !pause.expired?
     end

--- a/lib/kafka/pause_manager.rb
+++ b/lib/kafka/pause_manager.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "kafka/pause"
+
+module Kafka
+  class PauseManager
+    def initialize
+      @pauses = Hash.new {|h, k|
+        h[k] = Hash.new {|h2, k2|
+          h2[k2] = Pause.new
+        }
+      }
+    end
+
+    def pause!(topic, partition, timeout:, max_timeout:, exponential_backoff:)
+      pause_for(topic, partition).pause!(
+        timeout: timeout,
+        max_timeout: max_timeout,
+        exponential_backoff: exponential_backoff,
+      )
+    end
+
+    def pause?(topic, partition)
+      pause = pause_for(topic, partition)
+      pause.paused? && !pause.expired?
+    end
+
+    def resume!(topic, partition)
+      pause_for(topic, partition).resume!
+    end
+
+    def reset!(topic, partition)
+      pause_for(topic, partition).reset!
+    end
+
+    private
+
+    def pause_for(topic, partition)
+      @pauses[topic][partition]
+    end
+  end
+end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -10,6 +10,7 @@ describe Kafka::Consumer do
   let(:group) { double(:group) }
   let(:offset_manager) { double(:offset_manager) }
   let(:heartbeat) { double(:heartbeat) }
+  let(:pause_manager) { Kafka::PauseManager.new }
   let(:fetcher) { double(:fetcher, configure: nil, subscribe: nil, seek: nil, start: nil, stop: nil) }
   let(:session_timeout) { 30 }
   let(:assigned_partitions) { { "greetings" => [0] } }
@@ -24,6 +25,7 @@ describe Kafka::Consumer do
       fetcher: fetcher,
       session_timeout: session_timeout,
       heartbeat: heartbeat,
+      pause_manager: pause_manager,
     )
   }
 

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -11,7 +11,7 @@ describe Kafka::Consumer do
   let(:offset_manager) { double(:offset_manager) }
   let(:heartbeat) { double(:heartbeat) }
   let(:pause_manager) { Kafka::PauseManager.new }
-  let(:fetcher) { double(:fetcher, configure: nil, subscribe: nil, seek: nil, start: nil, stop: nil) }
+  let(:fetcher) { double(:fetcher, configure: nil, subscribe: nil, seek: nil, start: nil, stop: nil, clean: nil) }
   let(:session_timeout) { 30 }
   let(:assigned_partitions) { { "greetings" => [0] } }
 

--- a/spec/fetcher_spec.rb
+++ b/spec/fetcher_spec.rb
@@ -5,12 +5,16 @@ describe Kafka::Fetcher do
   let(:instrumenter) { double(:instrumenter) }
   let(:logger) { Logger.new(StringIO.new) }
   let(:cluster) { double(:cluster) }
+  let(:pause_manager) { double(:pause_manager) }
   let(:fetcher) do
-    described_class.new(group: group,
-                        instrumenter: instrumenter,
-                        logger: logger,
-                        cluster: cluster,
-                        max_queue_size: 1)
+    described_class.new(
+      group: group,
+      instrumenter: instrumenter,
+      logger: logger,
+      cluster: cluster,
+      max_queue_size: 1,
+      pause_manager: pause_manager,
+    )
   end
 
   before do

--- a/spec/functional/batch_consumer_spec.rb
+++ b/spec/functional/batch_consumer_spec.rb
@@ -201,9 +201,10 @@ describe "Batch Consumer API", functional: true do
     )
 
     consumer.resume(topic, 0)
-    sleep 5
+    sleep 10
     expect(records).to match_array(
       ['hello', 'hello2', 'hello3', 'hi', 'bye']
     )
+    t.kill
   end
 end

--- a/spec/functional/batch_consumer_spec.rb
+++ b/spec/functional/batch_consumer_spec.rb
@@ -89,4 +89,121 @@ describe "Batch Consumer API", functional: true do
       ]
     )
   end
+
+  example 'pause permanently a partition' do
+    topic = create_random_topic(num_partitions: 3)
+
+    kafka = Kafka.new(seed_brokers: kafka_brokers, client_id: "test")
+    producer = kafka.producer
+    producer.produce('hello', topic: topic, partition: 0)
+    producer.produce('hello2', topic: topic, partition: 0)
+    producer.produce('hi', topic: topic, partition: 1)
+    producer.produce('bye', topic: topic, partition: 2)
+    producer.deliver_messages
+
+    producer.produce('hello3', topic: topic, partition: 0)
+    producer.deliver_messages
+
+    consumer = kafka.consumer(group_id: SecureRandom.uuid)
+    consumer.subscribe(topic, max_bytes_per_partition: 50)
+
+    records = []
+    t = Thread.new do
+      consumer.each_batch do |batch|
+        batch.messages.each do |message|
+          if message.partition == 0
+            consumer.pause(topic, 0)
+          end
+          records << message.value
+        end
+      end
+    end
+    t.abort_on_exception = true
+
+    sleep 5
+    t.kill
+
+    expect(records).to match_array(
+      ['hello', 'hello2', 'hi', 'bye']
+    )
+  end
+
+  example 'pause with timeout' do
+    topic = create_random_topic(num_partitions: 3)
+
+    kafka = Kafka.new(seed_brokers: kafka_brokers, client_id: "test")
+    producer = kafka.producer
+    producer.produce('hello', topic: topic, partition: 0)
+    producer.produce('hello2', topic: topic, partition: 0)
+    producer.produce('hi', topic: topic, partition: 1)
+    producer.produce('bye', topic: topic, partition: 2)
+    producer.deliver_messages
+    producer.produce('hello3', topic: topic, partition: 0)
+    producer.deliver_messages
+
+    consumer = kafka.consumer(group_id: SecureRandom.uuid)
+    consumer.subscribe(topic, max_bytes_per_partition: 50)
+
+    records = []
+    t = Thread.new do
+      consumer.each_batch do |batch|
+        batch.messages.each do |message|
+          if message.partition == 0
+            consumer.pause(topic, 0, timeout: 4)
+          end
+          records << message.value
+        end
+      end
+    end
+    t.abort_on_exception = true
+
+    sleep 3
+    expect(records).to match_array(
+      ['hello', 'hello2', 'hi', 'bye']
+    )
+    sleep 10
+    expect(records).to match_array(
+      ['hello', 'hello2', 'hello3', 'hi', 'bye']
+    )
+    t.kill
+  end
+
+  example 'pause then resume' do
+    topic = create_random_topic(num_partitions: 3)
+
+    kafka = Kafka.new(seed_brokers: kafka_brokers, client_id: "test")
+    producer = kafka.producer
+    producer.produce('hello', topic: topic, partition: 0)
+    producer.produce('hello2', topic: topic, partition: 0)
+    producer.produce('hi', topic: topic, partition: 1)
+    producer.produce('bye', topic: topic, partition: 2)
+    producer.deliver_messages
+    producer.produce('hello3', topic: topic, partition: 0)
+    producer.deliver_messages
+
+    consumer = kafka.consumer(group_id: SecureRandom.uuid)
+    consumer.subscribe(topic, max_bytes_per_partition: 50)
+
+    records = []
+    t = Thread.new do
+      consumer.pause(topic, 0)
+      consumer.each_batch do |batch|
+        batch.messages.each do |message|
+          records << message.value
+        end
+      end
+    end
+    t.abort_on_exception = true
+
+    sleep 3
+    expect(records).to match_array(
+      ['hi', 'bye']
+    )
+
+    consumer.resume(topic, 0)
+    sleep 2
+    expect(records).to match_array(
+      ['hello', 'hello2', 'hello3', 'hi', 'bye']
+    )
+  end
 end

--- a/spec/functional/batch_consumer_spec.rb
+++ b/spec/functional/batch_consumer_spec.rb
@@ -201,7 +201,7 @@ describe "Batch Consumer API", functional: true do
     )
 
     consumer.resume(topic, 0)
-    sleep 2
+    sleep 5
     expect(records).to match_array(
       ['hello', 'hello2', 'hello3', 'hi', 'bye']
     )

--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -372,9 +372,11 @@ describe "Consumer API", functional: true do
     )
 
     consumer.resume(topic, 0)
-    sleep 5
+    sleep 10
     expect(records).to match_array(
       ['hello', 'hello2', 'hi', 'bye']
     )
+
+    t.kill
   end
 end

--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -372,7 +372,7 @@ describe "Consumer API", functional: true do
     )
 
     consumer.resume(topic, 0)
-    sleep 2
+    sleep 5
     expect(records).to match_array(
       ['hello', 'hello2', 'hi', 'bye']
     )

--- a/spec/locked_queue_spec.rb
+++ b/spec/locked_queue_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+describe Kafka::LockedQueue do
+  context '1 producer 1 consumer' do
+    let!(:queue) { described_class.new }
+
+    it 'transfers the data to the producer' do
+      records = []
+      t = Thread.new do
+        loop do
+          records << queue.deq
+          sleep 0.2
+        end
+      end
+      t.abort_on_exception = true
+
+      queue << 'one'
+      queue << 'two'
+      queue << 'three'
+      sleep 1
+
+      expect(records).to eql(%w(one two three))
+      t.kill
+    end
+  end
+
+  context '1 producer 3 consumers' do
+    let!(:queue) { described_class.new }
+
+    it 'spreads the data to consumers' do
+      records = {}
+      threads = (1..3).map do
+        Thread.new do
+          loop do
+            records[Thread.current] ||= []
+            records[Thread.current] << queue.deq
+            sleep 1
+          end
+        end.tap do |thread|
+          thread.abort_on_exception = true
+        end
+      end
+
+      queue << 'one'
+      queue << 'two'
+      queue << 'three'
+      queue << 'four'
+      sleep 0.5
+      expect(records.values.flatten).to match_array(%w(one two three))
+      expect(records.keys.count).to eql(3)
+      sleep 1
+      expect(records.values.flatten).to match_array(%w(one two three four))
+      expect(records.keys.count).to eql(3)
+      threads.map(&:kill)
+    end
+  end
+
+  context 'map data' do
+    let!(:queue) { described_class.new }
+
+    it 'spreads the data to consumers' do
+      records = []
+      threads = (1..3).map do
+        Thread.new do
+          loop do
+            records << queue.deq
+            sleep 1
+          end
+        end.tap do |thread|
+          thread.abort_on_exception = true
+        end
+      end
+
+      queue << 'one'
+      queue << 'two'
+      queue << 'three'
+      queue << 'four'
+      queue << 'five'
+      sleep 0.5
+      queue.map! do |value|
+        value * 2
+      end
+      sleep 2
+      expect(records).to match_array(
+        %w(one two three fourfour fivefive)
+      )
+      threads.map(&:kill)
+    end
+  end
+end

--- a/spec/offset_manager_spec.rb
+++ b/spec/offset_manager_spec.rb
@@ -5,14 +5,12 @@ require 'timecop'
 describe Kafka::OffsetManager do
   let(:cluster) { double(:cluster) }
   let(:group) { double(:group) }
-  let(:fetcher) { double(:fetcher) }
   let(:logger) { LOGGER }
 
   let(:offset_manager) {
     Kafka::OffsetManager.new(
       cluster: cluster,
       group: group,
-      fetcher: fetcher,
       logger: logger,
       commit_interval: commit_interval,
       commit_threshold: 0,
@@ -24,7 +22,6 @@ describe Kafka::OffsetManager do
 
   before do
     allow(group).to receive(:commit_offsets)
-    allow(fetcher).to receive(:seek)
   end
 
   describe "#commit_offsets" do
@@ -220,16 +217,6 @@ describe Kafka::OffsetManager do
       offset = offset_manager.next_offset_for(topic, partition)
 
       expect(offset).to eq seek_offset
-    end
-
-    it "propagates the seek to the fetcher" do
-      topic = "greetings"
-      partition = 0
-      offset = 14
-
-      offset_manager.seek_to(topic, partition, offset)
-
-      expect(fetcher).to have_received(:seek).with(topic, partition, offset)
     end
   end
 

--- a/spec/pause_manager_spec.rb
+++ b/spec/pause_manager_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "timecop"
+
+describe Kafka::PauseManager do
+  let(:manager) { described_class.new }
+
+  describe '#paused?' do
+    context 'call with non-existing partition' do
+      it 'returns false' do
+        expect(manager.paused?('hello', 12)).to eql(false)
+      end
+    end
+
+    context 'partition already paused' do
+      before do
+        manager.pause!('hello', 12)
+      end
+
+      it 'returns true' do
+        expect(manager.paused?('hello', 12)).to eql(true)
+      end
+    end
+
+    context 'partition resumed' do
+      before do
+        manager.pause!('hello', 12)
+        manager.resume!('hello', 12)
+      end
+
+      it 'returns false' do
+        expect(manager.paused?('hello', 12)).to eql(false)
+      end
+    end
+
+    context 'partition pause expired' do
+      it do
+        time = Time.now
+
+        Timecop.freeze time do
+          manager.pause!('hello', 12, timeout: 5)
+          Timecop.travel 3 do
+            expect(manager.paused?('hello', 12)).to eql(true)
+          end
+          Timecop.travel 6 do
+            expect(manager.paused?('hello', 12)).to eql(false)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Our recent implementation of pause mechanism supports limited use case. We need to extend it to support more practical use cases, described in https://github.com/zendesk/ruby-kafka/issues/552. A desired usage:

```ruby
kafka.deliver_message('Hello 1', topic: 'a')
kafka.deliver_message('Hello 2', topic: 'a')
kafka.deliver_message('Hello 3', topic: 'a')
consumer = kafka.consumer(group_id: 'consumer-name')
consumer.subscribe('a')
consumer.each_message do |message|
  p message
  consumer.pause(message.topic, message.partition)
end
# Expect only Hello 1 consumed.
```

Or

```ruby

consumer.each_batch do |batch|
  batch.messages.each do |message|
     p message
  end
  consumer.pause(message.topic, message.partition)  if message.partition == 0
end
# Expect partition 0 to be paused after the first batch
```

This issue is address at https://github.com/zendesk/ruby-kafka/pull/575 and https://github.com/zendesk/ruby-kafka/pull/553. However, the two PRs are outdated with the master branch, where from version 0.6.x, we introduce new threaded fetcher. That change makes the situation more complicated.

When a consumer pause a partition, rejecting it in the consumer loop is not enough. That leads to message lost when the consumer resumes. This will demonstrate the situation:
- Fetcher fetches batch 1 of topic/1
- Fetcher fetches batch 2 of topic/1
- Fetcher fetches batch 3 of topic/1
- Consumer pauses topic/1
- Consumer polls batch 1 from the fetcher, then rejected
- Consumer polls batch 2 from the fetcher, then rejected
- Fetcher fetches batch 4 of topic/1
- Consumer resumes topic/1
- Consumer consumes batch 3 and batch 4 and then commit offsets. We lost batch 1 and batch 2

To overcome this issue, I apply some big changes:
- Create PauseManager to manage pause state of multiple parittions and share this object between consumer and fetcher. Fetcher now only fetches the non-paused partitions.
- When a consumer pauses a partition it removes all the fetched batches of a partition in the fetcher.  To enable this, I have to replace fetcher's queue data structure and replace by a similar implementation called LockedQueue.
- Check carefully the pause state of a partition before processing a message. After processing, call seek on the fetcher of recently paused partition to prevent message duplication or lost. 