### PR TITLE
Add some hardening

### DIFF
--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -162,6 +162,12 @@ module Kafka
       sleep 1
 
       retry
+    rescue CoordinatorLoadInProgress
+      @logger.error "Coordinator broker still loading, retrying in 1s..."
+
+      sleep 1
+
+      retry
     end
 
     def group_leader?


### PR DESCRIPTION
Addresses [this](https://app.circleci.com/pipelines/github/zendesk/ruby-kafka/46/workflows/a633c3e5-e1f0-4dd8-b54a-e3c37beb16a6/jobs/4849) and [this](https://app.circleci.com/pipelines/github/zendesk/ruby-kafka/48/workflows/79b9c0db-e5ab-44e0-8d21-c86b8aba459b/jobs/4876) CI failure. Both seem to be ephemeral problems caused by the Kafka cluster being in an initializing state.