### PR TITLE
Add client function for fetching topic replica count

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -694,6 +694,15 @@ module Kafka
       @cluster.partitions_for(topic).count
     end
 
+    # Counts the number of replicas for a topic's partition
+    #
+    # @param topic [String]
+    # @return [Integer] the number of replica nodes for the topic's partition
+
+    def replica_count_for(topic)
+      @cluster.partitions_for(topic).first.replicas.count
+    end
+
     # Retrieve the offset of the last message in a partition. If there are no
     # messages in the partition -1 is returned.
     #

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -698,7 +698,6 @@ module Kafka
     #
     # @param topic [String]
     # @return [Integer] the number of replica nodes for the topic's partition
-
     def replica_count_for(topic)
       @cluster.partitions_for(topic).first.replicas.count
     end

--- a/lib/kafka/protocol/metadata_response.rb
+++ b/lib/kafka/protocol/metadata_response.rb
@@ -34,7 +34,7 @@ module Kafka
     #
     class MetadataResponse
       class PartitionMetadata
-        attr_reader :partition_id, :leader
+        attr_reader :partition_id, :leader, :replicas
 
         attr_reader :partition_error_code
 

--- a/spec/functional/client_spec.rb
+++ b/spec/functional/client_spec.rb
@@ -130,6 +130,23 @@ describe "Client API", functional: true do
     expect(kafka.partitions_for(topic)).to be > 0
   end
 
+  example "fetching the replica count for a topic" do
+    expect(kafka.replica_count_for(topic)).to eq 1
+  end
+
+  example "fetching the replica count for a topic that doesn't yet exist" do
+    topic = "unknown-topic-#{SecureRandom.uuid}"
+
+    expect { kafka.replica_count_for(topic) }.to raise_exception(Kafka::LeaderNotAvailable)
+
+    # Eventually the call should succeed.
+    expect {
+      10.times { kafka.replica_count_for(topic) rescue nil }
+    }.not_to raise_exception
+
+    expect(kafka.replica_count_for(topic)).to be > 0
+  end
+
   example "delivering a message to a topic" do
     kafka.deliver_message("yolo", topic: topic, key: "xoxo", partition: 0)
 


### PR DESCRIPTION
For tooling / automation scripts, it would be super helpful to expose a method in the client object for querying a topic's replica count, which is possible from the `cluster.partitions_for` function. 

https://github.com/zendesk/ruby-kafka/blob/1b2ed7cd0c79d4ae7e915c4be616df6f59a93eba/lib/kafka/cluster.rb#L180

Another option could be to write a client function that returns the full partition array instead of just the `count` then I can grab the replica count from my code.

https://github.com/zendesk/ruby-kafka/blob/1b2ed7cd0c79d4ae7e915c4be616df6f59a93eba/lib/kafka/client.rb#L694

Let me know what you think or if there's a better place for this.