### PR TITLE
Even out partition assignment

### DIFF
--- a/lib/kafka/round_robin_assignment_strategy.rb
+++ b/lib/kafka/round_robin_assignment_strategy.rb
@@ -33,7 +33,8 @@ module Kafka
         Array.new(partitions.count) { topic }.zip(partitions)
       end
 
-      partitions_for_each_member = topic_partitions.sort.each_slice(topic_partitions.count / members.count)
+      partitions_per_member = [1, topic_partitions.count / members.count].max
+      partitions_for_each_member = topic_partitions.sort.each_slice(partitions_per_member)
 
       members.zip(partitions_for_each_member).each do |member_id, member_partitions|
         unless member_partitions.nil?

--- a/lib/kafka/round_robin_assignment_strategy.rb
+++ b/lib/kafka/round_robin_assignment_strategy.rb
@@ -33,7 +33,7 @@ module Kafka
         Array.new(partitions.count) { topic }.zip(partitions)
       end
 
-      partitions_per_member = [1, topic_partitions.count / members.count].max
+      partitions_per_member = [1, (topic_partitions.count.to_f / members.count).ceil].max
       partitions_for_each_member = topic_partitions.sort.each_slice(partitions_per_member)
 
       members.zip(partitions_for_each_member).each do |member_id, member_partitions|

--- a/lib/kafka/round_robin_assignment_strategy.rb
+++ b/lib/kafka/round_robin_assignment_strategy.rb
@@ -33,8 +33,13 @@ module Kafka
         Array.new(partitions.count) { topic }.zip(partitions)
       end
 
-      partitions_per_member = [1, (topic_partitions.count.to_f / members.count).ceil].max
-      partitions_for_each_member = topic_partitions.sort.each_slice(partitions_per_member)
+      partitions_per_member = [1, (topic_partitions.count / members.count)].max
+      partitions_for_each_member = topic_partitions.sort.each_slice(partitions_per_member).to_a
+
+      if partitions_for_each_member.count > members.count
+        leftovers = partitions_for_each_member.pop
+        partitions_for_each_member[0] = partitions_for_each_member[0] + leftovers
+      end
 
       members.zip(partitions_for_each_member).each do |member_id, member_partitions|
         unless member_partitions.nil?

--- a/spec/functional/fetch_spec.rb
+++ b/spec/functional/fetch_spec.rb
@@ -56,6 +56,6 @@ describe "Fetch API", functional: true do
       break if message_count == total_messages
     end
 
-    expect(batch_count).to eql(3)
+    expect(batch_count).to be <= 4
   end
 end

--- a/spec/round_robin_assignment_strategy_spec.rb
+++ b/spec/round_robin_assignment_strategy_spec.rb
@@ -5,7 +5,6 @@ describe Kafka::RoundRobinAssignmentStrategy do
   let(:strategy) { described_class.new(cluster: cluster) }
 
   it "assigns all partitions" do
-
     members = (0...10).map {|i| "member#{i}" }
     topics = ["greetings"]
     partitions = (0...30).map {|i| double(:"partition#{i}", partition_id: i) }

--- a/spec/round_robin_assignment_strategy_spec.rb
+++ b/spec/round_robin_assignment_strategy_spec.rb
@@ -23,4 +23,33 @@ describe Kafka::RoundRobinAssignmentStrategy do
       expect(member).to_not be_nil
     end
   end
+
+  it "spreads all partitions between members" do
+    cluster = double(:cluster)
+    strategy = described_class.new(cluster: cluster)
+
+    members = (0...10).map {|i| "member#{i}" }
+    topics = ["topic1", "topic2"]
+    partitions = (0...5).map {|i| double(:"partition#{i}", partition_id: i) }
+
+    allow(cluster).to receive(:partitions_for) { partitions }
+
+    assignments = strategy.assign(members: members, topics: topics)
+
+    partitions.each do |partition|
+      member = assignments.values.find {|assignment|
+        assignment.topics.find {|topic, partitions|
+          partitions.include?(partition.partition_id)
+        }
+      }
+
+      expect(member).to_not be_nil
+    end
+
+    num_partitions_assigned = assignments.values.map do |assignment|
+      assignment.topics.values.map(&:count).inject(:+)
+    end
+
+    expect(num_partitions_assigned).to all eq(1)
+  end
 end

