### PR TITLE
Support zstd compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Compression is enabled by passing the `compression_codec` parameter to `#produce
 * `:snappy` for [Snappy](http://google.github.io/snappy/) compression.
 * `:gzip` for [gzip](https://en.wikipedia.org/wiki/Gzip) compression.
 * `:lz4` for [LZ4](https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)) compression.
+* `:zstd` for [zstd](https://facebook.github.io/zstd/) compression.
 
 By default, all message sets will be compressed if you specify a compression codec. To increase the compression threshold, set `compression_threshold` to an integer value higher than one.
 

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -234,7 +234,7 @@ module Kafka
     #
     # @param compression_codec [Symbol, nil] the name of the compression codec to
     #   use, or nil if no compression should be performed. Valid codecs: `:snappy`,
-    #   `:gzip`, `:lz4`
+    #   `:gzip`, `:lz4`, `:zstd`
     #
     # @param compression_threshold [Integer] the number of messages that needs to
     #   be in a message set before it should be compressed. Note that message sets

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -233,8 +233,8 @@ module Kafka
     #   result in {BufferOverflow} being raised.
     #
     # @param compression_codec [Symbol, nil] the name of the compression codec to
-    #   use, or nil if no compression should be performed. Valid codecs: `:snappy`
-    #   and `:gzip`.
+    #   use, or nil if no compression should be performed. Valid codecs: `:snappy`,
+    #   `:gzip`, `:lz4`
     #
     # @param compression_threshold [Integer] the number of messages that needs to
     #   be in a message set before it should be compressed. Note that message sets

--- a/lib/kafka/compression.rb
+++ b/lib/kafka/compression.rb
@@ -3,6 +3,7 @@
 require "kafka/snappy_codec"
 require "kafka/gzip_codec"
 require "kafka/lz4_codec"
+require "kafka/zstd_codec"
 
 module Kafka
   module Compression
@@ -10,6 +11,7 @@ module Kafka
       :gzip => GzipCodec.new,
       :snappy => SnappyCodec.new,
       :lz4 => LZ4Codec.new,
+      :zstd => ZstdCodec.new,
     }.freeze
 
     CODECS_BY_ID = CODECS_BY_NAME.each_with_object({}) do |(_, codec), hash|

--- a/lib/kafka/compressor.rb
+++ b/lib/kafka/compressor.rb
@@ -18,6 +18,7 @@ module Kafka
   # * `compressed_bytesize` – the byte size of the compressed data.
   #
   class Compressor
+    attr_reader :codec
 
     # @param codec_name [Symbol, nil]
     # @param threshold [Integer] the minimum number of messages in a message set

--- a/lib/kafka/gzip_codec.rb
+++ b/lib/kafka/gzip_codec.rb
@@ -6,6 +6,10 @@ module Kafka
       1
     end
 
+    def produce_api_min_version
+      0
+    end
+
     def load
       require "zlib"
     end

--- a/lib/kafka/lz4_codec.rb
+++ b/lib/kafka/lz4_codec.rb
@@ -6,6 +6,10 @@ module Kafka
       3
     end
 
+    def produce_api_min_version
+      0
+    end
+
     def load
       require "extlz4"
     rescue LoadError

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -68,6 +68,7 @@ module Kafka
   #
   # * `:snappy` for [Snappy](http://google.github.io/snappy/) compression.
   # * `:gzip` for [gzip](https://en.wikipedia.org/wiki/Gzip) compression.
+  # * `:lz4` for [LZ4](https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)) compression.
   #
   # By default, all message sets will be compressed if you specify a compression
   # codec. To increase the compression threshold, set `compression_threshold` to

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -69,6 +69,7 @@ module Kafka
   # * `:snappy` for [Snappy](http://google.github.io/snappy/) compression.
   # * `:gzip` for [gzip](https://en.wikipedia.org/wiki/Gzip) compression.
   # * `:lz4` for [LZ4](https://en.wikipedia.org/wiki/LZ4_(compression_algorithm)) compression.
+  # * `:zstd` for [zstd](https://facebook.github.io/zstd/) compression.
   #
   # By default, all message sets will be compressed if you specify a compression
   # codec. To increase the compression threshold, set `compression_threshold` to

--- a/lib/kafka/protocol/produce_request.rb
+++ b/lib/kafka/protocol/produce_request.rb
@@ -27,6 +27,8 @@ module Kafka
     #         Value => bytes
     #
     class ProduceRequest
+      API_MIN_VERSION = 3
+
       attr_reader :transactional_id, :required_acks, :timeout, :messages_for_topics, :compressor
 
       # @param required_acks [Integer]
@@ -45,7 +47,7 @@ module Kafka
       end
 
       def api_version
-        3
+        compressor.codec.nil? ? API_MIN_VERSION : [compressor.codec.produce_api_min_version, API_MIN_VERSION].max
       end
 
       def response_class

--- a/lib/kafka/snappy_codec.rb
+++ b/lib/kafka/snappy_codec.rb
@@ -6,6 +6,10 @@ module Kafka
       2
     end
 
+    def produce_api_min_version
+      0
+    end
+
     def load
       require "snappy"
     rescue LoadError

--- a/lib/kafka/zstd_codec.rb
+++ b/lib/kafka/zstd_codec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Kafka
+  class ZstdCodec
+    def codec_id
+      4
+    end
+
+    def produce_api_min_version
+      7
+    end
+
+    def load
+      require "zstd-ruby"
+    rescue LoadError
+      raise LoadError, "using zstd compression requires adding a dependency on the `zstd-ruby` gem to your Gemfile."
+    end
+
+    def compress(data)
+      Zstd.compress(data)
+    end
+
+    def decompress(data)
+      Zstd.decompress(data)
+    end
+  end
+end

--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "activesupport"
   spec.add_development_dependency "snappy"
   spec.add_development_dependency "extlz4"
+  spec.add_development_dependency "zstd-ruby"
   spec.add_development_dependency "colored"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
   spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0", "< 5.0.0"

--- a/spec/functional/compression_spec.rb
+++ b/spec/functional/compression_spec.rb
@@ -1,54 +1,31 @@
 # frozen_string_literal: true
 
-require "snappy"
-
 describe "Compression", functional: true do
   let!(:topic) { create_random_topic(num_partitions: 3) }
 
-  example "producing and consuming snappy-compressed messages" do
-    producer = kafka.producer(
-      compression_codec: :snappy,
-      max_retries: 0,
-      retry_backoff: 0
-    )
+  Kafka::Compression.codecs.each do |codec_name|
+    example "producing and consuming #{codec_name}-compressed messages" do
+      producer = kafka.producer(
+        compression_codec: codec_name,
+        max_retries: 0,
+        retry_backoff: 0
+      )
 
-    last_offset = fetch_last_offset
+      last_offset = fetch_last_offset
 
-    producer.produce("message1", topic: topic, partition: 0)
-    producer.produce("message2", topic: topic, partition: 0)
+      producer.produce("message1", topic: topic, partition: 0)
+      producer.produce("message2", topic: topic, partition: 0)
 
-    producer.deliver_messages
+      producer.deliver_messages
 
-    messages = kafka.fetch_messages(
-      topic: topic,
-      partition: 0,
-      offset: last_offset + 1,
-    )
+      messages = kafka.fetch_messages(
+        topic: topic,
+        partition: 0,
+        offset: last_offset + 1,
+      )
 
-    expect(messages.last(2).map(&:value)).to eq ["message1", "message2"]
-  end
-
-  example "producing and consuming gzip-compressed messages" do
-    producer = kafka.producer(
-      compression_codec: :gzip,
-      max_retries: 0,
-      retry_backoff: 0
-    )
-
-    last_offset = fetch_last_offset
-
-    producer.produce("message1", topic: topic, partition: 0)
-    producer.produce("message2", topic: topic, partition: 0)
-
-    producer.deliver_messages
-
-    messages = kafka.fetch_messages(
-      topic: topic,
-      partition: 0,
-      offset: last_offset + 1,
-    )
-
-    expect(messages.last(2).map(&:value)).to eq ["message1", "message2"]
+      expect(messages.last(2).map(&:value)).to eq ["message1", "message2"]
+    end
   end
 
   def fetch_last_offset

--- a/spec/functional/compression_spec.rb
+++ b/spec/functional/compression_spec.rb
@@ -5,6 +5,11 @@ describe "Compression", functional: true do
 
   Kafka::Compression.codecs.each do |codec_name|
     example "producing and consuming #{codec_name}-compressed messages" do
+      codec = Kafka::Compression.find_codec(codec_name)
+      unless kafka.supports_api?(Kafka::Protocol::PRODUCE_API, codec.produce_api_min_version)
+        skip("This Kafka version does not support #{codec_name}")
+      end
+
       producer = kafka.producer(
         compression_codec: codec_name,
         max_retries: 0,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require "colored"
 require "securerandom"
 require 'snappy'
 require 'extlz4'
+require 'zstd-ruby'
 
 Dotenv.load
 


### PR DESCRIPTION
Kafka [now supports](https://cwiki.apache.org/confluence/display/KAFKA/KIP-110%3A+Add+Codec+for+ZStandard+Compression) zstd compression with its `2.1` release.  This does a little cleanup of codec-related code, then adds zstd compression support.