### PR TITLE
Instrument create_time from last message in batch

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -308,6 +308,7 @@ module Kafka
               topic: batch.topic,
               partition: batch.partition,
               last_offset: batch.last_offset,
+              last_create_time: batch.messages.last.try(:create_time),
               offset_lag: batch.offset_lag,
               highwater_mark_offset: batch.highwater_mark_offset,
               message_count: batch.messages.count,

--- a/lib/kafka/datadog.rb
+++ b/lib/kafka/datadog.rb
@@ -160,6 +160,8 @@ module Kafka
       def process_batch(event)
         offset = event.payload.fetch(:last_offset)
         messages = event.payload.fetch(:message_count)
+        create_time = event.payload.fetch(:last_create_time)
+        time_lag = create_time && ((Time.now - create_time) * 1000).to_i
 
         tags = {
           client: event.payload.fetch(:client_id),
@@ -176,6 +178,10 @@ module Kafka
         end
 
         gauge("consumer.offset", offset, tags: tags)
+
+        if time_lag
+          gauge("consumer.time_lag", time_lag, tags: tags)
+        end
       end
 
       def fetch_batch(event)

--- a/spec/prometheus_spec.rb
+++ b/spec/prometheus_spec.rb
@@ -114,6 +114,7 @@ describe Kafka::Prometheus do
         topic: 'AAA',
         partition: 4,
         last_offset: 100,
+        last_create_time: Time.now,
         message_count: 7
       }
     end


### PR DESCRIPTION
## Why?

My team at GitHub uses racecar version 1.0.1 and by extension ruby-kafka. We're interested in the potential of racecar 2 that uses the rdkafka-ruby client but we heavily rely on the `consumer.offset_lag` metric for monitoring our stream processors.

It doesn't look like that metric is going to be straightforward to implement in racecar 2 but I'm wondering if we could instead switch to the `consumer.time_lag` metric instead? Unfortunately that metric isn't published in the `process_batch.consumer` payload in racecar 1.0.1 or racecar 2.0.0-beta.

## How?

This PR updates the `process_batch.consumer` payload to include a `last_create_time` metric which comes from the last message in the batch. 

We could use a fork of `ruby-kafka` with these changes to accomplish our goal with racecar 1.0.1 in the short term but I thought others may benefit as well so I'm opening this PR.

I'm also hoping to open a PR against racecar 2 to add the same metric to the `process_batch` payload so we can easily transition from racecar 1.0.1 with ruby-kafka to racecar 2.0.0 with rdkafka-ruby.

Thank you for your consideration.