### PR TITLE
Discard messages that were fetched under a previous consumer group generation

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -458,7 +458,7 @@ module Kafka
         @offset_manager.clear_offsets_excluding(@group.assigned_partitions)
       end
 
-      @fetcher.reset(@group.generation_id)
+      @fetcher.reset
 
       @group.assigned_partitions.each do |topic, partitions|
         partitions.each do |partition|
@@ -515,18 +515,10 @@ module Kafka
         sleep 2
         []
       else
-        tag, message, generation_id = @fetcher.poll
+        tag, message = @fetcher.poll
 
         case tag
         when :batches
-          # Message batches are tagged with the current consumer group generation id, so we filter
-          # out messages from older consumer group generations that might be lingering in the
-          # fetcher queue.
-          if message.any? && generation_id && @group.generation_id > generation_id
-            @logger.warn "Skipping stale buffered messages from previous consumer group generation #{generation_id}"
-            return []
-          end
-
           # make sure any old batches, fetched prior to the completion of a consumer group sync,
           # are only processed if the batches are from brokers for which this broker is still responsible.
           message.select { |batch| @group.assigned_to?(batch.topic, batch.partition) }

--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -28,6 +28,10 @@ module Kafka
 
       # The maximum number of bytes to fetch per partition, by topic.
       @max_bytes_per_partition = {}
+
+      # An incrementing counter used to synchronize resets between the
+      # foreground and background thread.
+      @current_reset_counter = 0
     end
 
     def subscribe(topic, max_bytes_per_partition:)
@@ -85,6 +89,8 @@ module Kafka
     end
 
     private
+
+    attr_reader :current_reset_counter
 
     def loop
       @instrumenter.instrument("loop.fetcher", {
@@ -206,12 +212,6 @@ module Kafka
       sleep backoff
 
       []
-    end
-
-    # An incrementing counter used to synchronize resets between the
-    # foreground and background thread.
-    def current_reset_counter
-      @current_reset_counter ||= 0
     end
   end
 end

--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -76,7 +76,7 @@ module Kafka
       # Batches are tagged with the current reset counter value. If the batch
       # has a reset_counter < current_reset_counter, we know it was fetched
       # prior to the most recent reset and should be discarded.
-      if message.any? && current_reset_counter > reset_counter
+      if tag == :batches && message.any? && current_reset_counter > reset_counter
         @logger.warn "Skipping stale messages buffered prior to reset"
         return tag, []
       end

--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -61,8 +61,8 @@ module Kafka
       @commands << [:stop, []]
     end
 
-    def reset
-      @commands << [:reset, []]
+    def reset(new_generation_id)
+      @commands << [:reset, [new_generation_id]]
     end
 
     def data?
@@ -102,9 +102,10 @@ module Kafka
       @max_wait_time = max_wait_time
     end
 
-    def handle_reset
+    def handle_reset(new_generation_id = nil)
       @next_offsets.clear
       @queue.clear
+      @generation_id = new_generation_id
     end
 
     def handle_stop(*)
@@ -149,7 +150,7 @@ module Kafka
         @next_offsets[batch.topic][batch.partition] = batch.last_offset + 1 unless batch.unknown_last_offset?
       end
 
-      @queue << [:batches, batches]
+      @queue << [:batches, batches, @generation_id]
     rescue Kafka::NoPartitionsToFetchFrom
       @logger.warn "No partitions to fetch from, sleeping for 1s"
       sleep 1

--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -322,9 +322,9 @@ describe "Consumer API", functional: true do
       expect(@consumer_1_messages).to_not contain_duplicate_messages
       expect(@consumer_2_messages).to_not contain_duplicate_messages
     ensure
-      producer_thread&.kill
-      consumer_1_thread&.kill
-      consumer_2_thread&.kill
+      producer_thread && producer_thread.kill
+      consumer_1_thread && consumer_1_thread.kill
+      consumer_2_thread && consumer_2_thread.kill
     end
   end
 

--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -302,7 +302,11 @@ describe "Consumer API", functional: true do
       end.tap(&:abort_on_exception)
 
       # Ensure consumer 1 started processing
-      wait_until(timeout: 10) { @consumer_1_messages.size >= 5 }
+      begin
+        wait_until(timeout: 20) { @consumer_1_messages.size >= 5 }
+      rescue TimeoutError
+        fail "consumer #1 didn't consumer 5 messages within 20 seconds"
+      end
 
       # A single consumer joins the consumer group, forcing all consumers to
       # rejoin.
@@ -317,7 +321,11 @@ describe "Consumer API", functional: true do
       end.tap(&:abort_on_exception)
 
       # Ensure consumer 2 has joined the group and been assigned partitions
-      wait_until(timeout: 10) { @consumer_2_messages.size >= 5 }
+      begin
+        wait_until(timeout: 20) { @consumer_2_messages.size >= 5 }
+      rescue TimeoutError
+        fail "consumer #2 didn't consumer 5 messages within 20 seconds"
+      end
 
       expect(@consumer_1_messages).to_not contain_duplicate_messages
       expect(@consumer_2_messages).to_not contain_duplicate_messages


### PR DESCRIPTION
As described in https://github.com/zendesk/ruby-kafka/issues/664, when a consumer re-joins a consumer group, it instructs the fetcher to asynchronously reset and seek to committed offset positions. The consumer will then continue processing fetched messages until the reset and seek take place. When the seek eventually occurs, it will seek to offsets < most recently processed messages. 

This PR tags fetched message batches with the consumer group `generation_id` that was active when fetch took place. When a consumer re-joins a group and receives an incremented `generation_id`, it passes the `generation_id` along to the fetcher reset command. Then, the consumer discards messages until it sees the current `generation_id` in fetched batches and can be assured that the reset occurred. 

An alternative to this implementation would be to make `Fetcher#reset` synchronous. 

Closes https://github.com/zendesk/ruby-kafka/issues/664