### PR TITLE
Avoid Ruby warnings about unused vars

### DIFF
--- a/lib/kafka/protocol/describe_groups_response.rb
+++ b/lib/kafka/protocol/describe_groups_response.rb
@@ -45,7 +45,7 @@ module Kafka
             member_id = decoder.string
             client_id = decoder.string
             client_host = decoder.string
-            metadata = decoder.bytes
+            _metadata = decoder.bytes
             assignment = MemberAssignment.decode(Decoder.from_string(decoder.bytes))
 
             Member.new(

--- a/lib/kafka/protocol/message.rb
+++ b/lib/kafka/protocol/message.rb
@@ -67,7 +67,7 @@ module Kafka
         offset = decoder.int64
         message_decoder = Decoder.from_string(decoder.bytes)
 
-        crc = message_decoder.int32
+        _crc = message_decoder.int32
         magic_byte = message_decoder.int8
         attributes = message_decoder.int8
 

--- a/lib/kafka/protocol/metadata_response.rb
+++ b/lib/kafka/protocol/metadata_response.rb
@@ -113,7 +113,7 @@ module Kafka
       # @param node_id [Integer] the node id of the broker.
       # @return [Kafka::BrokerInfo] information about the broker.
       def find_broker(node_id)
-        broker = @brokers.find {|broker| broker.node_id == node_id }
+        broker = @brokers.find {|b| b.node_id == node_id }
 
         raise Kafka::NoSuchBroker, "No broker with id #{node_id}" if broker.nil?
 
@@ -145,7 +145,7 @@ module Kafka
           node_id = decoder.int32
           host = decoder.string
           port = decoder.int32
-          rack = decoder.string
+          _rack = decoder.string
 
           BrokerInfo.new(
             node_id: node_id,
@@ -159,7 +159,7 @@ module Kafka
         topics = decoder.array do
           topic_error_code = decoder.int16
           topic_name = decoder.string
-          is_internal = decoder.boolean
+          _is_internal = decoder.boolean
 
           partitions = decoder.array do
             PartitionMetadata.new(


### PR DESCRIPTION
This PR tries to avoid "warning: assigned but unused variable" which is output by Ruby when warnings are enabled.

Thanks for maintaining this gem. Thanks a lot.