### PR TITLE
Async producer limit number of retries

### DIFF
--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -258,7 +258,7 @@ module Kafka
             retry
           else
             @logger.error("Failed to asynchronously produce messages due to BufferOverflow")
-            @instrumenter.instrument("error.async_producer", {error: e})
+            @instrumenter.instrument("error.async_producer", { error: e })
           end
         end
       end

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -254,7 +254,7 @@ module Kafka
           end
           if retries < @max_retries
             retries += 1
-            sleep @retry_backoff ** retries
+            sleep @retry_backoff**retries
             retry
           else
             @logger.error("Failed to asynchronously produce messages due to BufferOverflow")

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -83,13 +83,13 @@ module Kafka
       @logger = TaggedLogger.new(logger)
 
       @worker = Worker.new(
-          queue: @queue,
-          producer: sync_producer,
-          delivery_threshold: delivery_threshold,
-          max_retries: max_retries,
-          retry_backoff: retry_backoff,
-          instrumenter: instrumenter,
-          logger: logger,
+        queue: @queue,
+        producer: sync_producer,
+        delivery_threshold: delivery_threshold,
+        max_retries: max_retries,
+        retry_backoff: retry_backoff,
+        instrumenter: instrumenter,
+        logger: logger
       )
 
       # The timer will no-op if the delivery interval is zero.
@@ -107,16 +107,16 @@ module Kafka
 
       if @queue.size >= @max_queue_size
         buffer_overflow topic,
-                        "Cannot produce to #{topic}, max queue size (#{@max_queue_size} messages) reached"
+          "Cannot produce to #{topic}, max queue size (#{@max_queue_size} messages) reached"
       end
 
       args = [value, **options.merge(topic: topic)]
       @queue << [:produce, args]
 
       @instrumenter.instrument("enqueue_message.async_producer", {
-          topic: topic,
-          queue_size: @queue.size,
-          max_queue_size: @max_queue_size,
+        topic: topic,
+        queue_size: @queue.size,
+        max_queue_size: @max_queue_size,
       })
 
       nil
@@ -151,18 +151,18 @@ module Kafka
     def ensure_threads_running!
       THREAD_MUTEX.synchronize do
         @worker_thread = nil unless @worker_thread && @worker_thread.alive?
-        @worker_thread ||= Thread.new {@worker.run}
+        @worker_thread ||= Thread.new { @worker.run }
       end
 
       THREAD_MUTEX.synchronize do
         @timer_thread = nil unless @timer_thread && @timer_thread.alive?
-        @timer_thread ||= Thread.new {@timer.run}
+        @timer_thread ||= Thread.new { @timer.run }
       end
     end
 
     def buffer_overflow(topic, message)
       @instrumenter.instrument("buffer_overflow.async_producer", {
-          topic: topic,
+        topic: topic,
       })
 
       raise BufferOverflow, message
@@ -217,7 +217,7 @@ module Kafka
               @logger.error("Failed to deliver messages during shutdown: #{e.message}")
 
               @instrumenter.instrument("drop_messages.async_producer", {
-                  message_count: @producer.buffer_size + @queue.size,
+                message_count: @producer.buffer_size + @queue.size,
               })
             end
 
@@ -253,11 +253,11 @@ module Kafka
             retry
           elsif retries < @max_retries
             retries += 1
-            sleep @retry_backoff ** retries
+            sleep @retry_backoff**retries
             retry
           else
             @logger.error("Failed to asynchronously produce messages due to BufferOverflow")
-            @instrumenter.instrument("error.async_producer", {error: e})
+            @instrumenter.instrument("error.async_producer", { error: e })
           end
         end
       end
@@ -267,12 +267,12 @@ module Kafka
       rescue DeliveryFailed, ConnectionError => e
         # Failed to deliver messages -- nothing to do but log and try again later.
         @logger.error("Failed to asynchronously deliver messages: #{e.message}")
-        @instrumenter.instrument("error.async_producer", {error: e})
+        @instrumenter.instrument("error.async_producer", { error: e })
       end
 
       def threshold_reached?
         @delivery_threshold > 0 &&
-            @producer.buffer_size >= @delivery_threshold
+          @producer.buffer_size >= @delivery_threshold
       end
     end
   end

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -72,7 +72,7 @@ module Kafka
     # @param delivery_interval [Integer] if greater than zero, the number of
     #   seconds between automatic message deliveries.
     #
-    def initialize(sync_producer:, max_queue_size: 1000, delivery_threshold: 0, delivery_interval: 0, instrumenter:, logger:)
+    def initialize(sync_producer:, max_queue_size: 1000, delivery_threshold: 0, delivery_interval: 0, max_retries: -1, retry_backoff: 0, instrumenter:, logger:)
       raise ArgumentError unless max_queue_size > 0
       raise ArgumentError unless delivery_threshold >= 0
       raise ArgumentError unless delivery_interval >= 0
