### PR TITLE
Fix missing constant errors

### DIFF
--- a/lib/kafka/datadog.rb
+++ b/lib/kafka/datadog.rb
@@ -40,7 +40,7 @@ module Kafka
       end
 
       def host
-        @host ||= default_host
+        @host
       end
 
       def host=(host)
@@ -49,7 +49,7 @@ module Kafka
       end
 
       def port
-        @port ||= default_port
+        @port
       end
 
       def port=(port)
@@ -76,14 +76,6 @@ module Kafka
       end
 
       private
-
-      def default_host
-        ::Datadog::Statsd.const_defined?(:Connection) ? ::Datadog::Statsd::Connection::DEFAULT_HOST : ::Datadog::Statsd::DEFAULT_HOST
-      end
-
-      def default_port
-        ::Datadog::Statsd.const_defined?(:Connection) ? ::Datadog::Statsd::Connection::DEFAULT_PORT : ::Datadog::Statsd::DEFAULT_PORT
-      end
 
       def clear
         @statsd && @statsd.close

--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "zstd-ruby"
   spec.add_development_dependency "colored"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
-  spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0", "< 4.6.0"
+  spec.add_development_dependency "dogstatsd-ruby", ">= 4.0.0", "< 5.0.0"
   spec.add_development_dependency "statsd-ruby"
   spec.add_development_dependency "prometheus-client", "~> 0.10.0"
   spec.add_development_dependency "ruby-prof"

--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "zstd-ruby"
   spec.add_development_dependency "colored"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
-  spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0", "< 5.0.0"
+  spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0", "< 4.6.0"
   spec.add_development_dependency "statsd-ruby"
   spec.add_development_dependency "prometheus-client", "~> 0.10.0"
   spec.add_development_dependency "ruby-prof"


### PR DESCRIPTION
## Why?

After cloning https://github.com/zendesk/ruby-kafka and following the development instructions to run `bin/setup` and then `rake spec` I encountered a number of failed specs with errors that looked like this:

```
      NameError:
        uninitialized constant Datadog::Statsd::Connection::DEFAULT_HOST
        Did you mean?  Datadog::Statsd::DEFAULT_BUFFER_SIZE
```

## How?

Applied suggestion from @tjwp in https://github.com/zendesk/ruby-kafka/pull/810#issuecomment-589415255.