### PR TITLE
add client methods to manage configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
-  kafka-1.0:
+  kafka-1.0.0:
     docker:
       - image: circleci/ruby:2.5.1-node
         environment:
@@ -209,7 +209,7 @@ workflows:
     jobs:
       - unit
       - kafka-0.11
-      - kafka-1.0
+      - kafka-1.0.0
       - kafka-1.1
       - kafka-2.0
       - kafka-2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
-  kafka-1.0.0:
+  kafka-1.0:
     docker:
       - image: circleci/ruby:2.5.1-node
         environment:
@@ -209,7 +209,7 @@ workflows:
     jobs:
       - unit
       - kafka-0.11
-      - kafka-1.0.0
+      - kafka-1.0
       - kafka-1.1
       - kafka-2.0
       - kafka-2.1

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -530,6 +530,24 @@ module Kafka
       end
     end
 
+    # Describe broker configs
+    #
+    # @param broker_id [int] the id of the broker
+    # @param configs [Array] array of config keys.
+    # @return [Array<Kafka::Protocol::DescribeConfigsResponse::ConfigEntry>]
+    def describe_configs(broker_id, configs = [])
+      @cluster.describe_configs(broker_id, configs)
+    end
+
+    # Alter broker configs
+    #
+    # @param broker_id [int] the id of the broker
+    # @param configs [Array] array of config strings.
+    # @return [nil]
+    def alter_configs(broker_id, configs = [])
+      @cluster.alter_configs(broker_id, configs)
+    end
+
     # Creates a topic in the cluster.
     #
     # @example Creating a topic with log compaction

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -139,6 +139,40 @@ module Kafka
       end
     end
 
+    def describe_configs(broker_id, configs = [])
+      options = {
+        resources: [[Kafka::Protocol::RESOURCE_TYPE_CLUSTER, broker_id.to_s, configs]]
+      }
+
+      info = cluster_info.brokers.find {|broker| broker.node_id == broker_id }
+      broker = @broker_pool.connect(info.host, info.port, node_id: info.node_id)
+
+      response = broker.describe_configs(**options)
+
+      response.resources.each do |resource|
+        Protocol.handle_error(resource.error_code, resource.error_message)
+      end
+
+      response.resources.first.configs
+    end
+
+    def alter_configs(broker_id, configs = [])
+      options = {
+        resources: [[Kafka::Protocol::RESOURCE_TYPE_CLUSTER, broker_id.to_s, configs]]
+      }
+
+      info = cluster_info.brokers.find {|broker| broker.node_id == broker_id }
+      broker = @broker_pool.connect(info.host, info.port, node_id: info.node_id)
+
+      response = broker.alter_configs(**options)
+
+      response.resources.each do |resource|
+        Protocol.handle_error(resource.error_code, resource.error_message)
+      end
+
+      nil
+    end
+
     def partitions_for(topic)
       add_target_topics([topic])
       refresh_metadata_if_necessary!

--- a/spec/functional/config_management_spec.rb
+++ b/spec/functional/config_management_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+describe "Config management API", functional: true do
+  let(:broker_id) { kafka.controller_broker.node_id }
+
+  example "describe config" do
+    unless kafka.supports_api?(Kafka::Protocol::DESCRIBE_CONFIGS_API)
+      skip("This Kafka version not support DescribeConfigs for broker configs")
+    end
+
+    expect(kafka.describe_configs(broker_id, ['background.threads']).first.value.to_i).to eq(10)
+  end
+end


### PR DESCRIPTION
We have methods in to manage configs, but they are not exposed to the `Kafka::Client`. This PR adds `describe_configs` and `alter_configs` to `Kafka::Client`. This useful to make per-broker changes without having to restart the service.

Also, updated CircleCI config to include testing Kafka 2.2.1.