@@ -86,6 +86,8 @@ module Kafka
         queue: @queue,
         producer: sync_producer,
         delivery_threshold: delivery_threshold,
+        max_retries: max_retries,
+        retry_backoff: retry_backoff,
         instrumenter: instrumenter,
         logger: logger,
       )
@@ -184,10 +186,12 @@ module Kafka
     end
 
     class Worker
-      def initialize(queue:, producer:, delivery_threshold:, instrumenter:, logger:)
+      def initialize(queue:, producer:, delivery_threshold:, max_retries: -1, retry_backoff: 0, instrumenter:, logger:)
         @queue = queue
         @producer = producer
         @delivery_threshold = delivery_threshold
+        @max_retries = max_retries
+        @retry_backoff = retry_backoff
         @instrumenter = instrumenter
         @logger = TaggedLogger.new(logger)
       end
@@ -240,10 +244,23 @@ module Kafka
       private
 
       def produce(*args)
-        @producer.produce(*args)
-      rescue BufferOverflow
-        deliver_messages
-        retry
+        retries = 0
+        begin
+          @producer.produce(*args)
+        rescue BufferOverflow => e
+          deliver_messages
+          if @max_retries == -1
+            retry
+          end
+          if retries < @max_retries
+            retries += 1
+            sleep(@retry_backoff ** retries)
+            retry
+          else
+            @logger.error("Failed to asynchronously produce messages due to BufferOverflow")
+            @instrumenter.instrument("error.async_producer", {error: e})
+          end
+        end
       end
 
       def deliver_messages

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -254,7 +254,7 @@ module Kafka
           end
           if retries < @max_retries
             retries += 1
-            sleep(@retry_backoff ** retries)
+            sleep @retry_backoff ** retries
             retry
           else
             @logger.error("Failed to asynchronously produce messages due to BufferOverflow")

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -296,7 +296,7 @@ module Kafka
     #
     # @see AsyncProducer
     # @return [AsyncProducer]
-    def async_producer(delivery_interval: 0, delivery_threshold: 0, max_queue_size: 1000, **options)
+    def async_producer(delivery_interval: 0, delivery_threshold: 0, max_queue_size: 1000, max_retries: -1, retry_backoff: 0, **options)
       sync_producer = producer(**options)
 
       AsyncProducer.new(
@@ -304,6 +304,8 @@ module Kafka
         delivery_interval: delivery_interval,
         delivery_threshold: delivery_threshold,
         max_queue_size: max_queue_size,
+        max_retries: max_retries,
+        retry_backoff: retry_backoff,
         instrumenter: @instrumenter,
         logger: @logger,
       )

--- a/spec/async_producer_spec.rb
+++ b/spec/async_producer_spec.rb
@@ -76,7 +76,6 @@ describe Kafka::AsyncProducer do
       sleep 0.2 # wait for worker to call produce
 
       expect(sync_producer).to have_received(:produce)
-
     end
 
     it "retries until configured max_retries" do
@@ -90,7 +89,6 @@ describe Kafka::AsyncProducer do
       metric = instrumenter.metrics_for("error.async_producer").first
       expect(metric.payload[:error]).to be_a(Kafka::BufferOverflow)
       expect(sync_producer).to have_received(:produce).exactly(3).times
-
     end
   end
 end

--- a/spec/async_producer_spec.rb
+++ b/spec/async_producer_spec.rb
@@ -27,6 +27,8 @@ describe Kafka::AsyncProducer do
     Kafka::AsyncProducer.new(
       sync_producer: sync_producer,
       instrumenter: instrumenter,
+      max_retries: 2,
+      retry_backoff: 0.2,
       logger: logger,
     )
   }
@@ -65,6 +67,30 @@ describe Kafka::AsyncProducer do
 
       metric = instrumenter.metrics_for("drop_messages.async_producer").first
       expect(metric.payload[:message_count]).to eq 42
+    end
+  end
+
+  describe "#produce" do
+    it "delivers buffered messages" do
+      async_producer.produce("hello", topic: "greetings")
+      sleep 0.2 # wait for worker to call produce
+
+      expect(sync_producer).to have_received(:produce)
+
+    end
+
+    it "retries until configured max_retries" do
+      allow(sync_producer).to receive(:produce) {raise Kafka::BufferOverflow}
+
+      async_producer.produce("hello", topic: "greetings")
+      sleep 0.3 # wait for all retries to be done
+
+      expect(log.string).to include "Failed to asynchronously produce messages due to BufferOverflow"
+
+      metric = instrumenter.metrics_for("error.async_producer").first
+      expect(metric.payload[:error]).to be_a(Kafka::BufferOverflow)
+      expect(sync_producer).to have_received(:produce).exactly(3).times
+
     end
   end
 end


### PR DESCRIPTION
Related issue: https://github.com/zendesk/ruby-kafka/issues/707