### PR TITLE
Fix confusing error message with nil or empty string topic

### DIFF
--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -45,6 +45,10 @@ module Kafka
         new_topics = topics - @target_topics
 
         unless new_topics.empty?
+          if new_topics.any? { |topic| topic.nil? or topic.empty? }
+            raise ArgumentError, "Topic must not be nil or empty"
+          end
+
           @logger.info "New topics added to target list: #{new_topics.to_a.join(', ')}"
 
           @target_topics.merge(new_topics)

--- a/spec/cluster_spec.rb
+++ b/spec/cluster_spec.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 describe Kafka::Cluster do
+  let(:broker) { double(:broker) }
+  let(:broker_pool) { double(:broker_pool) }
+
+  let(:cluster) {
+    Kafka::Cluster.new(
+      seed_brokers: [URI("kafka://test1:9092")],
+      broker_pool: broker_pool,
+      logger: LOGGER,
+    )
+  }
+
   describe "#get_leader" do
-    let(:broker) { double(:broker) }
-    let(:broker_pool) { double(:broker_pool) }
-
-    let(:cluster) {
-      Kafka::Cluster.new(
-        seed_brokers: [URI("kafka://test1:9092")],
-        broker_pool: broker_pool,
-        logger: LOGGER,
-      )
-    }
-
     before do
       allow(broker_pool).to receive(:connect) { broker }
       allow(broker).to receive(:disconnect)
@@ -87,6 +87,20 @@ describe Kafka::Cluster do
       expect {
         cluster.get_leader("greetings", 42)
       }.to raise_exception(Kafka::ConnectionError)
+    end
+  end
+
+  describe "#add_target_topics" do
+    it "raises ArgumentError if the topic is nil" do
+      expect {
+        cluster.add_target_topics([nil])
+      }.to raise_exception(ArgumentError)
+    end
+
+    it "raises ArgumentError if the topic is empty" do
+      expect {
+        cluster.add_target_topics([""])
+      }.to raise_exception(ArgumentError)
     end
   end
 end


### PR DESCRIPTION
Resolves #802 

Currently nil or empty string topic is basically allowed and will raise `Kafka::ConnectionError` (`Connection error EOFError`) in `Cluster#fetch_cluster_info` which is confusing.

Actually nil raises error due to #791 (nil has not to_str) , but there are still 2 problems.
* Empty string as topic is allowed in `Producer#produce` and `Kafka::DeliveryFailed` will be raised in `Producer#deliver_messages` which is still confusing.
* Some libraries (ex fluent-plugin-kafka) uses internal class directly and still raises `Kafka::ConnectionError` with nil topic.

This PR raises ArgumentError with nil or empty topic in `Cluster#add_target_topics` to resolve these problems.