### PR TITLE
Add concurrent-ruby dependency.

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -4,6 +4,7 @@ require "kafka/consumer_group"
 require "kafka/offset_manager"
 require "kafka/fetcher"
 require "kafka/pause"
+require "concurrent"
 
 module Kafka
 

--- a/lib/kafka/version.rb
+++ b/lib/kafka/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kafka
-  VERSION = "1.1.0.beta1"
+  VERSION = "1.1.0.beta2"
 end

--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'digest-crc'
+  spec.add_dependency 'concurrent-ruby', '~> 1.0', '>= 1.0.2'
 
   spec.add_development_dependency "bundler", ">= 1.9.5"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Somewhere between v1.0 and v1.1.0-beta1, a change was committed that uses `Concurrent::Map` but without adding `concurrent-ruby` to the dependencies in the gemspec.

The tests pass because `activesupport` is a development dependency, and they've had `concurrent-ruby` as one of their dependencies since version 5.0.0.

But without this in the gemspec, any project that doesn't load in activesupport or concurrent-ruby itself won't work with ruby-kafka.