### PR TITLE
Allow the partitioner implementation to be pluggable

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -71,7 +71,7 @@ module Kafka
                    ssl_client_cert_key_password: nil, ssl_client_cert_chain: nil, sasl_gssapi_principal: nil,
                    sasl_gssapi_keytab: nil, sasl_plain_authzid: '', sasl_plain_username: nil, sasl_plain_password: nil,
                    sasl_scram_username: nil, sasl_scram_password: nil, sasl_scram_mechanism: nil,
-                   sasl_over_ssl: true, ssl_ca_certs_from_system: false, sasl_oauth_token_provider: nil, ssl_verify_hostname: true)
+                   sasl_over_ssl: true, ssl_ca_certs_from_system: false, partitioner: nil, sasl_oauth_token_provider: nil, ssl_verify_hostname: true)
       @logger = TaggedLogger.new(logger)
       @instrumenter = Instrumenter.new(client_id: client_id)
       @seed_brokers = normalize_seed_brokers(seed_brokers)
@@ -115,6 +115,7 @@ module Kafka
       )
 
       @cluster = initialize_cluster
+      @partitioner = partitioner || Partitioner.new
     end
 
     # Delivers a single message to the Kafka cluster.
@@ -150,7 +151,7 @@ module Kafka
 
       if partition.nil?
         partition_count = @cluster.partitions_for(topic).count
-        partition = Partitioner.partition_for_key(partition_count, message)
+        partition = @partitioner.partition_for_key(partition_count, message)
       end
 
       buffer = MessageBuffer.new
@@ -284,6 +285,7 @@ module Kafka
         retry_backoff: retry_backoff,
         max_buffer_size: max_buffer_size,
         max_buffer_bytesize: max_buffer_bytesize,
+        partitioner: @partitioner,
       )
     end
 

--- a/lib/kafka/partitioner.rb
+++ b/lib/kafka/partitioner.rb
@@ -19,7 +19,7 @@ module Kafka
     # @param message [Kafka::PendingMessage] the message that should be assigned
     #   a partition.
     # @return [Integer] the partition number.
-    def self.partition_for_key(partition_count, message)
+    def partition_for_key(partition_count, message)
       raise ArgumentError if partition_count == 0
 
       # If no explicit partition key is specified we use the message key instead.

--- a/spec/partitioner_spec.rb
+++ b/spec/partitioner_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Kafka::Partitioner, "#partition_for_key" do
-  let(:partitioner) { Kafka::Partitioner }
+  let(:partitioner) { Kafka::Partitioner.new }
   let(:message) { double(:message, key: nil, partition_key: "yolo") }
 
   it "deterministically returns a partition number for a partition key and partition count" do

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -2,6 +2,7 @@
 
 require "fake_broker"
 require "timecop"
+require "kafka/partitioner"
 
 describe Kafka::Producer do
   let(:logger) { LOGGER }
@@ -12,6 +13,7 @@ describe Kafka::Producer do
   let(:cluster) { double(:cluster) }
   let(:transaction_manager) { double(:transaction_manager) }
   let(:producer) { initialize_producer }
+  let(:partitioner) { Kafka::Partitioner.new }
 
   before do
     allow(cluster).to receive(:mark_as_stale!)
@@ -367,6 +369,7 @@ describe Kafka::Producer do
       required_acks: 1,
       max_buffer_size: 1000,
       max_buffer_bytesize: 10_000_000,
+      partitioner: partitioner,
     }
 
     Kafka::Producer.new(**default_options.merge(options))


### PR DESCRIPTION
This PR enables a customer partitioner implementation to be used, which can be useful if you are producing from the Java and Ruby clients for example and want to ensure you are using a consistent hashing method across the two.