### PR TITLE
Add the option of including metadata into messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,11 +734,14 @@ All notification events have the `client_id` key in the payload, referring to th
   * `topic` is the topic that the message was produced to.
   * `buffer_size` is the size of the producer buffer after adding the message.
   * `max_buffer_size` is the maximum size of the producer buffer.
+  * `metadata` is any additional metadata that was passed into the `produce` method.
 
 * `deliver_messages.producer.kafka` is sent whenever a producer attempts to deliver its buffered messages to the Kafka brokers. It includes the following payload:
   * `attempts` is the number of times delivery was attempted.
   * `message_count` is the number of messages for which delivery was attempted.
   * `delivered_message_count` is the number of messages that were acknowledged by the brokers - if this number is smaller than `message_count` not all messages were successfully delivered.
+  * You can also access failed messages if the `exception_object` is set
+    and refers to a `Kafka::DeliveryFailed` exception via `payload[:exception_object].failed_messages`.
 
 #### Consumer Notifications
 

--- a/lib/kafka/message_buffer.rb
+++ b/lib/kafka/message_buffer.rb
@@ -16,8 +16,9 @@ module Kafka
       @bytesize = 0
     end
 
-    def write(value:, key:, topic:, partition:, create_time: Time.now, headers: {})
-      message = Protocol::Record.new(key: key, value: value, create_time: create_time, headers: headers)
+    def write(value:, key:, topic:, partition:, create_time: Time.now, headers: {}, metadata: nil)
+      message = Protocol::Record.new(key: key, value: value, create_time: create_time, headers: headers,
+                                     metadata: metadata)
 
       buffer_for(topic, partition) << message
 

--- a/lib/kafka/pending_message.rb
+++ b/lib/kafka/pending_message.rb
@@ -2,9 +2,11 @@
 
 module Kafka
   class PendingMessage
-    attr_reader :value, :key, :headers, :topic, :partition, :partition_key, :create_time, :bytesize
+    attr_reader :value, :key, :headers, :topic, :partition, :partition_key,
+                :create_time, :bytesize, :metadata
 
-    def initialize(value:, key:, headers: {}, topic:, partition:, partition_key:, create_time:)
+    def initialize(value:, key:, headers: {}, topic:, partition:, partition_key:,
+                   create_time:, metadata: nil)
       @value = value
       @key = key
       @headers = headers
@@ -13,6 +15,7 @@ module Kafka
       @partition_key = partition_key
       @create_time = create_time
       @bytesize = key.to_s.bytesize + value.to_s.bytesize
+      @metadata = metadata
     end
 
     def ==(other)

--- a/lib/kafka/protocol/record.rb
+++ b/lib/kafka/protocol/record.rb
@@ -2,7 +2,8 @@ module Kafka
   module Protocol
     class Record
       attr_reader :key, :value, :headers, :attributes, :bytesize
-      attr_accessor :offset_delta, :timestamp_delta, :offset, :create_time, :is_control_record
+      attr_accessor :offset_delta, :timestamp_delta, :offset, :create_time,
+                    :is_control_record, :metadata
 
       def initialize(
         key: nil,
@@ -13,7 +14,8 @@ module Kafka
         offset: 0,
         timestamp_delta: 0,
         create_time: Time.now,
-        is_control_record: false
+        is_control_record: false,
+        metadata: nil
       )
         @key = key
         @value = value
@@ -25,6 +27,7 @@ module Kafka
         @timestamp_delta = timestamp_delta
         @create_time = create_time
         @is_control_record = is_control_record
+        @metadata = metadata
 
         @bytesize = @key.to_s.bytesize + @value.to_s.bytesize
       end

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -134,7 +134,7 @@ describe "Producer API", functional: true do
     expect(cluster).to receive(:add_target_topics)
     expect(cluster).to receive(:refresh_metadata_if_necessary!).and_raise(Kafka::ConnectionError)
 
-    instrumenter = Kafka::Instrumenter.new
+    instrumenter = Kafka::Instrumenter.new(client_id: 'abc')
 
     transman = instance_double(Kafka::TransactionManager)
     allow(transman).to receive(:transactional?).and_return(false)

--- a/spec/functional/producer_spec.rb
+++ b/spec/functional/producer_spec.rb
@@ -140,17 +140,17 @@ describe "Producer API", functional: true do
     allow(transman).to receive(:transactional?).and_return(false)
 
     producer = Kafka::Producer.new(
-                                cluster: cluster,
-                                transaction_manager: transman,
-                                logger: double('logger'),
-                                instrumenter: instrumenter,
-                                compressor: double('compressor'),
-                                ack_timeout: 5,
-                                required_acks: 1,
-                                max_retries: 0,
-                                retry_backoff: 0,
-                                max_buffer_size: 1000,
-                                max_buffer_bytesize: 1024
+      cluster: cluster,
+      transaction_manager: transman,
+      logger: double('logger'),
+      instrumenter: instrumenter,
+      compressor: double('compressor'),
+      ack_timeout: 5,
+      required_acks: 1,
+      max_retries: 0,
+      retry_backoff: 0,
+      max_buffer_size: 1000,
+      max_buffer_bytesize: 1024
     )
 
     callback = lambda do |*args|
@@ -166,11 +166,10 @@ describe "Producer API", functional: true do
 
     ActiveSupport::Notifications.subscribed(callback, 'deliver_messages.producer.kafka') do
       expect {
-        producer.produce('MyValue', topic: 'my-topic', metadata: { publisher_name: 'MyPublisher'})
-        producer.produce('MyValue2', topic: 'my-topic', metadata: { publisher_name: 'MyPublisher2'})
+        producer.produce('MyValue', topic: 'my-topic', metadata: { publisher_name: 'MyPublisher' })
+        producer.produce('MyValue2', topic: 'my-topic', metadata: { publisher_name: 'MyPublisher2' })
         producer.deliver_messages
       }.to raise_error(Kafka::DeliveryFailed)
     end
   end
-
 end


### PR DESCRIPTION
We have a pattern where we are using Kafka to be the data backbone for our systems - we write data into a database and use Kafka to publish that data. Sometimes there's downtime for our brokers or schema registry which results in a message being unable to be published even after retries. We have a method to re-publish this message after a wait time. However, at this point the database may have been updated, meaning the message would be outdated. We want to inspect the original payload to check the latest state and re-send the message.

The problem is that we've already Avro-encoded the message and we'd need to decode it again to get access to the original. We also need to store the class name we're using to do the publishing so it can use its internal logic to get the right model from the database.

This PR adds the ability to add metadata to all messages. This data is ignored most of the time, unless there is an error, at which point it is added into the `DeliveryFailed` exception.

Questions and comments welcome!