### PR TITLE
[Feat] Allow consumers to refresh the topic lists

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -336,6 +336,9 @@ module Kafka
     # @param fetcher_max_queue_size [Integer] max number of items in the fetch queue that
     #   are stored for further processing. Note, that each item in the queue represents a
     #   response from a single broker.
+    # @param refresh_topic_interval [Integer] interval of refreshing the topic list.
+    #   If it is 0, the topic list won't be refreshed (default)
+    #   If it is n (n > 0), the topic list will be refreshed every n seconds
     # @return [Consumer]
     def consumer(
         group_id:,
@@ -345,7 +348,8 @@ module Kafka
         offset_commit_threshold: 0,
         heartbeat_interval: 10,
         offset_retention_time: nil,
-        fetcher_max_queue_size: 100
+        fetcher_max_queue_size: 100,
+        refresh_topic_interval: 0
     )
       cluster = initialize_cluster
 
@@ -399,6 +403,7 @@ module Kafka
         fetcher: fetcher,
         session_timeout: session_timeout,
         heartbeat: heartbeat,
+        refresh_topic_interval: refresh_topic_interval
       )
     end
 

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -76,7 +76,7 @@ module Kafka
 
       # Hash storing topics that are already being subscribed
       # When subcribing to a new topic, if it's already being subscribed before, skip it
-      @subscribed_topics = {}
+      @subscribed_topics = Set.new
     end
 
     # Subscribes the consumer to a topic.
@@ -595,8 +595,8 @@ module Kafka
     end
 
     def subscribe_to_topic(topic, default_offset, start_from_beginning, max_bytes_per_partition)
-      return if @subscribed_topics[topic]
-      @subscribed_topics[topic] = true
+      return if @subscribed_topics.include?(topic)
+      @subscribed_topics.add(topic)
 
       @group.subscribe(topic)
       @offset_manager.set_default_offset(topic, default_offset)

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -472,6 +472,7 @@ module Kafka
     end
 
     def join_group
+      @join_group_for_new_topics = false
       old_generation_id = @group.generation_id
 
       @group.join
@@ -492,7 +493,6 @@ module Kafka
       end
 
       @fetcher.reset
-      @join_group_for_new_topics = false
 
       @group.assigned_partitions.each do |topic, partitions|
         partitions.each do |partition|

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -593,11 +593,10 @@ module Kafka
     end
 
     def scan_for_subscribing
-      @subscribed_topics.keys.each do |topic_or_regex|
-        default_offset = @subscribed_topics[topic_or_regex][:default_offset]
-        start_from_beginning = @subscribed_topics[topic_or_regex][:start_from_beginning]
-        max_bytes_per_partition = @subscribed_topics[topic_or_regex][:max_bytes_per_partition]
-
+      @subscribed_topics.each do |topic_or_regex, config|
+        default_offset = config[:default_offset]
+        start_from_beginning = config[:start_from_beginning]
+        max_bytes_per_partition = config[:max_bytes_per_partition]
         if topic_or_regex.is_a?(Regexp)
           subscribe_to_regex(topic_or_regex, default_offset, start_from_beginning, max_bytes_per_partition)
         else

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -594,9 +594,9 @@ module Kafka
 
     def scan_for_subscribing
       @subscribed_topics.each do |topic_or_regex, config|
-        default_offset = config[:default_offset]
-        start_from_beginning = config[:start_from_beginning]
-        max_bytes_per_partition = config[:max_bytes_per_partition]
+        default_offset = config.fetch(:default_offset)
+        start_from_beginning = config.fetch(:start_from_beginning)
+        max_bytes_per_partition = config.fetch(:max_bytes_per_partition)
         if topic_or_regex.is_a?(Regexp)
           subscribe_to_regex(topic_or_regex, default_offset, start_from_beginning, max_bytes_per_partition)
         else

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -218,7 +218,6 @@ module Kafka
       )
 
       consumer_loop do
-        refresh_topic_list_if_enabled
         batches = fetch_batches
 
         batches.each do |batch|
