### PR TITLE
Support SASL OAuthBearer Authentication

### DIFF
--- a/lib/kafka.rb
+++ b/lib/kafka.rb
@@ -351,6 +351,10 @@ module Kafka
   class FailedScramAuthentication < SaslScramError
   end
 
+  # The Token Provider object used for SASL OAuthBearer does not implement the method `token`
+  class NoTokenMethodError < Error
+  end
+
   # Initializes a new Kafka client.
   #
   # @see Client#initialize

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -62,13 +62,16 @@ module Kafka
     #
     # @param sasl_over_ssl [Boolean] whether to enforce SSL with SASL
     #
+    # @param sasl_oauth_token_provider [Object, nil] OAuthBearer Token Provider class that
+    #   implements method token. See {Sasl::OAuth#initialize}
+    #
     # @return [Client]
     def initialize(seed_brokers:, client_id: "ruby-kafka", logger: nil, connect_timeout: nil, socket_timeout: nil,
                    ssl_ca_cert_file_path: nil, ssl_ca_cert: nil, ssl_client_cert: nil, ssl_client_cert_key: nil,
                    ssl_client_cert_key_password: nil, ssl_client_cert_chain: nil, sasl_gssapi_principal: nil,
                    sasl_gssapi_keytab: nil, sasl_plain_authzid: '', sasl_plain_username: nil, sasl_plain_password: nil,
                    sasl_scram_username: nil, sasl_scram_password: nil, sasl_scram_mechanism: nil,
-                   sasl_over_ssl: true, ssl_ca_certs_from_system: false)
+                   sasl_over_ssl: true, ssl_ca_certs_from_system: false, sasl_oauth_token_provider: nil)
       @logger = TaggedLogger.new(logger)
       @instrumenter = Instrumenter.new(client_id: client_id)
       @seed_brokers = normalize_seed_brokers(seed_brokers)
@@ -92,6 +95,7 @@ module Kafka
         sasl_scram_username: sasl_scram_username,
         sasl_scram_password: sasl_scram_password,
         sasl_scram_mechanism: sasl_scram_mechanism,
+        sasl_oauth_token_provider: sasl_oauth_token_provider,
         logger: @logger
       )
 

--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -107,7 +107,6 @@ module Kafka
         response = wait_for_response(response_class, notification) unless response_class.nil?
 
         @last_request = Time.now
-        @logger.debug response
         response
       end
     rescue SystemCallError, EOFError, IOError => e

--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -107,7 +107,7 @@ module Kafka
         response = wait_for_response(response_class, notification) unless response_class.nil?
 
         @last_request = Time.now
-
+        @logger.debug response
         response
       end
     rescue SystemCallError, EOFError, IOError => e

--- a/lib/kafka/protocol/decoder.rb
+++ b/lib/kafka/protocol/decoder.rb
@@ -163,7 +163,6 @@ module Kafka
         return "" if number_of_bytes == 0
 
         data = @io.read(number_of_bytes) or raise EOFError
-
         # If the `read` call returned less data than expected we should not
         # proceed.
         raise EOFError if data.size != number_of_bytes

--- a/lib/kafka/protocol/decoder.rb
+++ b/lib/kafka/protocol/decoder.rb
@@ -163,6 +163,7 @@ module Kafka
         return "" if number_of_bytes == 0
 
         data = @io.read(number_of_bytes) or raise EOFError
+
         # If the `read` call returned less data than expected we should not
         # proceed.
         raise EOFError if data.size != number_of_bytes

--- a/lib/kafka/protocol/sasl_handshake_request.rb
+++ b/lib/kafka/protocol/sasl_handshake_request.rb
@@ -8,7 +8,7 @@ module Kafka
 
     class SaslHandshakeRequest
 
-      SUPPORTED_MECHANISMS = %w(GSSAPI PLAIN SCRAM-SHA-256 SCRAM-SHA-512)
+      SUPPORTED_MECHANISMS = %w(GSSAPI PLAIN SCRAM-SHA-256 SCRAM-SHA-512 OAUTHBEARER)
 
       def initialize(mechanism)
         unless SUPPORTED_MECHANISMS.include?(mechanism)

