### PR TITLE
SimpleDelegator is not loaded by default and require implicit require

### DIFF
--- a/lib/kafka/tagged_logger.rb
+++ b/lib/kafka/tagged_logger.rb
@@ -1,6 +1,7 @@
 # Basic implementation of a tagged logger that matches the API of
 # ActiveSupport::TaggedLogging.
 
+require 'delegate'
 require 'logger'
 
 module Kafka


### PR DESCRIPTION
## Description

So it seems like `SimpleDelegator` is not always loaded by default and require explicit require 

This is the error I see after upgrading to `ruby-kafka-0.7.10`
```
NameError: uninitialized constant Kafka::SimpleDelegator
  /bundle/gems/ruby-kafka-0.7.10/lib/kafka/tagged_logger.rb:7:in `<module:Kafka>'
  /bundle/gems/ruby-kafka-0.7.10/lib/kafka/tagged_logger.rb:6:in `<top (required)>'
  /bundle/gems/ruby-kafka-0.7.10/lib/kafka/client.rb:17:in `require'
  /bundle/gems/ruby-kafka-0.7.10/lib/kafka/client.rb:17:in `<top (required)>'
  /bundle/gems/ruby-kafka-0.7.10/lib/kafka.rb:373:in `require'
  /bundle/gems/ruby-kafka-0.7.10/lib/kafka.rb:373:in `<top (required)>'
  /bundle/gems/racecar-0.4.2/lib/racecar/runner.rb:1:in `require'
  /bundle/gems/racecar-0.4.2/lib/racecar/runner.rb:1:in `<top (required)>'
  /bundle/gems/racecar-0.4.2/lib/racecar.rb:4:in `require'
  /bundle/gems/racecar-0.4.2/lib/racecar.rb:4:in `<top (required)>'
  /bundle/gems/racecar-0.4.2/exe/racecar:3:in `require'
  /bundle/gems/racecar-0.4.2/exe/racecar:3:in `<top (required)>'
  /bundle/bin/racecar:23:in `load'
  /bundle/bin/racecar:23:in `<top (required)>'
```

## Environment
* ruby 2.5.5p157 (2019-03-15 revision 67260) [x86_64-linux]
* ruby-kafka-0.7.10
