### PR TITLE
AsyncProducer#produce should fail fast if `topic` is a "bad" type

### DIFF
--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -103,6 +103,12 @@ module Kafka
     # @raise [BufferOverflow] if the message queue is full.
     # @return [nil]
     def produce(value, topic:, **options)
+      unless topic.is_a?(String) || topic.is_a?(Symbol)
+        raise ArgumentError, "topic must be either a String or a Symbol, not a #{topic.class.name}"
+      end
+
+      topic = topic.to_s
+
       ensure_threads_running!
 
       if @queue.size >= @max_queue_size

--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -103,11 +103,8 @@ module Kafka
     # @raise [BufferOverflow] if the message queue is full.
     # @return [nil]
     def produce(value, topic:, **options)
-      unless topic.is_a?(String) || topic.is_a?(Symbol)
-        raise ArgumentError, "topic must be either a String or a Symbol, not a #{topic.class.name}"
-      end
-
-      topic = topic.to_s
+      # We want to fail fast if `topic` isn't a String
+      topic = topic.to_str
 
       ensure_threads_running!
 

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -138,11 +138,8 @@ module Kafka
     def deliver_message(value, key: nil, headers: {}, topic:, partition: nil, partition_key: nil, retries: 1)
       create_time = Time.now
 
-      unless topic.is_a?(String) || topic.is_a?(Symbol)
-        raise ArgumentError, "topic must be either a String or a Symbol, not a #{topic.class.name}"
-      end
-
-      topic = topic.to_s
+      # We want to fail fast if `topic` isn't a String
+      topic = topic.to_str
 
       message = PendingMessage.new(
         value: value,

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -138,6 +138,12 @@ module Kafka
     def deliver_message(value, key: nil, headers: {}, topic:, partition: nil, partition_key: nil, retries: 1)
       create_time = Time.now
 
+      unless topic.is_a?(String) || topic.is_a?(Symbol)
+        raise ArgumentError, "topic must be either a String or a Symbol, not a #{topic.class.name}"
+      end
+
+      topic = topic.to_s
+
       message = PendingMessage.new(
         value: value,
         key: key,

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -188,11 +188,17 @@ module Kafka
     # @raise [BufferOverflow] if the maximum buffer size has been reached.
     # @return [nil]
     def produce(value, key: nil, headers: {}, topic:, partition: nil, partition_key: nil, create_time: Time.now)
+      unless topic.is_a?(String) || topic.is_a?(Symbol)
+        raise ArgumentError, "topic must be either a String or a Symbol, not a #{topic.class.name}"
+      end
+
+      topic = topic.to_s
+
       message = PendingMessage.new(
         value: value && value.to_s,
         key: key && key.to_s,
         headers: headers,
-        topic: topic.to_s,
+        topic: topic,
         partition: partition && Integer(partition),
         partition_key: partition_key && partition_key.to_s,
         create_time: create_time

--- a/lib/kafka/producer.rb
+++ b/lib/kafka/producer.rb
@@ -188,11 +188,8 @@ module Kafka
     # @raise [BufferOverflow] if the maximum buffer size has been reached.
     # @return [nil]
     def produce(value, key: nil, headers: {}, topic:, partition: nil, partition_key: nil, create_time: Time.now)
-      unless topic.is_a?(String) || topic.is_a?(Symbol)
-        raise ArgumentError, "topic must be either a String or a Symbol, not a #{topic.class.name}"
-      end
-
-      topic = topic.to_s
+      # We want to fail fast if `topic` isn't a String
+      topic = topic.to_str
 
       message = PendingMessage.new(
         value: value && value.to_s,

--- a/spec/async_producer_spec.rb
+++ b/spec/async_producer_spec.rb
@@ -90,5 +90,18 @@ describe Kafka::AsyncProducer do
       expect(metric.payload[:error]).to be_a(Kafka::BufferOverflow)
       expect(sync_producer).to have_received(:produce).exactly(3).times
     end
+
+    it "requires `topic` to be a String or a Symbol" do
+      expect {
+        async_producer.produce("hello", topic: 42)
+      }.to raise_exception(ArgumentError)
+    end
+
+    it "converts `topic` to a String if `topic` is a Symbol" do
+      async_producer.produce("hello", topic: :greetings)
+      sleep 0.2 # wait for worker to call produce
+
+      expect(sync_producer).to have_received(:produce).with("hello", topic: "greetings")
+    end
   end
 end

--- a/spec/async_producer_spec.rb
+++ b/spec/async_producer_spec.rb
@@ -91,17 +91,10 @@ describe Kafka::AsyncProducer do
       expect(sync_producer).to have_received(:produce).exactly(3).times
     end
 
-    it "requires `topic` to be a String or a Symbol" do
+    it "requires `topic` to be a String" do
       expect {
-        async_producer.produce("hello", topic: 42)
-      }.to raise_exception(ArgumentError)
-    end
-
-    it "converts `topic` to a String if `topic` is a Symbol" do
-      async_producer.produce("hello", topic: :greetings)
-      sleep 0.2 # wait for worker to call produce
-
-      expect(sync_producer).to have_received(:produce).with("hello", topic: "greetings")
+        async_producer.produce("hello", topic: :topic)
+      }.to raise_exception(NoMethodError, /to_str/)
     end
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -47,4 +47,20 @@ describe Kafka::Client do
       end
     end
   end
+
+  describe "#deliver_message" do
+    subject(:client) { described_class.new(client_opts) }
+
+    it "requires `topic` to be a String or a Symbol" do
+      expect {
+        client.deliver_message("hello", topic: 42)
+      }.to raise_exception(ArgumentError)
+    end
+
+    it "converts `topic` to a String if `topic` is a Symbol" do
+      expect {
+        client.deliver_message("hello", topic: :greetings)
+      }.to_not raise_exception(ArgumentError)
+    end
+  end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -51,16 +51,10 @@ describe Kafka::Client do
   describe "#deliver_message" do
     subject(:client) { described_class.new(client_opts) }
 
-    it "requires `topic` to be a String or a Symbol" do
+    it "requires `topic` to be a String" do
       expect {
-        client.deliver_message("hello", topic: 42)
-      }.to raise_exception(ArgumentError)
-    end
-
-    it "converts `topic` to a String if `topic` is a Symbol" do
-      expect {
-        client.deliver_message("hello", topic: :greetings)
-      }.to_not raise_exception(ArgumentError)
+        client.deliver_message("hello", topic: :topic)
+      }.to raise_exception(NoMethodError, /to_str/)
     end
   end
 end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -119,6 +119,18 @@ describe Kafka::Producer do
 
       expect(broker1.messages.map(&:key)).to eq [nil]
     end
+
+    it "requires `topic` to be a String or a Symbol" do
+      expect {
+        producer.produce("hello", topic: 42)
+      }.to raise_exception(ArgumentError)
+    end
+
+    it "converts `topic` to a String if `topic` is a Symbol" do
+      expect {
+        producer.produce("hello", topic: :greetings)
+      }.to_not raise_exception(ArgumentError)
+    end
   end
 
   describe "#deliver_messages" do

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -120,16 +120,10 @@ describe Kafka::Producer do
       expect(broker1.messages.map(&:key)).to eq [nil]
     end
 
-    it "requires `topic` to be a String or a Symbol" do
+    it "requires `topic` to be a String" do
       expect {
-        producer.produce("hello", topic: 42)
-      }.to raise_exception(ArgumentError)
-    end
-
-    it "converts `topic` to a String if `topic` is a Symbol" do
-      expect {
-        producer.produce("hello", topic: :greetings)
-      }.to_not raise_exception(ArgumentError)
+        producer.produce("hello", topic: :topic)
+      }.to raise_exception(NoMethodError, /to_str/)
     end
   end
 


### PR DESCRIPTION
One of my users (I maintain a library that wraps ruby-kafka) was producing asynchronously with the topic argument being a Symbol, but they weren't seeing problems until messages couldn't be added to the async message queue because the thread producer couldn't deliver messages with Symbol topics.

The proposed code ensures that `topic` is either a String or a Symbol upfront (every Ruby object has a String representation, and while a Symbol makes sense, a Hash doesn't, so the code needs to explicitly typecheck `topic`).

I updated all 3 producing methods because it seems nicer to have a uniform, and explanatory error message (the previous one was a `NoMethodError` about a method named `bytesize`).

If y'all don't want to allow Symbols, let me know, and I'll change it to only allow Strings.

If the "preamble" that's now in all 3 producing methods offends your sensibilities (it kind of offends mine), I thought creating an uppercase `Topic` method (like `Kernel#Array`) to encapsulate all the type-checking logic might be a nice way to do it. That way, the single line `topic = Topic(topic)` is all that would have to be added to any producing method. Let me know if you'd prefer that (or something else) to the typecheck preamble I've written, and I'll change it.