### PR TITLE
use maxTimestamp for logAppendTime timestamps

### DIFF
--- a/lib/kafka/protocol/record_batch.rb
+++ b/lib/kafka/protocol/record_batch.rb
@@ -11,6 +11,7 @@ module Kafka
       CODEC_ID_MASK = 0b00000111
       IN_TRANSACTION_MASK = 0b00010000
       IS_CONTROL_BATCH_MASK = 0b00100000
+      TIMESTAMP_TYPE_MASK = 0b001000
 
       attr_reader :records, :first_offset, :first_timestamp, :partition_leader_epoch, :in_transaction, :is_control_batch, :last_offset_delta, :max_timestamp, :producer_id, :producer_epoch, :first_sequence
 
@@ -163,6 +164,7 @@ module Kafka
         codec_id = attributes & CODEC_ID_MASK
         in_transaction = (attributes & IN_TRANSACTION_MASK) > 0
         is_control_batch = (attributes & IS_CONTROL_BATCH_MASK) > 0
+        log_append_time = (attributes & TIMESTAMP_TYPE_MASK) != 0
 
         last_offset_delta = record_batch_decoder.int32
         first_timestamp = Time.at(record_batch_decoder.int64 / 1000)
@@ -186,7 +188,7 @@ module Kafka
         until records_array_decoder.eof?
           record = Record.decode(records_array_decoder)
           record.offset = first_offset + record.offset_delta
-          record.create_time = first_timestamp + record.timestamp_delta
+          record.create_time = log_append_time && max_timestamp ? max_timestamp : first_timestamp + record.timestamp_delta
           records_array << record
         end
 


### PR DESCRIPTION
When consuming records that were produced to kafka with the new Record format and when the `log.message.timestamp.type` configuration for the broker/topic is `LogAppendTime`, we need to fetch the record timestamp from `maxTimestamp` field and not from `FirstTimestamp + delta`. Because Kafka send `-1` as the `FirstTimestamp` in this case.

This Pr fix this.

Similar implementation can be found for other clients:
https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java#L325-L327
https://github.com/Shopify/sarama/blob/a6c1f7eaf9e4ed696183f5be645361ac97ab38bf/consumer.go#L526-L528
