### PR TITLE
Workaround missing monotonic_time dependency for ActiveSupport 6.0

### DIFF
--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "docker-api"
   spec.add_development_dependency "rspec-benchmark"
-  spec.add_development_dependency "activesupport", ">= 4.0", "< 6.0.0"
+  spec.add_development_dependency "activesupport", ">= 4.0", "< 6.1"
   spec.add_development_dependency "snappy"
   spec.add_development_dependency "extlz4"
   spec.add_development_dependency "zstd-ruby"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require "concurrent/utility/monotonic_time"
 require "active_support/notifications"
 require "kafka"
 require "kafka/tagged_logger"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "concurrent/utility/monotonic_time"
+require "active_support/core_ext/object/try"
 require "active_support/notifications"
 require "kafka"
 require "kafka/tagged_logger"


### PR DESCRIPTION
This addresses the build issue seen here: https://github.com/zendesk/ruby-kafka/pull/770

ActiveSupport 6.0 added calls to `Concurrent.monotonic_time` but the relevant code from Concurrent is only loaded if the entire `activesupport` library is required.

I consider this a bug in activesupport and I will also submit a patch there, but this works around the issue. Rails PR https://github.com/rails/rails/pull/37033.

This is not an issue at runtime for ruby-kafka provided that either `activesupport` or `concurrent` is required. For additional safety we could require `concurrent/utility/monotonic_time` if `ActiveSupport::Notifications` is defined here: https://github.com/zendesk/ruby-kafka/blob/cc52504bc2b8dc59dbccbebc1e0e64a7c1aaeda8/lib/kafka/instrumenter.rb#L11

Updated:

It looks like there is another missing require within active_support/notifications.
This has been fixed on master here: https://github.com/rails/rails/commit/530f7805ed5790af1d472a041bc74089dc183f47#diff-7d21210eb262dd39635c5b4952d29dee
Added a require for `active_support/core_ext/object/try` to also work around it here.