### PR TITLE
Producer send offsets in transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.log
 *.swp
 .byebug_history
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@
 *.log
 *.swp
 .byebug_history
-.DS_Store

--- a/lib/kafka/broker.rb
+++ b/lib/kafka/broker.rb
@@ -182,6 +182,18 @@ module Kafka
       send_request(request)
     end
 
+    def add_offsets_to_txn(**options)
+      request = Protocol::AddOffsetsToTxnRequest.new(**options)
+
+      send_request(request)
+    end
+
+    def txn_offset_commit(**options)
+      request = Protocol::TxnOffsetCommitRequest.new(**options)
+
+      send_request(request)
+    end
+
     private
 
     def send_request(request)

--- a/lib/kafka/fetched_batch.rb
+++ b/lib/kafka/fetched_batch.rb
@@ -13,18 +13,22 @@ module Kafka
     # @return [Integer]
     attr_reader :last_offset
 
+    # @return [Integer]
+    attr_reader :leader_epoch
+
     # @return [Integer] the offset of the most recent message in the partition.
     attr_reader :highwater_mark_offset
 
     # @return [Array<Kafka::FetchedMessage>]
     attr_accessor :messages
 
-    def initialize(topic:, partition:, highwater_mark_offset:, messages:, last_offset: nil)
+    def initialize(topic:, partition:, highwater_mark_offset:, messages:, last_offset: nil, leader_epoch: nil)
       @topic = topic
       @partition = partition
       @highwater_mark_offset = highwater_mark_offset
       @messages = messages
       @last_offset = last_offset
+      @leader_epoch = leader_epoch
     end
 
     def empty?

--- a/lib/kafka/fetched_batch_generator.rb
+++ b/lib/kafka/fetched_batch_generator.rb
@@ -62,11 +62,13 @@ module Kafka
     def extract_records
       records = []
       last_offset = nil
+      leader_epoch = nil
       aborted_transactions = @fetched_partition.aborted_transactions.sort_by(&:first_offset)
       aborted_producer_ids = {}
 
       @fetched_partition.messages.each do |record_batch|
         last_offset = record_batch.last_offset if last_offset.nil? || last_offset < record_batch.last_offset
+        leader_epoch = record_batch.partition_leader_epoch if leader_epoch.nil? || leader_epoch < record_batch.partition_leader_epoch
         # Find the list of aborted producer IDs less than current offset
         unless aborted_transactions.empty?
           if aborted_transactions.first.first_offset <= record_batch.last_offset
@@ -99,6 +101,7 @@ module Kafka
         topic: @topic,
         partition: @fetched_partition.partition,
         last_offset: last_offset,
+        leader_epoch: leader_epoch,
         highwater_mark_offset: @fetched_partition.highwater_mark_offset,
         messages: records
       )

--- a/lib/kafka/fetched_message.rb
+++ b/lib/kafka/fetched_message.rb
@@ -43,5 +43,6 @@ module Kafka
     def is_control_record
       @message.is_control_record
     end
+
   end
 end

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -328,6 +328,20 @@ module Kafka
       @transaction_manager.abort_transaction
     end
 
+    # Sends batch last offset to the consumer group coordinator, and also marks
+    # this offset as part of the current transaction. This offset will be considered
+    # committed only if the transaction is committed successfully.
+    #
+    # This method should be used when you need to batch consumed and produced messages
+    # together, typically in a consume-transform-produce pattern. Thus, the specified
+    # group_id should be the same as config parameter group_id of the used
+    # consumer.
+    #
+    # @return [nil]
+    def send_offsets_to_transaction(batch:, group_id:)
+      @transaction_manager.send_offsets_to_txn(offsets: { batch.topic => { batch.partition => { offset: batch.last_offset + 1, leader_epoch: batch.leader_epoch } } }, group_id: group_id)
+    end
+
     # Syntactic sugar to enable easier transaction usage. Do the following steps
     #
     # - Start the transaction (with Producer#begin_transaction)

--- a/lib/kafka/protocol.rb
+++ b/lib/kafka/protocol.rb
@@ -33,7 +33,9 @@ module Kafka
     DELETE_TOPICS_API         = 20
     INIT_PRODUCER_ID_API      = 22
     ADD_PARTITIONS_TO_TXN_API = 24
+    ADD_OFFSETS_TO_TXN_API    = 25
     END_TXN_API               = 26
