### PR TITLE
Support Rails 6.0, require active_support for specs

### DIFF
--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "docker-api"
   spec.add_development_dependency "rspec-benchmark"
-  spec.add_development_dependency "activesupport", ">= 4.0", "< 6.0.0"
+  spec.add_development_dependency "activesupport", ">= 4.0", "< 6.1"
   spec.add_development_dependency "snappy"
   spec.add_development_dependency "extlz4"
   spec.add_development_dependency "zstd-ruby"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+require "active_support"
 require "active_support/notifications"
 require "kafka"
 require "kafka/tagged_logger"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,10 @@
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "active_support"
+# A missing require for try has been added to rails master here:
+#   https://github.com/rails/rails/commit/530f7805ed5790af1d472a041bc74089dc183f47
+# The explicit require below can be removed with a future Rails release (6.1?).
+require "active_support/core_ext/object/try"
 require "active_support/notifications"
 require "kafka"
 require "kafka/tagged_logger"


### PR DESCRIPTION
This addresses the build issue seen in #770, to restore support for Rails 6.0.

Based on https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support, `active_support` should be required. That doesn't actually load much, but then when `active_support/notifications` is required the other relevant dependencies will be found.

Still needs to require  `active_support/core_ext/object/try` to work around a missing require within active_support/notifications. This has been fixed on master here: https://github.com/rails/rails/commit/530f7805ed5790af1d472a041bc74089dc183f47#diff-7d21210eb262dd39635c5b4952d29dee
