### PR TITLE
add producer consumer interceptors

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -248,6 +248,9 @@ module Kafka
     #   be in a message set before it should be compressed. Note that message sets
     #   are per-partition rather than per-topic or per-producer.
     #
+    # @param interceptors [Array<Object>] a list of producer interceptors the implement
+    #   `call(Kafka::PendingMessage)`.
+    #
     # @return [Kafka::Producer] the Kafka producer.
     def producer(
       compression_codec: nil,
@@ -261,7 +264,8 @@ module Kafka
       idempotent: false,
       transactional: false,
       transactional_id: nil,
-      transactional_timeout: 60
+      transactional_timeout: 60,
+      interceptors: []
     )
       cluster = initialize_cluster
       compressor = Compressor.new(
@@ -291,6 +295,7 @@ module Kafka
         retry_backoff: retry_backoff,
         max_buffer_size: max_buffer_size,
         max_buffer_bytesize: max_buffer_bytesize,
+        interceptors: interceptors
       )
     end
 
@@ -343,6 +348,8 @@ module Kafka
     # @param refresh_topic_interval [Integer] interval of refreshing the topic list.
     #   If it is 0, the topic list won't be refreshed (default)
     #   If it is n (n > 0), the topic list will be refreshed every n seconds
+    # @param interceptors [Array<Object>] a list of consumer interceptors that implement
+    #   `call(Kafka::FetchedBatch)`.
     # @return [Consumer]
     def consumer(
         group_id:,
@@ -353,7 +360,8 @@ module Kafka
         heartbeat_interval: 10,
         offset_retention_time: nil,
         fetcher_max_queue_size: 100,
-        refresh_topic_interval: 0
+        refresh_topic_interval: 0,
+        interceptors: []
     )
       cluster = initialize_cluster
 
@@ -407,7 +415,8 @@ module Kafka
         fetcher: fetcher,
         session_timeout: session_timeout,
         heartbeat: heartbeat,
-        refresh_topic_interval: refresh_topic_interval
+        refresh_topic_interval: refresh_topic_interval,
+        interceptors: interceptors
       )
     end
 

--- a/lib/kafka/interceptors.rb
+++ b/lib/kafka/interceptors.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Kafka
+  # Holds a list of interceptors that implement `call`
+  # and wraps calls to a chain of custom interceptors.
+  class Interceptors
+    def initialize(interceptors:, logger:)
+      @interceptors = interceptors || []
+      @logger = TaggedLogger.new(logger)
+    end
+
+    # This method is called when the client produces a message or once the batches are fetched.
+    # The message returned from the first call is passed to the second interceptor call, and so on in an
+    # interceptor chain. This method does not throw exceptions.
+    #
+    # @param intercepted [Kafka::PendingMessage || Kafka::FetchedBatch] the produced message or
+    #   fetched batch.
+    #
+    # @return [Kafka::PendingMessage || Kafka::FetchedBatch] the intercepted message or batch
+    #   returned by the last interceptor.
+    def call(intercepted)
+      @interceptors.each do |interceptor|
+        begin
+          intercepted = interceptor.call(intercepted)
+        rescue Exception => e
+          @logger.warn "Error executing interceptor for topic: #{intercepted.topic} partition: #{intercepted.partition}: #{e.message}\n#{e.backtrace.join("\n")}"
+        end
+      end
+
+      intercepted
+    end
+  end
+end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "timecop"
+require "fake_consumer_interceptor"
+require "kafka/interceptors"
 
 describe Kafka::Consumer do
   let(:cluster) { double(:cluster) }
@@ -523,5 +525,51 @@ describe Kafka::Consumer do
     subject(:method_original_name) { consumer.method(:send_heartbeat).original_name }
 
     it { expect(method_original_name).to eq(:trigger_heartbeat!) }