@@ -307,7 +306,6 @@ module Kafka
       )
 
       consumer_loop do
-        refresh_topic_list_if_enabled
         batches = fetch_batches
 
         batches.each do |batch|
@@ -413,6 +411,7 @@ module Kafka
       while running?
         begin
           @instrumenter.instrument("loop.consumer") do
+            refresh_topic_list_if_enabled
             yield
           end
         rescue HeartbeatError

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -143,6 +143,7 @@ describe Kafka::Consumer do
     allow(offset_manager).to receive(:set_default_offset)
     allow(offset_manager).to receive(:mark_as_processed)
     allow(offset_manager).to receive(:next_offset_for) { 42 }
+    allow(offset_manager).to receive(:clear_offsets)
 
     allow(group).to receive(:subscribe)
     allow(group).to receive(:group_id)
@@ -151,11 +152,15 @@ describe Kafka::Consumer do
     allow(group).to receive(:subscribed_partitions) { assigned_partitions }
     allow(group).to receive(:assigned_to?) { false }
     allow(group).to receive(:assigned_to?).with('greetings', 0) { true }
+    allow(group).to receive(:generation_id) { 1 }
+    allow(group).to receive(:join)
+    allow(group).to receive(:assigned_partitions) { [] }
 
     allow(heartbeat).to receive(:trigger)
 
     allow(fetcher).to receive(:data?) { fetched_batches.any? }
     allow(fetcher).to receive(:poll) { [:batches, fetched_batches] }
+    allow(fetcher).to receive(:reset)
 
     consumer.subscribe("greetings")
   end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -137,6 +137,7 @@ describe Kafka::Consumer do
     allow(cluster).to receive(:add_target_topics)
     allow(cluster).to receive(:disconnect)
     allow(cluster).to receive(:refresh_metadata_if_necessary!)
+    allow(cluster).to receive(:mark_as_stale!)
 
     allow(offset_manager).to receive(:commit_offsets)
     allow(offset_manager).to receive(:commit_offsets_if_necessary)

--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -131,8 +131,8 @@ describe "Consumer API", functional: true do
     received_messages = []
 
     kafka = Kafka.new(kafka_brokers, client_id: "test", logger: logger)
-    consumer = kafka.consumer(group_id: group_id, offset_retention_time: offset_retention_time)
-    consumer.subscribe(/#{topic_a}|#{topic_b}/, refresh_topic_interval: 2)
+    consumer = kafka.consumer(group_id: group_id, offset_retention_time: offset_retention_time, refresh_topic_interval: 1)
+    consumer.subscribe(/#{topic_a}|#{topic_b}/)
 
     thread = Thread.new do
       consumer.each_message do |message|
@@ -145,7 +145,7 @@ describe "Consumer API", functional: true do
     end
     thread.abort_on_exception = true
 
-    sleep 2
+    sleep 1
     messages_b.each { |i| producer.produce(i.to_s, topic: topic_b) }
     producer.deliver_messages
 

--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -145,6 +145,7 @@ describe "Consumer API", functional: true do
     end
     thread.abort_on_exception = true
 
+    sleep 2
     messages_b.each { |i| producer.produce(i.to_s, topic: topic_b) }
     producer.deliver_messages
 

--- a/spec/functional/consumer_group_spec.rb
+++ b/spec/functional/consumer_group_spec.rb
@@ -117,8 +117,8 @@ describe "Consumer API", functional: true do
     topic_a = generate_topic_name
     topic_b = generate_topic_name
 
-    messages_a = (1..5).to_a
-    messages_b = (6..10).to_a
+    messages_a = (1..500).to_a
+    messages_b = (501..1000).to_a
     messages = messages_a + messages_b
 
     producer = Kafka.new(kafka_brokers, client_id: "test").producer


### PR DESCRIPTION
## Description

- Enable consumers to automatically subscribe to the new topics that match the regex
- This feature is not enabled by default to keep the backward compatibility
