### PR TITLE
Send JoinGroupRequest v1 messages with rebalance timeouts

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -337,6 +337,7 @@ module Kafka
     def consumer(
         group_id:,
         session_timeout: 30,
+        rebalance_timeout: 60,
         offset_commit_interval: 10,
         offset_commit_threshold: 0,
         heartbeat_interval: 10,
@@ -357,6 +358,7 @@ module Kafka
         logger: @logger,
         group_id: group_id,
         session_timeout: session_timeout,
+        rebalance_timeout: rebalance_timeout,
         retention_time: retention_time,
         instrumenter: instrumenter,
       )

--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -7,11 +7,12 @@ module Kafka
   class ConsumerGroup
     attr_reader :assigned_partitions, :generation_id, :group_id
 
-    def initialize(cluster:, logger:, group_id:, session_timeout:, retention_time:, instrumenter:)
+    def initialize(cluster:, logger:, group_id:, session_timeout:, rebalance_timeout:, retention_time:, instrumenter:)
       @cluster = cluster
       @logger = TaggedLogger.new(logger)
       @group_id = group_id
       @session_timeout = session_timeout
+      @rebalance_timeout = rebalance_timeout
       @instrumenter = instrumenter
       @member_id = ""
       @generation_id = nil
@@ -140,7 +141,9 @@ module Kafka
         response = coordinator.join_group(
           group_id: @group_id,
           session_timeout: @session_timeout,
+          rebalance_timeout: @rebalance_timeout,
           member_id: @member_id,
+          topics: @topics,
         )
 
         Protocol.handle_error(response.error_code)

--- a/lib/kafka/protocol/join_group_request.rb
+++ b/lib/kafka/protocol/join_group_request.rb
@@ -7,18 +7,23 @@ module Kafka
     class JoinGroupRequest
       PROTOCOL_TYPE = "consumer"
 
-      def initialize(group_id:, session_timeout:, member_id:, topics: [])
+      def initialize(group_id:, session_timeout:, rebalance_timeout:, member_id:, topics: [])
         @group_id = group_id
         @session_timeout = session_timeout * 1000 # Kafka wants ms.
+        @rebalance_timeout = rebalance_timeout * 1000 # Kafka wants ms.
         @member_id = member_id || ""
         @protocol_type = PROTOCOL_TYPE
         @group_protocols = {
-          "standard" => ConsumerGroupProtocol.new(topics: ["test-messages"]),
+          "roundrobin" => ConsumerGroupProtocol.new(topics: topics),
         }
       end
 
       def api_key
         JOIN_GROUP_API
+      end
+
+      def api_version
+        1
       end
 
       def response_class
@@ -28,6 +33,7 @@ module Kafka
       def encode(encoder)
         encoder.write_string(@group_id)
         encoder.write_int32(@session_timeout)
+        encoder.write_int32(@rebalance_timeout)
         encoder.write_string(@member_id)
         encoder.write_string(@protocol_type)
 

--- a/spec/functional/client_spec.rb
+++ b/spec/functional/client_spec.rb
@@ -54,7 +54,7 @@ describe "Client API", functional: true do
     end
 
     expect(result.state).to eq('Stable')
-    expect(result.protocol).to eq('standard')
+    expect(result.protocol).to eq('roundrobin')
     expect(result.members.count).to eq(1)
 
     member = result.members.first


### PR DESCRIPTION
If we send a JoinGroupRequest v0 message to join an existing consumer group, the broker does not wait for other members to send their own JoinGroupRequests, resulting in all other members being kicked out of the group. When they rejoin later, the same thing happens, resulting in the group continually being rebalanced with a single member each time.

Sending a JoinGroupRequest v1 message instead lets us specify a timeout to wait for other members. A new member is now added to the consumer group as expected, rather than becoming the only member.

The default value of 1 minute for rebalance_timeout is taken from what Sarama (Go library) does. librdkafka defaults to 5 minutes here, which seems a little excessive.

This will break if talking to a Kafka broker older than 0.10.1. This is unlikely to be a problem because these messages are only used in ruby-kafka to support consumer groups, which were already broken due to the issue described above.

While here, also send the correct group protocol information -- we only support round-robin assignment, and we have an actual list of topics rather than "test-messages". This is needed for interoperability with other clients participating in the same consumer group (found when debugging this issue with Sarama).