### PR TITLE
Instrument batch fetching

### DIFF
--- a/lib/kafka/datadog.rb
+++ b/lib/kafka/datadog.rb
@@ -188,6 +188,20 @@ module Kafka
         gauge("consumer.lag", lag, tags: tags)
       end
 
+      def fetch_batch(event)
+        lag = event.payload.fetch(:offset_lag)
+        batch_size = event.payload.fetch(:message_count)
+
+        tags = {
+          client: event.payload.fetch(:client_id),
+          group_id: event.payload.fetch(:group_id),
+          topic: event.payload.fetch(:topic),
+          partition: event.payload.fetch(:partition),
+        }
+
+        histogram("consumer.batch_size", batch_size, tags: tags)
+      end
+
       def join_group(event)
         tags = {
           client: event.payload.fetch(:client_id),

--- a/lib/kafka/datadog.rb
+++ b/lib/kafka/datadog.rb
@@ -167,7 +167,6 @@ module Kafka
 
       def process_batch(event)
         offset = event.payload.fetch(:last_offset)
-        lag = event.payload.fetch(:offset_lag)
         messages = event.payload.fetch(:message_count)
 
         tags = {
@@ -185,7 +184,6 @@ module Kafka
         end
 
         gauge("consumer.offset", offset, tags: tags)
-        gauge("consumer.lag", lag, tags: tags)
       end
 
       def fetch_batch(event)
@@ -200,6 +198,7 @@ module Kafka
         }
 
         histogram("consumer.batch_size", batch_size, tags: tags)
+        gauge("consumer.lag", lag, tags: tags)
       end
 
       def join_group(event)

--- a/lib/kafka/statsd.rb
+++ b/lib/kafka/statsd.rb
@@ -129,7 +129,7 @@ module Kafka
         topic = event.payload.fetch(:topic)
         partition = event.payload.fetch(:partition)
 
-        histogram("consumer.#{client}.#{group_id}.#{topic}.#{partition}.batch_size", batch_size)
+        count("consumer.#{client}.#{group_id}.#{topic}.#{partition}.batch_size", batch_size)
         gauge("consumer.#{client}.#{group_id}.#{topic}.#{partition}.lag", lag)
       end
 

--- a/lib/kafka/statsd.rb
+++ b/lib/kafka/statsd.rb
@@ -124,6 +124,17 @@ module Kafka
         gauge("consumer.#{client}.#{group_id}.#{topic}.#{partition}.lag", lag)
       end
 
+      def fetch_batch(event)
+        lag = event.payload.fetch(:offset_lag)
+        batch_size = event.payload.fetch(:message_count)
+        client = event.payload.fetch(:client_id)
+        group_id = event.payload.fetch(:group_id)
+        topic = event.payload.fetch(:topic)
+        partition = event.payload.fetch(:partition)
+
+        histogram("consumer.#{client}.#{group_id}.#{topic}.#{partition}.batch_size", batch_size)
+      end
+
       def join_group(event)
         client = event.payload.fetch(:client_id)
         group_id = event.payload.fetch(:group_id)

--- a/lib/kafka/statsd.rb
+++ b/lib/kafka/statsd.rb
@@ -107,7 +107,6 @@ module Kafka
       end
 
       def process_batch(event)
-        lag = event.payload.fetch(:offset_lag)
         messages = event.payload.fetch(:message_count)
         client = event.payload.fetch(:client_id)
         group_id = event.payload.fetch(:group_id)
@@ -120,8 +119,6 @@ module Kafka
           timing("consumer.#{client}.#{group_id}.#{topic}.#{partition}.process_batch.latency", event.duration)
           count("consumer.#{client}.#{group_id}.#{topic}.#{partition}.messages", messages)
         end
-
-        gauge("consumer.#{client}.#{group_id}.#{topic}.#{partition}.lag", lag)
       end
 
       def fetch_batch(event)
@@ -133,6 +130,7 @@ module Kafka
         partition = event.payload.fetch(:partition)
 
         histogram("consumer.#{client}.#{group_id}.#{topic}.#{partition}.batch_size", batch_size)
+        gauge("consumer.#{client}.#{group_id}.#{topic}.#{partition}.lag", lag)
       end
 
       def join_group(event)


### PR DESCRIPTION
1. Track the offset lag _before_ processing a batch – if processing fails, we still want to know the lag.
2. Start tracking the size of batches. This can be important when tuning e.g. max bytes per partition in order to not overwhelm a downstream system.