### PR TITLE
Fix wrong varint calculation that leads to message corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes and additions to the library will be listed here.
 
 ## Unreleased
+- Fix wrong encoding calculation that leads to message corruption (#682, #680)
 
 ## 0.7.3
 

--- a/lib/kafka/protocol/encoder.rb
+++ b/lib/kafka/protocol/encoder.rb
@@ -133,7 +133,7 @@ module Kafka
         int = ~int | 1 if int < 0
 
         chunks = []
-        while int & 0xff80 != 0
+        while int >> 7 != 0
           chunks << (int & 0x7f | 0x80)
           int >>= 7
         end

--- a/spec/protocol/encoder_spec.rb
+++ b/spec/protocol/encoder_spec.rb
@@ -42,6 +42,28 @@ describe Kafka::Protocol::Encoder do
           expect(binaries_in_io(io)).to eq ["10000010", "10100011", "00011010"]
         end
       end
+
+      context 'data is max positive int 64' do
+        it do
+          encoder = Kafka::Protocol::Encoder.new(io)
+          encoder.write_varint(2**63 - 1)
+          expect(binaries_in_io(io)).to eq [
+            "11111110", "11111111", "11111111", "11111111", "11111111",
+            "11111111", "11111111", "11111111", "11111111", "00000001"
+          ]
+        end
+      end
+
+      context 'data contains all trailing zero' do
+        it do
+          encoder = Kafka::Protocol::Encoder.new(io)
+          encoder.write_varint(2**62)
+          expect(binaries_in_io(io)).to eq [
+            "10000000", "10000000", "10000000", "10000000", "10000000",
+            "10000000", "10000000", "10000000", "10000000", "00000001"
+          ]
+        end
+      end
     end
 
     context 'data is negative' do
@@ -74,6 +96,17 @@ describe Kafka::Protocol::Encoder do
           encoder = Kafka::Protocol::Encoder.new(io)
           encoder.write_varint(-215233)
           expect(binaries_in_io(io)).to eq ["10000001", "10100011", "00011010"]
+        end
+      end
+
+      context 'data is min negative int 64' do
+        it do
+          encoder = Kafka::Protocol::Encoder.new(io)
+          encoder.write_varint(-2**63)
+          expect(binaries_in_io(io)).to eq [
+            "11111111", "11111111", "11111111", "11111111", "11111111",
+            "11111111", "11111111", "11111111", "11111111", "00000001"
+          ]
         end
       end
     end


### PR DESCRIPTION
The issue is reported in https://github.com/zendesk/ruby-kafka/issues/682 and https://github.com/zendesk/ruby-kafka/issues/680. In summary, ruby-kafka fails to deliver messages when the message size is equal to some magic number, like 32760 or 98296.

The issues come from varint encoding method of the encoder. The bit mask used in the method to determine the ending of encoding process is 16-bit long (2 bytes), which doesn't cover enough cases. Consider this example:
- Message size is 98296 byte. Record batch format adds some overhead and it becomes 98304 bytes.
- 98304 is `11000000000000000` in binary.
- When calculaing `int & 0xff80`, the 0xff80 is actually `000001111111110000000`
- So, the result is 0. This makes the process stop prematurely.

This error happens with all integers which are over 16-bit long, and have bit 7 -> 16 filled by zero. The condition is to stop when the integer has 7 bit left. So, we can replace error-prone bit mask by shifting operation, which produces the same result. 

I tested with reported examples. Could you please verify this fix on your system?
cc @doritochips, @jturkel