### PR TITLE
Cleanup setting of consecutive return values in stubs

### DIFF
--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -80,15 +80,10 @@ describe Kafka::Consumer do
     }
 
     before do
-      @count = 0
-      allow(fetcher).to receive(:poll) {
-        @count += 1
-        if @count == 1
-          [:batches, old_fetched_batches]
-        else
-          [:batches, fetched_batches]
-        end
-      }
+      allow(fetcher).to receive(:poll).and_return(
+        [:batches, old_fetched_batches], # first call
+        [:batches, fetched_batches] # any time after the first call
+      )
     end
   end
 
@@ -121,15 +116,10 @@ describe Kafka::Consumer do
     }
 
     before do
-      @count = 0
-      allow(fetcher).to receive(:poll) {
-        @count += 1
-        if @count == 1
-          [:batches, fetched_batches]
-        else
-          [:batches, batches_after_partition_reassignment]
-        end
-      }
+      allow(fetcher).to receive(:poll).and_return(
+        [:batches, fetched_batches], # first call
+        [:batches, batches_after_partition_reassignment] # any time after the first call
+      )
     end
   end
 


### PR DESCRIPTION
Minor cleanup of a spec. You don't need a counter variable to setup multiple return values.