### PR TITLE
Cover transactional manager with retries on certain errors

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -270,6 +270,8 @@ module Kafka
         transactional: transactional,
         transactional_id: transactional_id,
         transactional_timeout: transactional_timeout,
+        max_retries: max_retries,
+        retry_backoff: retry_backoff
       )
 
       Producer.new(

--- a/lib/kafka/protocol/txn_offset_commit_request.rb
+++ b/lib/kafka/protocol/txn_offset_commit_request.rb
@@ -35,8 +35,8 @@ module Kafka
           encoder.write_array(partitions) do |partition, offset|
             encoder.write_int32(partition)
             encoder.write_int64(offset[:offset])
-            encoder.write_string(nil) # metadata
             encoder.write_int32(offset[:leader_epoch])
+            encoder.write_string(nil) # metadata
           end
         end
       end

--- a/spec/functional/transactional_producer_spec.rb
+++ b/spec/functional/transactional_producer_spec.rb
@@ -283,17 +283,30 @@ describe "Transactional producer", functional: true do
     producer_1.produce('Test 3', topic: topic, partition: 2)
     producer_1.deliver_messages
 
+    # Producer 2 starts with the same transactional id to cause the concurrent transactions error
     producer_2 = kafka.producer(
       transactional: true,
       transactional_id: transactional_id
     )
-    expect do
-      producer_2.init_transactions
-    end.to raise_error(Kafka::ConcurrentTransactionError)
+
+    producer_2.init_transactions
+    producer_2.begin_transaction
+    producer_2.produce('Test 3', topic: topic, partition: 2)
+    producer_2.deliver_messages
+    producer_2.commit_transaction
 
     begin
       producer_1.shutdown
       producer_2.shutdown
+
+      records = kafka.fetch_messages(topic: topic, partition: 0, offset: :earliest, max_wait_time: 1)
+      expect(records.length).to eql(0)
+
+      records = kafka.fetch_messages(topic: topic, partition: 1, offset: :earliest, max_wait_time: 1)
+      expect(records.length).to eql(0)
+
+      records = kafka.fetch_messages(topic: topic, partition: 2, offset: :earliest, max_wait_time: 1)
+      expect(records.length).to eql(1)
     rescue; end
   end
 


### PR DESCRIPTION
Kafka Java Client handle certain types of errors with retries
For example:
https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java#L1185
https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java#L1189
https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java#L1141

This PR sync behavior for these scenarios.