+    TXN_OFFSET_COMMIT_API     = 28
     DESCRIBE_CONFIGS_API      = 32
     ALTER_CONFIGS_API         = 33
     CREATE_PARTITIONS_API     = 37
@@ -57,7 +59,9 @@ module Kafka
       DELETE_TOPICS_API         => :delete_topics,
       INIT_PRODUCER_ID_API      => :init_producer_id_api,
       ADD_PARTITIONS_TO_TXN_API => :add_partitions_to_txn_api,
+      ADD_OFFSETS_TO_TXN_API    => :add_offsets_to_txn_api,
       END_TXN_API               => :end_txn_api,
+      TXN_OFFSET_COMMIT_API     => :txn_offset_commit_api,
       DESCRIBE_CONFIGS_API      => :describe_configs_api,
       CREATE_PARTITIONS_API     => :create_partitions
     }
@@ -177,6 +181,10 @@ require "kafka/protocol/fetch_request"
 require "kafka/protocol/fetch_response"
 require "kafka/protocol/list_offset_request"
 require "kafka/protocol/list_offset_response"
+require "kafka/protocol/add_offsets_to_txn_request"
+require "kafka/protocol/add_offsets_to_txn_response"
+require "kafka/protocol/txn_offset_commit_request"
+require "kafka/protocol/txn_offset_commit_response"
 require "kafka/protocol/find_coordinator_request"
 require "kafka/protocol/find_coordinator_response"
 require "kafka/protocol/join_group_request"

--- a/lib/kafka/protocol/add_offsets_to_txn_request.rb
+++ b/lib/kafka/protocol/add_offsets_to_txn_request.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Kafka
+  module Protocol
+    class AddOffsetsToTxnRequest
+      def initialize(transactional_id: nil, producer_id:, producer_epoch:, group_id:)
+        @transactional_id = transactional_id
+        @producer_id = producer_id
+        @producer_epoch = producer_epoch
+        @group_id = group_id
+      end
+
+      def api_key
+        ADD_OFFSETS_TO_TXN_API
+      end
+
+      def response_class
+        AddOffsetsToTxnResponse
+      end
+
+      def encode(encoder)
+        encoder.write_string(@transactional_id.to_s)
+        encoder.write_int64(@producer_id)
+        encoder.write_int16(@producer_epoch)
+        encoder.write_string(@group_id)
+      end
+    end
+  end
+end

--- a/lib/kafka/protocol/add_offsets_to_txn_response.rb
+++ b/lib/kafka/protocol/add_offsets_to_txn_response.rb
@@ -1,0 +1,19 @@
+module Kafka
+  module Protocol
+    class AddOffsetsToTxnResponse
+
+      attr_reader :error_code
+
+      def initialize(error_code:)
+        @error_code = error_code
+      end
+
+      def self.decode(decoder)
+        _throttle_time_ms = decoder.int32
+        error_code = decoder.int16
+        new(error_code: error_code)
+      end
+
+    end
+  end
+end

--- a/lib/kafka/protocol/txn_offset_commit_request.rb
+++ b/lib/kafka/protocol/txn_offset_commit_request.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Kafka
+  module Protocol
+    class TxnOffsetCommitRequest
+
+      def api_key
+        TXN_OFFSET_COMMIT_API
+      end
+
+      def api_version
+        2
+      end
+
+      def response_class
+        TxnOffsetCommitResponse
+      end
+
+      def initialize(transactional_id:, group_id:, producer_id:, producer_epoch:, offsets:)
+        @transactional_id = transactional_id
+        @producer_id = producer_id
+        @producer_epoch = producer_epoch
+        @group_id = group_id
+        @offsets = offsets
+      end
+
+      def encode(encoder)
+        encoder.write_string(@transactional_id.to_s)
+        encoder.write_string(@group_id)
+        encoder.write_int64(@producer_id)
+        encoder.write_int16(@producer_epoch)
+
+        encoder.write_array(@offsets) do |topic, partitions|
+          encoder.write_string(topic)
+          encoder.write_array(partitions) do |partition, offset|
+            encoder.write_int32(partition)
+            encoder.write_int64(offset[:offset])
+            encoder.write_string(nil) # metadata
+            encoder.write_int32(offset[:leader_epoch])
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/kafka/protocol/txn_offset_commit_response.rb
+++ b/lib/kafka/protocol/txn_offset_commit_response.rb
@@ -1,0 +1,18 @@
+module Kafka
+  module Protocol
+    class TxnOffsetCommitResponse
+
+      attr_reader :error_code
+
+      def initialize(error_code:)
+        @error_code = error_code
+      end
+
+      def self.decode(decoder)
+        _throttle_time_ms = decoder.int32
+        error_code = decoder.int16
+        new(error_code: error_code)
+      end
+    end
+  end
+end

