### PR TITLE
Define instance variables to avoid warnings

### DIFF
--- a/lib/kafka/connection.rb
+++ b/lib/kafka/connection.rb
@@ -58,6 +58,9 @@ module Kafka
       @connect_timeout = connect_timeout || CONNECT_TIMEOUT
       @socket_timeout = socket_timeout || SOCKET_TIMEOUT
       @ssl_context = ssl_context
+
+      @socket = nil
+      @last_request = nil
     end
 
     def to_s

--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -17,6 +17,9 @@ module Kafka
       @commands = Queue.new
       @next_offsets = Hash.new { |h, k| h[k] = {} }
 
+      # We are only running when someone calls start.
+      @running = false
+
       # Long poll until at least this many bytes can be fetched.
       @min_bytes = 1
 


### PR DESCRIPTION
We've noticed warnings when calling 
- `open?` like on https://github.com/zendesk/ruby-kafka/blob/v0.7.10/lib/kafka/connection.rb#L98
- `idle?` like on https://github.com/zendesk/ruby-kafka/blob/v0.7.10/lib/kafka/connection.rb#L94 

To fix this, we're defining them in the initializer.  
Those interrogator methods already check if those instance variables are non-nil so defining them will be safe.