--- a/lib/kafka/sasl/oauth.rb
+++ b/lib/kafka/sasl/oauth.rb
@@ -51,12 +51,12 @@ module Kafka
       private
 
       def initial_client_response
-        "n,,\x01auth=Bearer #{@token_provider.token}#{token_extensions}\x01\x01"#.force_encoding("utf-8")
+        "n,,\x01auth=Bearer #{@token_provider.token}#{token_extensions}\x01\x01"
       end
 
       def token_extensions
         return nil unless @token_provider.respond_to? :extensions
-        "\x01#{@token_provider.extensions.map{|e| e.join("=")}.join("\x01")}"
+        "\x01#{@token_provider.extensions.map {|e| e.join("=")}.join("\x01")}"
       end
     end
   end

--- a/lib/kafka/sasl/oauth.rb
+++ b/lib/kafka/sasl/oauth.rb
@@ -51,6 +51,7 @@ module Kafka
       private
 
       def initial_client_response
+        raise Kafka::NoTokenMethodError, "Token provider doesn't define 'token'" unless @token_provider.respond_to? :token
         "n,,\x01auth=Bearer #{@token_provider.token}#{token_extensions}\x01\x01"
       end
 

--- a/lib/kafka/sasl/oauth.rb
+++ b/lib/kafka/sasl/oauth.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Kafka
+  module Sasl
+    class OAuth
+      OAUTH_IDENT = "OAUTHBEARER"
+
+      # token_provider: THE FOLLOWING INTERFACE MUST BE FULFILLED:
+      #
+      # [REQUIRED] TokenProvider#token      - Returns an ID/Access Token to be sent to the Kafka client.
+      #   The implementation should ensure token reuse so that multiple calls at connect time do not
+      #   create multiple tokens. The implementation should also periodically refresh the token in
+      #   order to guarantee that each call returns an unexpired token. A timeout error should
+      #   be returned after a short period of inactivity so that the broker can log debugging
+      #   info and retry.
+      #
+      # [OPTIONAL] TokenProvider#extensions - Returns a map of key-value pairs that can be sent with the
+      #   SASL/OAUTHBEARER initial client response. If not provided, the values are ignored. This feature
+      #   is only available in Kafka >= 2.1.0.
+      #
+      def initialize(logger:, token_provider:)
+        @logger = TaggedLogger.new(logger)
+        @token_provider = token_provider
+      end
+
+      def ident
+        OAUTH_IDENT
+      end
+
+      def configured?
+        @token_provider
+      end
+
+      def authenticate!(host, encoder, decoder)
+        # Send SASLOauthBearerClientResponse with token
+        @logger.debug "Authenticating to #{host} with SASL #{OAUTH_IDENT}"
+
+        encoder.write_bytes(initial_client_response)
+
+        begin
+          # receive SASL OAuthBearer Server Response
+          msg = decoder.bytes
+          raise Kafka::Error, "SASL #{OAUTH_IDENT} authentication failed: unknown error" unless msg
+        rescue Errno::ETIMEDOUT, EOFError => e
+          raise Kafka::Error, "SASL #{OAUTH_IDENT} authentication failed: #{e.message}"
+        end
+
+        @logger.debug "SASL #{OAUTH_IDENT} authentication successful."
+      end
+
+      private
+
+      def initial_client_response
+        "n,,\x01auth=Bearer #{@token_provider.token}#{token_extensions}\x01\x01"#.force_encoding("utf-8")
+      end
+
+      def token_extensions
+        return nil unless @token_provider.respond_to? :extensions
+        "\x01#{@token_provider.extensions.map{|e| e.join("=")}.join("\x01")}"
+      end
+    end
+  end
+end

--- a/lib/kafka/sasl_authenticator.rb
+++ b/lib/kafka/sasl_authenticator.rb
@@ -3,12 +3,14 @@
 require 'kafka/sasl/plain'
 require 'kafka/sasl/gssapi'
 require 'kafka/sasl/scram'
