### PR TITLE
Change asyn_producer method arguments name

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -300,15 +300,15 @@ module Kafka
     #
     # @see AsyncProducer
     # @return [AsyncProducer]
-    def async_producer(delivery_interval: 0, delivery_threshold: 0, max_queue_size: 1000, max_retries: -1, retry_backoff: 0, **options)
+    def async_producer(delivery_interval: 0, delivery_threshold: 0, ap_max_queue_size: 1000, ap_max_retries: -1, retry_backoff: 0, **options)
       sync_producer = producer(**options)
 
       AsyncProducer.new(
         sync_producer: sync_producer,
         delivery_interval: delivery_interval,
         delivery_threshold: delivery_threshold,
-        max_queue_size: max_queue_size,
-        max_retries: max_retries,
+        max_queue_size: ap_max_queue_size,
+        max_retries: ap_max_retries,
         retry_backoff: retry_backoff,
         instrumenter: @instrumenter,
         logger: @logger,


### PR DESCRIPTION
In PR (already merged) https://github.com/zendesk/ruby-kafka/pull/708, I added 2 new arguments: `max_retries` and `retry_backoff` to `async_producer` method in `client.rb`. It seems that the internal `sync_producer` doesn't get those params because they have the same names (like in the `AsyncProducer`) and it takes the default (`max_retries: 2, retry_backoff: 1`). I changed the params name in the `async_producer` to fix that.
### _This will break the current API_