+  end
+
+  describe '#interceptor' do
+    it "creates and stops a consumer with interceptor" do
+      interceptor = FakeConsumerInterceptor.new
+      consumer = Kafka::Consumer.new(
+        cluster: cluster,
+        logger: logger,
+        instrumenter: instrumenter,
+        group: group,
+        offset_manager: offset_manager,
+        fetcher: fetcher,
+        session_timeout: session_timeout,
+        heartbeat: heartbeat,
+        interceptors: [interceptor]
+      )
+
+      consumer.stop
+    end
+
+    it "chains call" do
+      interceptor1 = FakeConsumerInterceptor.new(append_s: 'hello2')
+      interceptor2 = FakeConsumerInterceptor.new(append_s: 'hello3')
+      interceptors = Kafka::Interceptors.new(interceptors: [interceptor1, interceptor2], logger: logger)
+      intercepted_batch = interceptors.call(fetched_batches[0])
+
+      expect(intercepted_batch.messages[0].value).to eq "hellohello2hello3"
+    end
+
+    it "does not break the call chain" do
+      interceptor1 = FakeConsumerInterceptor.new(append_s: 'hello2', on_call_error: true)
+      interceptor2 = FakeConsumerInterceptor.new(append_s: 'hello3')
+      interceptors = Kafka::Interceptors.new(interceptors: [interceptor1, interceptor2], logger: logger)
+      intercepted_batch = interceptors.call(fetched_batches[0])
+
+      expect(intercepted_batch.messages[0].value).to eq "hellohello3"
+    end
+
+    it "returns original batch when all interceptors fail" do
+      interceptor1 = FakeConsumerInterceptor.new(append_s: 'hello2', on_call_error: true)
+      interceptor2 = FakeConsumerInterceptor.new(append_s: 'hello3', on_call_error: true)
+      interceptors = Kafka::Interceptors.new(interceptors: [interceptor1, interceptor2], logger: logger)
+      intercepted_batch = interceptors.call(fetched_batches[0])
+
+      expect(intercepted_batch.messages[0].value).to eq "hello"
+    end
   end
 end

--- a/spec/fake_consumer_interceptor.rb
+++ b/spec/fake_consumer_interceptor.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class FakeConsumerInterceptor
+  def initialize(append_s: '', on_call_error: false)
+    @append_s = append_s
+    @on_call_error = on_call_error
+  end
+
+  def call(batch)
+    if @on_call_error
+      raise StandardError, "Something went wrong in the consumer interceptor"
+    end
+    intercepted_messages = batch.messages.collect do |message|
+      Kafka::FetchedMessage.new(
+        message: Kafka::Protocol::Message.new(
+          value: message.value + @append_s,
+          key: message.key,
+          create_time: message.create_time,
+          offset: message.offset
+        ),
+        topic: message.topic,
+        partition: message.partition
+      )
+    end
+    Kafka::FetchedBatch.new(
+      topic: batch.topic,
+      partition: batch.partition,
+      highwater_mark_offset: batch.highwater_mark_offset,
+      messages: intercepted_messages,
+      last_offset: batch.last_offset,
+      leader_epoch: batch.leader_epoch
+    )
+  end
+end

--- a/spec/fake_producer_interceptor.rb
+++ b/spec/fake_producer_interceptor.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class FakeProducerInterceptor
+  def initialize(append_s: '', on_call_error: false)
+    @append_s = append_s
+    @on_call_error = on_call_error
+  end
+
+  def call(pending_message)
+    if @on_call_error
+      raise StandardError, "Something went wrong in the producer interceptor"
+    end
+    Kafka::PendingMessage.new(
+      value: pending_message.value + @append_s,
+      key: pending_message.key,
+      headers: pending_message.headers,
+      topic: pending_message.topic,
+      partition: pending_message.partition,
+      partition_key: pending_message.partition_key,
+      create_time: pending_message.create_time
+    )
+  end
+end

--- a/spec/functional/interceptors_spec.rb
+++ b/spec/functional/interceptors_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "fake_consumer_interceptor"
+require "fake_producer_interceptor"
+
+describe "Interceptors", functional: true do
+  let!(:topic) { create_random_topic(num_partitions: 3) }
+
+  example "intercept produced and consumed message" do
+    producer_interceptor = FakeProducerInterceptor.new(append_s: 'producer')
+    producer = kafka.producer(max_retries: 3, retry_backoff: 1, interceptors: [producer_interceptor])
+    producer.produce("hello", topic: topic)
+    producer.deliver_messages
+    producer.shutdown
+
+    consumer_interceptor = FakeConsumerInterceptor.new(append_s: 'consumer')
+    consumer = kafka.consumer(group_id: SecureRandom.uuid, fetcher_max_queue_size: 1, interceptors: [consumer_interceptor])
+    consumer.subscribe(topic)
+    consumer.each_message do |message|
+      expect(message.value).to eq "helloproducerconsumer"
+      break
+    end
+    consumer.stop
+  end
+end

