### PR TITLE
Use the standard SPDX ID for license in gemspec

### DIFF
--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   DESC
 
   spec.homepage      = "https://github.com/zendesk/ruby-kafka"
-  spec.license       = "Apache License Version 2.0"
+  spec.license       = "Apache-2.0"
 
   spec.required_ruby_version = '>= 2.1.0'
 


### PR DESCRIPTION
It is better to use SPDX ID for license field.

  https://guides.rubygems.org/specification-reference/#license=

The list of licenses:

  https://spdx.org/licenses/