### PR TITLE
Add instrumentation for heartbeats

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -374,6 +374,7 @@ module Kafka
       heartbeat = Heartbeat.new(
         group: group,
         interval: heartbeat_interval,
+        instrumenter: instrumenter
       )
 
       Consumer.new(

--- a/lib/kafka/heartbeat.rb
+++ b/lib/kafka/heartbeat.rb
@@ -2,15 +2,20 @@
 
 module Kafka
   class Heartbeat
-    def initialize(group:, interval:)
+    def initialize(group:, interval:, instrumenter:)
       @group = group
       @interval = interval
       @last_heartbeat = Time.now
+      @instrumenter = instrumenter
     end
 
     def trigger!
-      @group.heartbeat
-      @last_heartbeat = Time.now
+      @instrumenter.instrument('heartbeat.consumer',
+        group_id: @group.group_id,
+        topic_partitions: @group.assigned_partitions) do
+           @group.heartbeat
+           @last_heartbeat = Time.now
+      end
     end
 
     def trigger


### PR DESCRIPTION
This is useful for lag reporting as heartbeats e.g. during batch processing are more frequent than the consumer loop.