### PR TITLE
Block on Fetcher#poll in Consumer#fetch_batches

### DIFF
--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -136,6 +136,7 @@ module Kafka
       # from. Otherwise we'd keep fetching from a bunch of partitions we may no
       # longer be assigned.
       handle_reset
+      @queue.close
     end
 
     def handle_subscribe(topic, max_bytes_per_partition)


### PR DESCRIPTION
As detailed in https://github.com/zendesk/ruby-kafka/pull/722, [`sleep 2` in `Consumer#fetch_batches`](https://github.com/zendesk/ruby-kafka/blob/master/lib/kafka/consumer.rb#L528) presents a problem for latency-sensitive consumers. This PR removes the `Fetcher#data?` check and `sleep` in favor of just calling `Fetcher#poll`, which calls the blocking `Queue#deq`. `Fetcher` pushes all batches, even empty batches, onto the `Queue`, so it seems like `Queue#deq` shouldn't block for much longer than the duration of a fetch request, but maybe I'm missing something. 