### PR TITLE
Critical bug fix: Extra sanity checking when marking offsets as processed

### DIFF
--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -58,7 +58,7 @@ module Kafka
 
       last_processed_offset = @processed_offsets[topic][partition] || -1
       if last_processed_offset > offset + 1
-        @logger.debug "Not overwriting newer offset #{topic}/#{partition}:#{last_processed_offset-1} with older #{offset}"
+        @logger.debug "Not overwriting newer offset #{topic}/#{partition}:#{last_processed_offset - 1} with older #{offset}"
         return
       end
 

--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -50,8 +50,19 @@ module Kafka
     # @param offset [Integer] the offset of the message that should be marked as processed.
     # @return [nil]
     def mark_as_processed(topic, partition, offset)
-      @uncommitted_offsets += 1
+      unless @group.assigned_to?(topic, partition)
+        @logger.debug "Not marking #{topic}/#{partition}:#{offset} as processed for partition not assigned to this consumer."
+        return
+      end
       @processed_offsets[topic] ||= {}
+
+      last_processed_offset = @processed_offsets[topic][partition] || -1
+      if last_processed_offset > offset + 1
+        @logger.debug "Not overwriting newer offset #{topic}/#{partition}:#{last_processed_offset-1} with older #{offset}"
+        return
+      end
+
+      @uncommitted_offsets += 1
 
       # The committed offset should always be the offset of the next message that the
       # application will read, thus adding one to the last message processed.


### PR DESCRIPTION
This pull request resolves an edge case, but one that represents a **_critical_** bug for us that has caused us a very significant amount of pain over the last couple years, but has also been quite elusive to nail down.

We have a system that needs to buffer a certain number of messages and insert them into another system all at once as a batch, in a SQL transaction.

To do this, inside the `each_message` loop, we add messages to an array until we've accumulated enough for a batch. Once the buffer is large enough, we atomically export the batch to the external system, call `mark_message_as_processed` for each buffered message, and clear the buffer.

The problem we've encountered several times now is that the consumer group may rebalance and end up with different partition assignments before the buffer is full. Once processing resumes after the rebalancing, the next time the buffer is cleared, it will call `mark_message_as_processed` with some messages from partitions it was consuming from before the rebalance and some partitions from after the rebalance.

Because there's no sanity check in `mark_message_as_processed` to make sure the partition and offset provided actually correspond to the partitions currently assigned to the group member, it will happily record the offset for the partition it's not supposed to be processing.

The result is that it will happily continue repeatedly re-committing that old, stale offset for the partition(s) it used to be consuming from along with all the new offsets as it continues processing.

This creates a race condition where two members of the consumer group constantly commit offsets for the same partition, back and forth. One member constantly committing the correct offset from its up-to-date processing of that partition, and the other constantly committing an old, stale offset from before the consumer-group rebalance.

If the consumer group is shut down or rebalances again, it's a race between the stale consumer and the active consumer which one will have the last word committing the offsets for the partition they're fighting over. This can result in the consumers suddenly and unpredictably re-processing potentially hundreds of thousands of messages, depending on how long the consumer group remained stable after the last partition assignment.

The fix in this pull request is just to add a simple sanity check to prevent marking offsets as processed for partitions that are not presently assigned to the current consumer group member.

I also added a sanity check to prevent overwriting a newer offset with an older one, in the event that the messages are processed out of order.

I was able to simplify our use case to the following code that demonstrates the issue. You have to start up several instances of this consumer, then start and stop an instance to trigger rebalancing of the consumer group several times until the random timing and partition assignments of the consumer group finally trigger the bug.

```ruby
consumer = kafka.consumer(group_id: 'cg1', offset_commit_interval: 5)
consumer.subscribe('race-test', default_offset: :earliest)

buffer = []
consumer.each_message(automatically_mark_as_processed: false) do |message|
  buffer << message

  # if the consumer group rebalancing occurs before the buffer is flushed,
  # there's a possibility that it may contain messages from before the
  # rebalancing was triggered.
  if buffer.length >= 15000
    # Shuffling the buffer to simulate processing messages out of order
    buffer.shuffle.each do |buffered_message|
      consumer.mark_message_as_processed(buffered_message)
    end

    partitions_list = buffer.map { |message| message.partition }.sort.uniq
    puts "Clearing buffer, messages from partitions: #{partitions_list.join(', ')}"
    buffer.clear
  end
end
```