### PR TITLE
Mark fetcher as running before starting thread

### DIFF
--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -49,6 +49,8 @@ module Kafka
     def start
       return if @running
 
+      @running = true
+
       @thread = Thread.new do
         while @running
           loop
@@ -56,8 +58,6 @@ module Kafka
         @logger.info "Fetcher thread exited."
       end
       @thread.abort_on_exception = true
-
-      @running = true
     end
 
     def stop


### PR DESCRIPTION
This should fix #688 I think.

There seems to be a case where the background fetching thread starts running before `@running = true` executes. That causes the fetcher thread to shut itself down before it does any work.