+require 'kafka/sasl/oauth'
 
 module Kafka
   class SaslAuthenticator
     def initialize(logger:, sasl_gssapi_principal:, sasl_gssapi_keytab:,
                    sasl_plain_authzid:, sasl_plain_username:, sasl_plain_password:,
-                   sasl_scram_username:, sasl_scram_password:, sasl_scram_mechanism:)
+                   sasl_scram_username:, sasl_scram_password:, sasl_scram_mechanism:,
+                   sasl_oauth_token_provider:)
       @logger = TaggedLogger.new(logger)
 
       @plain = Sasl::Plain.new(
@@ -31,7 +33,12 @@ module Kafka
         logger: @logger,
       )
 
-      @mechanism = [@gssapi, @plain, @scram].find(&:configured?)
+      @oauth = Sasl::OAuth.new(
+        token_provider: sasl_oauth_token_provider,
+        logger: @logger,
+      )
+
+      @mechanism = [@gssapi, @plain, @scram, @oauth].find(&:configured?)
     end
 
     def enabled?

--- a/spec/fake_server.rb
+++ b/spec/fake_server.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class FakeServer
-  SUPPORTED_MECHANISMS = ['PLAIN', 'SCRAM-SHA-256', 'SCRAM-SHA-512']
+  SUPPORTED_MECHANISMS = ['PLAIN', 'SCRAM-SHA-256', 'SCRAM-SHA-512', 'OAUTHBEARER']
 
   def self.start(server)
     thread = Thread.new { new(server).start }
@@ -77,6 +77,10 @@ class FakeServer
       end
     when 'SCRAM-SHA-256', 'SCRAM-SHA-512'
       scram_sasl_authenticate(auth_mechanism[6..-1], encoder, decoder)
+    when 'OAUTHBEARER'
+      message = decoder.bytes
+      puts 'OAUTHBEARER: ', message
+      encoder.write_bytes('')
     else
       puts "UNKNOWN AUTH MECHANISM"
     end

--- a/spec/fake_server.rb
+++ b/spec/fake_server.rb
@@ -79,8 +79,9 @@ class FakeServer
       scram_sasl_authenticate(auth_mechanism[6..-1], encoder, decoder)
     when 'OAUTHBEARER'
       message = decoder.bytes
-      puts 'OAUTHBEARER: ', message
-      encoder.write_bytes('')
+      if message == "n,,\x01auth=Bearer SASLOAUTHBEARER.TEST_ID_TOKEN\x01test_key=test_value\x01test_key_2=test_value_2\x01\x01"
+        encoder.write_bytes('')
+      end
     else
       puts "UNKNOWN AUTH MECHANISM"
     end

--- a/spec/fake_token_provider.rb
+++ b/spec/fake_token_provider.rb
@@ -5,7 +5,7 @@ class FakeTokenProvider
   end
 
   def token
-     "SASLOAUTHBEARER.TEST_ID_TOKEN"
+    "SASLOAUTHBEARER.TEST_ID_TOKEN"
   end
 
   def extensions

--- a/spec/fake_token_provider.rb
+++ b/spec/fake_token_provider.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class FakeTokenProvider
+    def initialize
+    end
+
+    def token
+        "SASLOauthbearerMessageTest"
+    end
+
+    def extensions
+        { test_key: "test_value", test_key_2: "test_value_2" }
+    end
+end

--- a/spec/fake_token_provider.rb
+++ b/spec/fake_token_provider.rb
@@ -5,10 +5,15 @@ class FakeTokenProvider
   end
 
   def token
-     "SASLOauthbearerMessageTest"
+     "SASLOAUTHBEARER.TEST_ID_TOKEN"
   end
 
   def extensions
     { test_key: "test_value", test_key_2: "test_value_2" }
+  end
+end
+
+class FakeBrokenTokenProvider
+  def initialize
   end
 end

