### PR TITLE
Cover transactional manager with retries on certain errors

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -270,6 +270,8 @@ module Kafka
         transactional: transactional,
         transactional_id: transactional_id,
         transactional_timeout: transactional_timeout,
+        max_retries: max_retries,
+        retry_backoff: retry_backoff
       )
 
       Producer.new(

--- a/lib/kafka/protocol/txn_offset_commit_request.rb
+++ b/lib/kafka/protocol/txn_offset_commit_request.rb
@@ -35,8 +35,8 @@ module Kafka
           encoder.write_array(partitions) do |partition, offset|
             encoder.write_int32(partition)
             encoder.write_int64(offset[:offset])
-            encoder.write_string(nil) # metadata
             encoder.write_int32(offset[:leader_epoch])
+            encoder.write_string(nil) # metadata
           end
         end
       end

--- a/lib/kafka/transaction_manager.rb
+++ b/lib/kafka/transaction_manager.rb
@@ -34,7 +34,7 @@ module Kafka
 
       @producer_id = -1
       @producer_epoch = 0
-      @retry_backoff_ms = retry_backoff_ms
+      @retry_backoff = retry_backoff
 
       @sequences = {}
       @retry_counter = 0

--- a/lib/kafka/transaction_manager.rb
+++ b/lib/kafka/transaction_manager.rb
@@ -17,7 +17,7 @@ module Kafka
       transactional: false,
       transactional_id: nil,
       transactional_timeout: DEFAULT_TRANSACTION_TIMEOUT,
-      retry_backoff_ms: 100,
+      retry_backoff: 100,
       max_retries: 5
     )
       @cluster = cluster
@@ -286,8 +286,8 @@ module Kafka
       if @retry_counter > @max_retries
         raise e
       end
-      @logger.info("#{e.class.name}, sleeping #{@retry_backoff_ms}ms, retrying...")
-      sleep @retry_backoff_ms / 1000.0
+      @logger.info("#{e.class.name}, sleeping #{@retry_backoff } , retrying...")
+      sleep @retry_backoff
       retry
     end
 

--- a/lib/kafka/transaction_manager.rb
+++ b/lib/kafka/transaction_manager.rb
@@ -286,7 +286,7 @@ module Kafka
       if @retry_counter > @max_retries
         raise e
       end
-      @logger.info("#{e.class.name}, sleeping #{@retry_backoff } , retrying...")
+      @logger.info("#{e.class.name}, sleeping #{@retry_backoff} , retrying...")
       sleep @retry_backoff
       retry
     end

--- a/lib/kafka/transaction_manager.rb
+++ b/lib/kafka/transaction_manager.rb
@@ -16,7 +16,8 @@ module Kafka
       idempotent: false,
       transactional: false,
       transactional_id: nil,
-      transactional_timeout: DEFAULT_TRANSACTION_TIMEOUT
+      transactional_timeout: DEFAULT_TRANSACTION_TIMEOUT,
+      retry_backoff_ms: 100
     )
       @cluster = cluster
       @logger = TaggedLogger.new(logger)
@@ -32,6 +33,7 @@ module Kafka
 
       @producer_id = -1
       @producer_epoch = 0
+      @retry_backoff_ms = retry_backoff_ms
 
       @sequences = {}
     end
@@ -47,20 +49,22 @@ module Kafka
     def init_producer_id(force = false)
       return if @producer_id >= 0 && !force
 
-      response = transaction_coordinator.init_producer_id(
-        transactional_id: @transactional_id,
-        transactional_timeout: @transactional_timeout
-      )
-      Protocol.handle_error(response.error_code)
+      retry_error_handler do
+        response = transaction_coordinator.init_producer_id(
+          transactional_id: @transactional_id,
+          transactional_timeout: @transactional_timeout
+        )
+        Protocol.handle_error(response.error_code)
 
-      # Reset producer id
-      @producer_id = response.producer_id
-      @producer_epoch = response.producer_epoch
+        # Reset producer id
+        @producer_id = response.producer_id
+        @producer_epoch = response.producer_epoch
 
-      # Reset sequence
-      @sequences = {}
+        # Reset sequence
+        @sequences = {}
 
-      @logger.debug "Current Producer ID is #{@producer_id} and Producer Epoch is #{@producer_epoch}"
+        @logger.debug "Current Producer ID is #{@producer_id} and Producer Epoch is #{@producer_epoch}"
+      end
     end
 
     def next_sequence_for(topic, partition)
@@ -112,20 +116,22 @@ module Kafka
         end
       end
 
-      unless new_topic_partitions.empty?
-        response = transaction_coordinator.add_partitions_to_txn(
-          transactional_id: @transactional_id,
-          producer_id: @producer_id,
-          producer_epoch: @producer_epoch,
-          topics: new_topic_partitions
-        )
+      retry_error_handler do
+        unless new_topic_partitions.empty?
+          response = transaction_coordinator.add_partitions_to_txn(
+            transactional_id: @transactional_id,
+            producer_id: @producer_id,
+            producer_epoch: @producer_epoch,
+            topics: new_topic_partitions
+          )
 
-        # Update added topic partitions
-        response.errors.each do |tp|
-          tp.partitions.each do |p|
-            Protocol.handle_error(p.error_code)
-            @transaction_partitions[tp.topic] ||= {}
-            @transaction_partitions[tp.topic][p.partition] = true
+          # Update added topic partitions
+          response.errors.each do |tp|
+            tp.partitions.each do |p|
+              Protocol.handle_error(p.error_code)
+              @transaction_partitions[tp.topic] ||= {}
+              @transaction_partitions[tp.topic][p.partition] = true
+            end
           end
         end
       end
