### PR TITLE
Issue 823 > Use max_wait_time while sleeping in fetch_batches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 /spec/reports/
 /tmp/
 .env
-.idea/
 *.log
 *.swp
 .byebug_history

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /spec/reports/
 /tmp/
 .env
+.idea/
 *.log
 *.swp
 .byebug_history

--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -546,7 +546,7 @@ module Kafka
 
       if !@fetcher.data?
         @logger.debug "No batches to process"
-        sleep 2
+        sleep(@fetcher.max_wait_time || 2)
         []
       else
         tag, message = @fetcher.poll

--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -4,7 +4,7 @@ require "kafka/fetch_operation"
 
 module Kafka
   class Fetcher
-    attr_reader :queue
+    attr_reader :queue, :max_wait_time
 
     def initialize(cluster:, logger:, instrumenter:, max_queue_size:, group:)
       @cluster = cluster


### PR DESCRIPTION
This an attempt to fix https://github.com/zendesk/ruby-kafka/issues/823 that causes consumer to sleep for 2 seconds and thus causing an avg 1.5 second pause between when a message is published and then started to be processed by a consumer.

Note that my fix is based on research done by https://github.com/paneq in the above issue.