### PR TITLE
Fix YARD warnings

### DIFF
--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -113,7 +113,7 @@ module Kafka
 
     # Finds the broker acting as the coordinator of the given group.
     #
-    # @param group_id: [String]
+    # @param group_id [String]
     # @return [Broker] the broker that's currently coordinator.
     def get_group_coordinator(group_id:)
       @logger.debug "Getting group coordinator for `#{group_id}`"
@@ -123,7 +123,7 @@ module Kafka
 
     # Finds the broker acting as the coordinator of the given transaction.
     #
-    # @param transactional_id: [String]
+    # @param transactional_id [String]
     # @return [Broker] the broker that's currently coordinator.
     def get_transaction_coordinator(transactional_id:)
       @logger.debug "Getting transaction coordinator for `#{transactional_id}`"

--- a/lib/kafka/protocol/encoder.rb
+++ b/lib/kafka/protocol/encoder.rb
@@ -126,7 +126,7 @@ module Kafka
       # Writes an integer under varints serializing to the IO object.
       # https://developers.google.com/protocol-buffers/docs/encoding#varints
       #
-      # @param string [Integer]
+      # @param int [Integer]
       # @return [nil]
       def write_varint(int)
         int = int << 1


### PR DESCRIPTION
This PR fixes YARD warnings:

```
lib/kafka/cluster.rb:116: [UnknownParam] @param tag has unknown parameter name: group_id:. Did you mean `group_id`?
lib/kafka/cluster.rb:126: [UnknownParam] @param tag has unknown parameter name: transactional_id:. Did you mean `transactional_id`?
lib/kafka/protocol/encoder.rb:129: [UnknownParam] @param tag has unknown parameter name: string
```