### PR TITLE
Verify SSL Certificates

### DIFF
--- a/lib/kafka/ssl_context.rb
+++ b/lib/kafka/ssl_context.rb
@@ -54,6 +54,8 @@ module Kafka
           store.set_default_paths
         end
         ssl_context.cert_store = store
+        ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        ssl_context.verify_hostname = true
       end
 
       ssl_context

--- a/lib/kafka/ssl_socket_with_timeout.rb
+++ b/lib/kafka/ssl_socket_with_timeout.rb
@@ -57,6 +57,7 @@ module Kafka
 
       # once that's connected, we can start initiating the ssl socket
       @ssl_socket = OpenSSL::SSL::SSLSocket.new(@tcp_socket, ssl_context)
+      @ssl_socket.hostname = host
 
       begin
         # Initiate the socket connection in the background. If it doesn't fail


### PR DESCRIPTION
The default in Ruby is to verify the certificate, but then ignore the result of that verification.
So it needs to be a structurally valid cert, but it's unrelated to the connection being opened or the CAs we've decided to trust.

This enables verification so we'll only trust certs we should trust.
It also sets the hostname so the cert presented has to correspond to the host we're connecting to.

It's possible that either of these changes could be a breaking change to someone somewhere that's using an invalid certificate without knowing it.
Example reasons:
1. It's expired and they didn't notice
2. It's not in their trust-store but they thought it was
3. It's not trusted by their system by they thought it was
4. It was a wildcard that is actually invalid, like `*.example.com` and servers like `east1.kafka.example.com`
5. The certificate has a hostname that doesn't match the host that's being connected to

Or perhaps others.
We may want to add options to disable parts of this, but I leave that up to the project to decide.
For now I've left this as simple as possible.