### PR TITLE
Do not add nil message entries when ignoring old messages.

### DIFF
--- a/lib/kafka/fetched_batch_generator.rb
+++ b/lib/kafka/fetched_batch_generator.rb
@@ -48,7 +48,7 @@ module Kafka
               partition: @fetched_partition.partition
             )
           end
-        end
+        end.compact
       end
       FetchedBatch.new(
         topic: @topic,


### PR DESCRIPTION
When using MessageSets, we want to remove messages when their offset is
smaller than the requested offset.

It appears that this was handled properly for the `RecordBatch` uses cases, but not for the `MessageSet` path.

This is intended to address #745