### PR TITLE
fix require on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Please see the [documentation site](http://www.rubydoc.info/gems/ruby-kafka) for
 A client must be initialized with at least one Kafka broker, from which the entire Kafka cluster will be discovered. Each client keeps a separate pool of broker connections. Don't use the same client from more than one thread.
 
 ```ruby
-require "kafka"
+require "ruby-kafka"
 
 # The first argument is a list of "seed brokers" that will be queried for the full
 # cluster topology. At least one of these *must* be available. `client_id` is

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ In this example, a producer is configured in a Rails initializer:
 
 ```ruby
 # config/initializers/kafka_producer.rb
-require "kafka"
+require "ruby-kafka"
 
 # Configure the Kafka client with the broker hosts and the Rails
 # logger.
@@ -490,7 +490,7 @@ end
 Consuming messages from a Kafka topic with ruby-kafka is simple:
 
 ```ruby
-require "kafka"
+require "ruby-kafka"
 
 kafka = Kafka.new(["kafka1:9092", "kafka2:9092"])
 
@@ -513,7 +513,7 @@ The Consumer API solves all of the above issues, and more. It uses the Consumer 
 Using the API is simple:
 
 ```ruby
-require "kafka"
+require "ruby-kafka"
 
 kafka = Kafka.new(["kafka1:9092", "kafka2:9092"])
 
@@ -728,7 +728,7 @@ Most operations are instrumented using [Active Support Notifications](http://api
 
 ```ruby
 require "active_support/notifications"
-require "kafka"
+require "ruby-kafka"
 ```
 
 The notifications are namespaced based on their origin, with separate namespaces for the producer and the consumer.


### PR DESCRIPTION
update require 'kafka' to 'ruby-kafka', which is the correct gem name.

I was trying the project on my local machine and took about 30 minutes to figure out that I had required the wrong lib :(