### PR TITLE
Add Envy functionality

### DIFF
--- a/.envyfile
+++ b/.envyfile
@@ -1,0 +1,27 @@
+environment:
+    base:
+        image: ruby:stretch
+    setup-steps:
+    - name: bundle
+      label: 'Installing Ruby Dependencies'
+      type: script
+      run:
+        - 'bundle install'
+      triggers:
+        files:
+          - Gemfile
+          - Gemfile.lock
+actions:
+    - name: bundle
+      script: 'bundle'
+      help: 'Execute ruby bundler inside environment'
+    - name: console
+      script: 'echo "Connect to kafka brokers at kafka1:9092,kafka2:9092,kafka3:9092" && bin/console'
+      help: 'Start an interactive prompt that will allow you to experiment'
+    - name: test
+      script: 'rake spec'
+      help: 'Run tests'
+services:
+  compose-file: docker-compose.yml
+network:
+  name: ruby-kafka

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.log
 *.swp
 .byebug_history
+/.envy/

--- a/README.md
+++ b/README.md
@@ -1131,6 +1131,8 @@ The Consumer API is designed for flexibility and stability. The first is accompl
 
 ## Development
 
+**Note:** This project supports [Envy](https://envy-project.github.io/index.html), a tool to isolate and manage your dev environment. Setup is as easy as `envy up`!
+
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 **Note:** the specs require a working [Docker](https://www.docker.com/) instance, but should work out of the box if you have Docker installed. Please create an issue if that's not the case.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.3'
 services:
   zookeeper:
     image: wurstmeister/zookeeper
@@ -10,8 +10,8 @@ services:
       - "9092:9092"
     environment:
       KAFKA_BROKER_ID: 1
-      KAFKA_ADVERTISED_HOST_NAME: 192.168.99.100
-      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://:9092
+      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -21,8 +21,8 @@ services:
       - "9093:9092"
     environment:
       KAFKA_BROKER_ID: 2
-      KAFKA_ADVERTISED_HOST_NAME: 192.168.99.100
-      KAFKA_ADVERTISED_PORT: 9093
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://:9093
+      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9093
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -32,8 +32,11 @@ services:
       - "9094:9092"
     environment:
       KAFKA_BROKER_ID: 3
-      KAFKA_ADVERTISED_HOST_NAME: 192.168.99.100
-      KAFKA_ADVERTISED_PORT: 9094
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
+      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+networks:
+  default:
+    name: ruby-kafka


### PR DESCRIPTION
Hello!
​
We (@magmastonealex, @omstrumpf, @gbateman, @Tim-Willard) have been working on a tool called ENVy.
​
ENVy is an environment manager to make working on disparate projects easier. You don't need to worry about what a system package is called on your Linux distribution, or figure out how to build for Mac from scratch.

​Setup with ENVy is as simple as typing `envy up` for any project you want to work on. Running `envy nuke` removes all traces of that environment.
With ENVy, you don't need to hunt down a lint command or how you run the tests. `envy -h` shows you all the commands you can run - or just jump into a shell with `envy shell`.
​
You can read more about ENVy [here](http://envy-project.github.io/), but the short version is that we think it'll make it easier for contributors to help out. 
​
This PR adds an `ENVyfile`, the file that describes a development environment and contains the commands to run. We used ruby-kafka while developing in order to test ENVy, and we hoped you'd consider committing this file to help out casual contributors.

While ruby-kafka doesn't have a particularly complex setup guide, one thing that might be difficult to new users is setting up a kafka cluster to test on. The envyfile provided here also starts up the docker-compose file containing the kafka cluster, and `envy console` will run the ruby console script inside the container with a helpful message on how to connect to the 3 test brokers.
 
In order to get this working, I modified the docker-compose file that was in the repository. I couldn't figure out how to connect to the brokers inside at all with the given configuration. This hopefully shouldn't break anything (I think the configuration change I made should be backwards compatible), but I couldn't find what the docker-compose file is used for so I can't be certain. If there is a use case I should test please let me know.
​
