### PR TITLE
Correctly handle timestamp deltas as milliseconds

### DIFF
--- a/lib/kafka/protocol/record_batch.rb
+++ b/lib/kafka/protocol/record_batch.rb
@@ -1,3 +1,4 @@
+require 'bigdecimal'
 require 'digest/crc32'
 require 'kafka/protocol/record'
 
@@ -131,7 +132,7 @@ module Kafka
 
         records.each_with_index do |record, index|
           record.offset_delta = index
-          record.timestamp_delta = (record.create_time - first_timestamp).to_i
+          record.timestamp_delta = ((record.create_time - first_timestamp) * 1000).to_i
         end
         @last_offset_delta = records.length - 1
       end
@@ -167,8 +168,8 @@ module Kafka
         log_append_time = (attributes & TIMESTAMP_TYPE_MASK) != 0
 
         last_offset_delta = record_batch_decoder.int32
-        first_timestamp = Time.at(record_batch_decoder.int64 / 1000)
-        max_timestamp = Time.at(record_batch_decoder.int64 / 1000)
+        first_timestamp = Time.at(record_batch_decoder.int64 / BigDecimal(1000))
+        max_timestamp = Time.at(record_batch_decoder.int64 / BigDecimal(1000))
 
         producer_id = record_batch_decoder.int64
         producer_epoch = record_batch_decoder.int16
@@ -188,7 +189,7 @@ module Kafka
         until records_array_decoder.eof?
           record = Record.decode(records_array_decoder)
           record.offset = first_offset + record.offset_delta
-          record.create_time = log_append_time && max_timestamp ? max_timestamp : first_timestamp + record.timestamp_delta
+          record.create_time = log_append_time && max_timestamp ? max_timestamp : first_timestamp + record.timestamp_delta / BigDecimal(1000)
           records_array << record
         end
 

--- a/spec/protocol/record_batch_spec.rb
+++ b/spec/protocol/record_batch_spec.rb
@@ -48,7 +48,7 @@ describe Kafka::Protocol::RecordBatch do
       records: [
         Kafka::Protocol::Record.new(
           attributes:     1,
-          timestamp_delta: 1000,
+          timestamp_delta: 1000000,
           offset_delta:    1,
           key: 'hello',
           value: 'world',
@@ -58,7 +58,7 @@ describe Kafka::Protocol::RecordBatch do
         ),
         Kafka::Protocol::Record.new(
           attributes: 2,
-          timestamp_delta: 2000,
+          timestamp_delta: 2000000,
           offset_delta: 2,
           key: 'ruby',
           value: 'kafka',
@@ -92,11 +92,11 @@ describe Kafka::Protocol::RecordBatch do
   let(:record_1_bytes) {
     [
       # Size
-      0x2c,
+      0x2e,
       # Attributes
       0x1,
       # Timestamp delta
-      0xd0, 0xf,
+      0x80, 0x89, 0x7a,
       # Offset delta
       0x2,
       # Key
@@ -115,11 +115,11 @@ describe Kafka::Protocol::RecordBatch do
   let(:record_2_bytes) {
     [
       # Size
-      0x2a,
+      0x2e,
       # Attributes
       0x2,
       # Timestamp delta
-      0xa0, 0x1f,
+      0x80, 0x92, 0xf4, 0x1,
       # Offset delta
       0x4,
       # Key
@@ -140,7 +140,7 @@ describe Kafka::Protocol::RecordBatch do
       # First offset
       0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
       # Record Batch Length
-      0x0, 0x0, 0x0, 0x5e,
+      0x0, 0x0, 0x0, 0x61,
       # Partition Leader Epoch
       0x0, 0x0, 0x0, 0x2,
       # Magic byte
@@ -160,7 +160,7 @@ describe Kafka::Protocol::RecordBatch do
       # First offset
       0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
       # Record Batch Length
-      0x0, 0x0, 0x0, 0x72,
+      0x0, 0x0, 0x0, 0x75,
       # Partition Leader Epoch
       0x0, 0x0, 0x0, 0x2,
       # Magic byte
@@ -181,7 +181,7 @@ describe Kafka::Protocol::RecordBatch do
       # First offset
       0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
       # Record Batch Length
-      0x0, 0x0, 0x0, 0x60,
+      0x0, 0x0, 0x0, 0x63,
       # Partition Leader Epoch
       0x0, 0x0, 0x0, 0x2,
       # Magic byte
@@ -202,7 +202,7 @@ describe Kafka::Protocol::RecordBatch do
       # First offset
       0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
       # Record Batch Length
-      0x0, 0x0, 0x0, 0x71,
+      0x0, 0x0, 0x0, 0x74,
       # Partition Leader Epoch
       0x0, 0x0, 0x0, 0x2,
       # Magic byte
@@ -223,7 +223,7 @@ describe Kafka::Protocol::RecordBatch do
       # First offset
       0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1,
       # Record Batch Length
-      0x0, 0x0, 0x0, 0x67,
+      0x0, 0x0, 0x0, 0x6a,
       # Partition Leader Epoch
       0x0, 0x0, 0x0, 0x2,
       # Magic byte
@@ -416,7 +416,7 @@ def expect_matched_records(records)
   record_1 = records.first
   expect(record_1.attributes).to eql(1)
 
-  expect(record_1.timestamp_delta).to eql(1000)
+  expect(record_1.timestamp_delta).to eql(1000000)
   expect(record_1.create_time.to_i).to eql(1521657000)
 
   expect(record_1.offset_delta).to eql(1)
@@ -430,7 +430,7 @@ def expect_matched_records(records)
 
   record_2 = records.last
   expect(record_2.attributes).to eql(2)
-  expect(record_2.timestamp_delta).to eql(2000)
+  expect(record_2.timestamp_delta).to eql(2000000)
   expect(record_2.create_time.to_i).to eql(1521658000)
   expect(record_2.offset_delta).to eql(2)
   expect(record_2.offset).to eql(3)


### PR DESCRIPTION
Kafka timestamps are always given in milliseconds, which is why first_timestamp was already divided by 1000 here. However, the timestamp_delta was then added as is, which is incorrect -- adding milliseconds to a timestamp in seconds will always produce the wrong result (except in the degenerate case where the delta is zero).

We could simply divide the delta by 1000 in the same way that was already being done for the first timestamp, but that would discard the sub-second part of the timestamp. Instead, first calculate the first timestamp using the full millisecond resolution (using integer arithmetic for this avoids floating point rounding errors). Then, add the delta divided by 1000 as a float to come up with each record's correct timestamp (we can't use integer arithmetic for this because a Time can only have seconds added to it).

With this patch, the record timestamps reported by ruby-kafka match those from <https://github.com/fgeller/kt>, so I'm reasonably confident this is correct.

I believe this is a fix for <https://github.com/zendesk/ruby-kafka/issues/721>.