### PR TITLE
[Improvement] Allow sleep time when no batch to process to be configured

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -340,7 +340,8 @@ module Kafka
         offset_commit_threshold: 0,
         heartbeat_interval: 10,
         offset_retention_time: nil,
-        fetcher_max_queue_size: 100
+        fetcher_max_queue_size: 100,
+        sleep_time_when_no_message: 2
     )
       cluster = initialize_cluster
 
@@ -393,6 +394,7 @@ module Kafka
         fetcher: fetcher,
         session_timeout: session_timeout,
         heartbeat: heartbeat,
+        sleep_time_when_no_message: sleep_time_when_no_message
       )
     end
 

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -44,7 +44,7 @@ module Kafka
   #
   class Consumer
 
-    def initialize(cluster:, logger:, instrumenter:, group:, fetcher:, offset_manager:, session_timeout:, heartbeat:, sleep_time_when_no_message:)
+    def initialize(cluster:, logger:, instrumenter:, group:, fetcher:, offset_manager:, session_timeout:, heartbeat:, sleep_time_when_no_message: 2)
       @cluster = cluster
       @logger = TaggedLogger.new(logger)
       @instrumenter = instrumenter

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -44,7 +44,7 @@ module Kafka
   #
   class Consumer
 
-    def initialize(cluster:, logger:, instrumenter:, group:, fetcher:, offset_manager:, session_timeout:, heartbeat:)
+    def initialize(cluster:, logger:, instrumenter:, group:, fetcher:, offset_manager:, session_timeout:, heartbeat:, sleep_time_when_no_message:)
       @cluster = cluster
       @logger = TaggedLogger.new(logger)
       @instrumenter = instrumenter
@@ -53,6 +53,7 @@ module Kafka
       @session_timeout = session_timeout
       @fetcher = fetcher
       @heartbeat = heartbeat
+      @sleep_time_when_no_message = sleep_time_when_no_message
 
       @pauses = Hash.new {|h, k|
         h[k] = Hash.new {|h2, k2|
@@ -525,7 +526,7 @@ module Kafka
 
       if !@fetcher.data?
         @logger.debug "No batches to process"
-        sleep 2
+        sleep @sleep_time_when_no_message
         []
       else
         tag, message = @fetcher.poll


### PR DESCRIPTION
Currently, when we fetch_batch from consumer, if batch has no data, we will sleep for 2 seconds before returning. It's better if we can let this fixed number(2) to be configured, because some consumer needs to receive and handle events asap.