@@ -166,15 +172,17 @@ module Kafka
 
       @logger.info "Commiting transaction #{@transactional_id}, Producer ID: #{@producer_id} (Epoch #{@producer_epoch})"
 
-      response = transaction_coordinator.end_txn(
-        transactional_id: @transactional_id,
-        producer_id: @producer_id,
-        producer_epoch: @producer_epoch,
-        transaction_result: TRANSACTION_RESULT_COMMIT
-      )
-      Protocol.handle_error(response.error_code)
+      retry_error_handler do
+        response = transaction_coordinator.end_txn(
+          transactional_id: @transactional_id,
+          producer_id: @producer_id,
+          producer_epoch: @producer_epoch,
+          transaction_result: TRANSACTION_RESULT_COMMIT
+        )
+        Protocol.handle_error(response.error_code)
+        @logger.info "Transaction #{@transactional_id} is committed, Producer ID: #{@producer_id} (Epoch #{@producer_epoch})"
+      end
 
-      @logger.info "Transaction #{@transactional_id} is committed, Producer ID: #{@producer_id} (Epoch #{@producer_epoch})"
       complete_transaction
 
       nil
@@ -199,15 +207,16 @@ module Kafka
 
       @logger.info "Aborting transaction #{@transactional_id}, Producer ID: #{@producer_id} (Epoch #{@producer_epoch})"
 
-      response = transaction_coordinator.end_txn(
-        transactional_id: @transactional_id,
-        producer_id: @producer_id,
-        producer_epoch: @producer_epoch,
-        transaction_result: TRANSACTION_RESULT_ABORT
-      )
-      Protocol.handle_error(response.error_code)
-
-      @logger.info "Transaction #{@transactional_id} is aborted, Producer ID: #{@producer_id} (Epoch #{@producer_epoch})"
+      retry_error_handler do
+        response = transaction_coordinator.end_txn(
+          transactional_id: @transactional_id,
+          producer_id: @producer_id,
+          producer_epoch: @producer_epoch,
+          transaction_result: TRANSACTION_RESULT_ABORT
+        )
+        Protocol.handle_error(response.error_code)
+        @logger.info "Transaction #{@transactional_id} is aborted, Producer ID: #{@producer_id} (Epoch #{@producer_epoch})"
+      end
 
       complete_transaction
 
@@ -224,22 +233,26 @@ module Kafka
         raise 'Transaction is not valid to send offsets'
       end
 
-      add_response = transaction_coordinator.add_offsets_to_txn(
-        transactional_id: @transactional_id,
-        producer_id: @producer_id,
-        producer_epoch: @producer_epoch,
-        group_id: group_id
-      )
-      Protocol.handle_error(add_response.error_code)
+      retry_error_handler do
+        add_response = transaction_coordinator.add_offsets_to_txn(
+          transactional_id: @transactional_id,
+          producer_id: @producer_id,
+          producer_epoch: @producer_epoch,
+          group_id: group_id
+        )
+        Protocol.handle_error(add_response.error_code)
+      end
 
-      send_response = transaction_coordinator.txn_offset_commit(
-        transactional_id: @transactional_id,
-        group_id: group_id,
-        producer_id: @producer_id,
-        producer_epoch: @producer_epoch,
-        offsets: offsets
-      )
-      Protocol.handle_error(send_response.error_code)
+      retry_error_handler do
+        send_response = transaction_coordinator.txn_offset_commit(
+          transactional_id: @transactional_id,
+          group_id: group_id,
+          producer_id: @producer_id,
+          producer_epoch: @producer_epoch,
+          offsets: offsets
+        )
+        Protocol.handle_error(send_response.error_code)
+      end
     end
 
     def in_transaction?
@@ -261,6 +274,14 @@ module Kafka
     end
 
     private
+
+    def retry_error_handler
+      yield
+    rescue ConcurrentTransactionError, CoordinatorLoadInProgress, NotCoordinatorForGroup, CoordinatorNotAvailable => e
+      @logger.info("#{e.class.name}, sleeping #{@retry_backoff_ms}ms, retrying...")
+      sleep @retry_backoff_ms / 1000.0
+      retry
+    end
 
     def force_transactional!
       unless transactional?

--- a/spec/functional/transactional_producer_spec.rb
+++ b/spec/functional/transactional_producer_spec.rb
@@ -293,7 +293,7 @@ describe "Transactional producer", functional: true do
     producer_2.begin_transaction
     producer_2.produce('Test 3', topic: topic, partition: 2)
     producer_2.deliver_messages
-    producer_2.commit_transaction    
+    producer_2.commit_transaction
 
     begin
       producer_1.shutdown
@@ -303,7 +303,7 @@ describe "Transactional producer", functional: true do
       expect(records.length).to eql(0)
 
       records = kafka.fetch_messages(topic: topic, partition: 1, offset: :earliest, max_wait_time: 1)
-      expect(records.length).to eql(0)      
+      expect(records.length).to eql(0)
 
       records = kafka.fetch_messages(topic: topic, partition: 2, offset: :earliest, max_wait_time: 1)
       expect(records.length).to eql(1)


### PR DESCRIPTION
Kafka Java Client handle certain types of errors with retries
For example:
https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java#L1185
https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java#L1189
https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java#L1141

This PR sync behavior for these scenarios. 