### PR TITLE
Synchronously commit offsets after HeartbeatError

### DIFF
--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -327,8 +327,8 @@ describe "Consumer API", functional: true do
         fail "consumer #2 didn't consumer 5 messages within 20 seconds"
       end
 
-      expect(@consumer_1_messages).to_not contain_duplicate_messages
-      expect(@consumer_2_messages).to_not contain_duplicate_messages
+      expect(@consumer_1_messages + @consumer_2_messages)
+        .to_not contain_duplicate_messages
     ensure
       producer_thread && producer_thread.kill
       consumer_1_thread && consumer_1_thread.kill


### PR DESCRIPTION
As detailed in https://github.com/zendesk/ruby-kafka/issues/675, if a consumer has processed messages since the last offset commit, messages may be reprocessed after a consumer group rebalance. This PR attempts to synchronously commit offsets after the consumer learns of the rebalance (from `HeartbeatError`) and before rejoining the group. For reference, the java client also tries to [commit offsets before joining a group](https://github.com/apache/kafka/blob/044350f28e4d0edcc0503b2bc2593c0d25948ed0/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java#L449-L452):

```Java
    @Override
    protected void onJoinPrepare(int generation, String memberId) {
        // commit offsets prior to rebalance if auto-commit enabled
        maybeAutoCommitOffsetsSync(time.timer(rebalanceTimeoutMs));
```

Closes https://github.com/zendesk/ruby-kafka/issues/675