### PR TITLE
Refactor tagged logging

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,8 +14,9 @@ require 'extlz4'
 
 Dotenv.load
 
-LOGGER = Kafka::TaggedLogger.new(Logger.new(ENV.key?("LOG_TO_STDERR") ? $stderr : "test-#{Time.now.to_i}.log"))
-LOGGER.level = Logger.const_get(ENV.fetch("LOG_LEVEL", "INFO"))
+LOGGER = Kafka::TaggedLogger.new(Logger.new(ENV.key?("LOG_TO_STDERR") ? $stderr : "test-#{Time.now.to_i}.log").tap do |logger|
+  logger.level = Logger.const_get(ENV.fetch("LOG_LEVEL", "INFO"))
+end)
 
 KAFKA_BROKERS = ENV.fetch("KAFKA_BROKERS", "localhost:9092").split(",")
 


### PR DESCRIPTION
PR #697 added support for tagged logging, but because it modifies the existing formatter any subsequent changes to the formatter cause exceptions at runtime. This instead wraps an underlying logger and duplicates the logic from the core `Logger` class to prepend the tags text when needed.

Also, could the changelog for 0.7.6 be updated to include PR #697?