--- a/spec/fake_token_provider.rb
+++ b/spec/fake_token_provider.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class FakeTokenProvider
-    def initialize
-    end
+  def initialize
+  end
 
-    def token
-        "SASLOauthbearerMessageTest"
-    end
+  def token
+     "SASLOauthbearerMessageTest"
+  end
 
-    def extensions
-        { test_key: "test_value", test_key_2: "test_value_2" }
-    end
+  def extensions
+    { test_key: "test_value", test_key_2: "test_value_2" }
+  end
 end

--- a/spec/protocol/sasl_handshake_request_spec.rb
+++ b/spec/protocol/sasl_handshake_request_spec.rb
@@ -20,6 +20,9 @@ describe Kafka::Protocol::SaslHandshakeRequest do
         it "allows SCRAM-SHA-512" do
           expect { Kafka::Protocol::SaslHandshakeRequest.new('SCRAM-SHA-512') }.not_to raise_error
         end
+        it "allows OAUTHBEARER" do
+          expect { Kafka::Protocol::SaslHandshakeRequest.new('OAUTHBEARER') }.not_to raise_error
+        end
       end
       context "#unsupported" do
         it "reject unknown handshake" do

--- a/spec/sasl_authenticator_spec.rb
+++ b/spec/sasl_authenticator_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'fake_server'
+require 'fake_token_provider'
 
 describe Kafka::SaslAuthenticator do
   let(:logger) { LOGGER }
@@ -38,7 +39,8 @@ describe Kafka::SaslAuthenticator do
       sasl_plain_password: nil,
       sasl_scram_username: nil,
       sasl_scram_password: nil,
-      sasl_scram_mechanism: nil
+      sasl_scram_mechanism: nil,
+      sasl_oauth_token_provider: nil,
     }
   }
 
@@ -89,6 +91,18 @@ describe Kafka::SaslAuthenticator do
       expect {
         sasl_authenticator.authenticate!(connection)
       }.to raise_error(Kafka::FailedScramAuthentication)
+    end
+  end
+
+  context "when SASL OAuthBearer has been configured" do
+    before do
+      auth_options.update(
+        sasl_oauth_token_provider: FakeTokenProvider.new
+      )
+
+      it "authenticates" do
+        sasl_authenticator.authenticate!(connection)
+      end
     end
   end
 end

--- a/spec/sasl_authenticator_spec.rb
+++ b/spec/sasl_authenticator_spec.rb
@@ -99,10 +99,18 @@ describe Kafka::SaslAuthenticator do
       auth_options.update(
         sasl_oauth_token_provider: FakeTokenProvider.new
       )
+    end
 
-      it "authenticates" do
+    it "authenticates" do
+      sasl_authenticator.authenticate!(connection)
+    end
+
+    it "raises error when the token provider does not generate a token" do
+      auth_options[:sasl_oauth_token_provider] = FakeBrokenTokenProvider.new
+
+      expect {
         sasl_authenticator.authenticate!(connection)
-      end
+      }.to raise_error(Kafka::NoTokenMethodError)
     end
   end
 end


### PR DESCRIPTION
**Note:** _Please leave any comments/reviews on https://github.com/zendesk/ruby-kafka/pull/710 instead since that's forked from Shopify as opposed to my personal account!_

This PR adds support for OAuthBearer as a method of SASL Authentication as described in [KIP-255](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=75968876) and https://github.com/zendesk/ruby-kafka/issues/705. 

When initializing the client, the user must pass in an instance of a class that implements a `token` method (the interface is described in `lib/kafka/sasl/oauth.rb`) which returns an ID Token. 

**Example:**

```ruby
require 'ruby-kafka'

class TokenProvider
    def token
        "some_id_token"
    end
end
# ...
client = Kafka.new(
    ["127.0.0.1:9094"],
    client_id: "phong-ruby-kafka",
    # ...
    sasl_over_ssl: false,
    sasl_oauth_token_provider: TokenProvider.new
)
```

Tested with a local Kafka cluster and ID Token, and successfully authenticated with the example client initialization above. I am open to suggestions for more cases to write unit tests for.