--- a/spec/producer_spec.rb
+++ b/spec/producer_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require "fake_broker"
+require "fake_producer_interceptor"
 require "timecop"
+require "kafka/interceptors"
 
 describe Kafka::Producer do
   let(:logger) { LOGGER }
@@ -20,6 +22,7 @@ describe Kafka::Producer do
 
     allow(cluster).to receive(:get_leader).with("greetings", 0) { broker1 }
     allow(cluster).to receive(:get_leader).with("greetings", 1) { broker2 }
+    allow(cluster).to receive(:disconnect).and_return(nil)
 
     allow(compressor).to receive(:compress) {|message_set| message_set }
 
@@ -30,6 +33,7 @@ describe Kafka::Producer do
     allow(transaction_manager).to receive(:producer_epoch).and_return(0)
     allow(transaction_manager).to receive(:transactional_id).and_return(nil)
     allow(transaction_manager).to receive(:send_offsets_to_txn).and_return(nil)
+    allow(transaction_manager).to receive(:close).and_return(nil)
   end
 
   describe "#produce" do
@@ -357,6 +361,81 @@ describe Kafka::Producer do
         },
         group_id: group_id
       )
+    end
+  end
+
+  describe '#interceptor' do
+    let(:now) { Time.now }
+    let(:pending_message) {
+      Kafka::PendingMessage.new(
+        value: "hello1",
+        key: nil,
+        headers: {
+          hello: 'World'
+        },
+        topic: "greetings",
+        partition: 0,
+        partition_key: nil,
+        create_time: now
+      )
+    }
+
+    it "creates and shuts down a producer with interceptor" do
+      interceptor = FakeProducerInterceptor.new
+      producer = initialize_producer(
+        interceptors: [interceptor],
+        cluster: cluster,
+        transaction_manager: transaction_manager
+      )
+
+      producer.shutdown
+    end
+
+    it "chains call" do
+      interceptor1 = FakeProducerInterceptor.new(append_s: 'hello2')
+      interceptor2 = FakeProducerInterceptor.new(append_s: 'hello3')
+      interceptors = Kafka::Interceptors.new(interceptors: [interceptor1, interceptor2], logger: logger)
+      intercepted_message = interceptors.call(pending_message)
+
+      expect(intercepted_message).to eq Kafka::PendingMessage.new(
+        value: "hello1hello2hello3",
+        key: nil,
+        headers: {
+          hello: 'World'
+        },
+        topic: "greetings",
+        partition: 0,
+        partition_key: nil,
+        create_time: now
+      )
+    end
+
+    it "does not break the call chain" do
+      interceptor1 = FakeProducerInterceptor.new(append_s: 'hello2', on_call_error: true)
+      interceptor2 = FakeProducerInterceptor.new(append_s: 'hello3')
+      interceptors = Kafka::Interceptors.new(interceptors: [interceptor1, interceptor2], logger: logger)
+      intercepted_message = interceptors.call(pending_message)
+
+      expect(intercepted_message).to eq Kafka::PendingMessage.new(
+        value: "hello1hello3",
+        key: nil,
+        headers: {
+          hello: 'World'
+        },
+        topic: "greetings",
+        partition: 0,
+        partition_key: nil,
+        create_time: now
+      )
+    end
+
+    it "returns original message when all interceptors fail" do
+      interceptor1 = FakeProducerInterceptor.new(append_s: 'hello2', on_call_error: true)
+      interceptor2 = FakeProducerInterceptor.new(append_s: 'hello3', on_call_error: true)
+      interceptors = Kafka::Interceptors.new(interceptors: [interceptor1, interceptor2], logger: logger)
+      intercepted_message = interceptors.call(pending_message)
+
+      expect(intercepted_message).to eq pending_message
     end
   end
 


### PR DESCRIPTION
Add producer and consumer interceptors that can intercept messages at different points on producer and consumer in order to trace the path of individual messages across the cluster.

- inspired in [KIP-42](https://cwiki.apache.org/confluence/display/KAFKA/KIP-42%3A+Add+Producer+and+Consumer+Interceptors#KIP42:AddProducerandConsumerInterceptors-Motivation)
- intercepts produced messages before they are sent to the brokers
- intercepts consumed messages before are returned to the client
- does not intercept the broker's acknowledgement
- does not intercept when the consumer commits