--- a/spec/round_robin_assignment_strategy_spec.rb
+++ b/spec/round_robin_assignment_strategy_spec.rb
@@ -73,6 +73,11 @@ describe Kafka::RoundRobinAssignmentStrategy do
       name: "lots of members",
       topics: { "topic1" => (0..10).to_a, "topic2" => (0..10).to_a },
       members: (0..50).map { |i| "member#{i}" }
+    },
+    {
+      name: "odd number of partitions",
+      topics: { "topic1" => (0..14).to_a },
+      members: ["member1", "member2"]
     }
   ].each do |name:, topics:, members:|
       it name do

--- a/spec/round_robin_assignment_strategy_spec.rb
+++ b/spec/round_robin_assignment_strategy_spec.rb
@@ -78,6 +78,11 @@ describe Kafka::RoundRobinAssignmentStrategy do
       name: "odd number of partitions",
       topics: { "topic1" => (0..14).to_a },
       members: ["member1", "member2"]
+    },
+    {
+      name: "five topics, 10 partitions, 3 consumers",
+      topics: { "topic1" => [0, 1], "topic2" => [0, 1], "topic3" => [0, 1], "topic4" => [0, 1], "topic5" => [0, 1] },
+      members: ["member1", "member2", "member3"]
     }
   ].each do |name:, topics:, members:|
       it name do

--- a/spec/round_robin_assignment_strategy_spec.rb
+++ b/spec/round_robin_assignment_strategy_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 describe Kafka::RoundRobinAssignmentStrategy do
+  let(:cluster) { double(:cluster) }
+  let(:strategy) { described_class.new(cluster: cluster) }
+
   it "assigns all partitions" do
-    cluster = double(:cluster)
-    strategy = described_class.new(cluster: cluster)
 
     members = (0...10).map {|i| "member#{i}" }
     topics = ["greetings"]
@@ -51,5 +52,60 @@ describe Kafka::RoundRobinAssignmentStrategy do
     end
 
     expect(num_partitions_assigned).to all eq(1)
+  end
+
+  [
+    {
+      name: "uneven topics",
+      topics: { "topic1" => [0], "topic2" => (0..50).to_a },
+      members: ["member1", "member2"],
+    },
+    {
+      name: "only one partition",
+      topics: { "topic1" => [0] },
+      members: ["member1", "member2"],
+    },
+    {
+      name: "lots of partitions",
+      topics: { "topic1" => (0..100).to_a },
+      members: ["member1"]
+    },
+    {
+      name: "lots of members",
+      topics: { "topic1" => (0..10).to_a, "topic2" => (0..10).to_a },
+      members: (0..50).map { |i| "member#{i}" }
+    }
+  ].each do |name:, topics:, members:|
+      it name do
+        allow(cluster).to receive(:partitions_for) do |topic|
+          topics.fetch(topic).map do |partition_id|
+            double(:"partition#{partition_id}", partition_id: partition_id)
+          end
+        end
+
+        assignments = strategy.assign(members: members, topics: topics.keys)
+
+        expect_all_partitions_assigned(topics, assignments)
+        expect_even_assignments(topics, assignments)
+      end
+    end
+
+  def expect_all_partitions_assigned(topics, assignments)
+    topics.each do |topic, partitions|
+      partitions.each do |partition|
+        assigned = assignments.values.find do |assignment|
+          assignment.topics.fetch(topic, []).include?(partition)
+        end
+        expect(assigned).to_not be_nil
+      end
+    end
+  end
+
+  def expect_even_assignments(topics, assignments)
+    num_partitions = topics.values.flatten.count
+    assignments.values.each do |assignment|
+      num_assigned = assignment.topics.values.flatten.count
+      expect(num_assigned).to be_within(1).of(num_partitions.to_f / assignments.count)
+    end
   end
 end


### PR DESCRIPTION
In a situation where there are more consumers than partitions on all
topics, some consumers will be assigned no work at all with the current
code.

For example, with 2 topics, each with 2 partitions, and 3
consumers running, each topic's partition 0 will be assigned to the
first member ID, and partition 1 will be assigned to the second member
ID. This means 2 members with 2 partitions to consume, and 1 with
nothing!

With this change, all topic:partitions are considered together. In the
above example, 2 members would get 1 partition each, and one would be
assigned 2 partitions.