--- a/lib/kafka/transaction_manager.rb
+++ b/lib/kafka/transaction_manager.rb
@@ -217,6 +217,31 @@ module Kafka
       raise
     end
 
+    def send_offsets_to_txn(offsets:, group_id:)
+      force_transactional!
+
+      unless @transaction_state.in_transaction?
+        raise 'Transaction is not valid to send offsets'
+      end
+
+      add_response = transaction_coordinator.add_offsets_to_txn(
+        transactional_id: @transactional_id,
+        producer_id: @producer_id,
+        producer_epoch: @producer_epoch,
+        group_id: group_id
+      )
+      Protocol.handle_error(add_response.error_code)
+
+      send_response = transaction_coordinator.txn_offset_commit(
+        transactional_id: @transactional_id,
+        group_id: group_id,
+        producer_id: @producer_id,
+        producer_epoch: @producer_epoch,
+        offsets: offsets
+      )
+      Protocol.handle_error(send_response.error_code)
+    end
+
     def in_transaction?
       @transaction_state.in_transaction?
     end

--- a/spec/broker_spec.rb
+++ b/spec/broker_spec.rb
@@ -134,4 +134,29 @@ describe Kafka::Broker do
       broker.disconnect
     end
   end
+
+  describe "#add_offsets_to_txn" do
+    it 'sends offsets to the transaction' do
+      allow(connection).to receive(:send_request)
+      broker.add_offsets_to_txn(
+        transactional_id: 1, producer_id: 2, producer_epoch: 3, group_id: 4
+      )
+      expect(connection).to have_received(:send_request)
+
+      broker.disconnect
+    end
+  end
+
+  describe "#txn_offset_commit" do
+    before do
+      allow(connection).to receive(:send_request)
+    end
+    it 'commits transaction' do
+      broker.txn_offset_commit(
+        transactional_id: 1, producer_id: 2, producer_epoch: 3, group_id: 4, offsets: []
+      )
+      expect(connection).to have_received(:send_request)
+      broker.disconnect
+    end
+  end
 end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -29,6 +29,7 @@ describe Kafka::Producer do
     allow(transaction_manager).to receive(:producer_id).and_return(-1)
     allow(transaction_manager).to receive(:producer_epoch).and_return(0)
     allow(transaction_manager).to receive(:transactional_id).and_return(nil)
+    allow(transaction_manager).to receive(:send_offsets_to_txn).and_return(nil)
   end
 
   describe "#produce" do
@@ -320,6 +321,36 @@ describe Kafka::Producer do
       expect(producer.buffer_size).to eq 1
       producer.clear_buffer
       expect(producer.buffer_size).to eq 0
+    end
+  end
+
+  describe "#send_offsets_to_transaction" do
+    let(:topic) { 'some_topic' }
+    let(:partition) { rand(2**31) }
+    let(:last_offset) { rand(2**31) }
+    let(:leader_epoch) { Time.now.to_i }
+    let(:group_id) { SecureRandom.uuid }
+    let(:batch) do
+      double(
+        topic: topic,
+        partition: partition,
+        last_offset: last_offset,
+        leader_epoch: leader_epoch
+      )
+    end
+    it 'sends offsets to transaction manager' do
+      producer.send_offsets_to_transaction(batch: batch, group_id: group_id)
+      expect(transaction_manager).to have_received(:send_offsets_to_txn).with(
+        offsets: {
+          topic => {
+            partition => {
+              leader_epoch: leader_epoch,
+              offset: last_offset + 1
+            }
+          }
+        },
+        group_id: group_id
+      )
     end
   end
 


### PR DESCRIPTION
Added send_offsets_to_transaction method to Producer.

[KIP-98 ](https://cwiki.apache.org/confluence/display/KAFKA/KIP-98+-+Exactly+Once+Delivery+and+Transactional+Messaging) provides the ability to commit offsets by the producer in a transaction. This method could be used when you need to batch consumed and produced messages together, typically in a consume-transform-produce pattern with exactly once semantics.