### PR TITLE
README calls out problems starting from Kafka 2.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,25 +110,27 @@ Or install it yourself as:
   </tr>
   <tr>
     <th>Kafka 2.2</th>
-    <td>Limited support</td>
-    <td>Limited support</td>
+    <td>Limited support (*)</td>
+    <td>Limited support (*)</td>
   </tr>
   <tr>
     <th>Kafka 2.3</th>
-    <td>Limited support</td>
-    <td>Limited support</td>
+    <td>Limited support (*)</td>
+    <td>Limited support (*)</td>
   </tr>
   <tr>
     <th>Kafka 2.4</th>
-    <td>Limited support</td>
-    <td>Limited support</td>
+    <td>Limited support (*)</td>
+    <td>Limited support (*)</td>
   </tr>
   <tr>
     <th>Kafka 2.5</th>
-    <td>Limited support</td>
-    <td>Limited support</td>
+    <td>Limited support (*)</td>
+    <td>Limited support (*)</td>
   </tr>
 </table>
+
+(\*): There are **production degradations observed when Kafka cluster version >= 2.2**. See for example https://github.com/fluent/fluent-plugin-kafka/issues/315.
 
 This library is targeting Kafka 0.9 with the v0.4.x series and Kafka 0.10 with the v0.5.x series. There's limited support for Kafka 0.8, and things should work with Kafka 0.11, although there may be performance issues due to changes in the protocol.
 
@@ -139,10 +141,10 @@ This library is targeting Kafka 0.9 with the v0.4.x series and Kafka 0.10 with t
 - **Kafka 1.0:** Everything that works with Kafka 0.11 should still work, but so far no features specific to Kafka 1.0 have been added.
 - **Kafka 2.0:** Everything that works with Kafka 1.0 should still work, but so far no features specific to Kafka 2.0 have been added.
 - **Kafka 2.1:** Everything that works with Kafka 2.0 should still work, but so far no features specific to Kafka 2.1 have been added.
-- **Kafka 2.2:** Everything that works with Kafka 2.1 should still work, but so far no features specific to Kafka 2.2 have been added.
-- **Kafka 2.3:** Everything that works with Kafka 2.2 should still work, but so far no features specific to Kafka 2.3 have been added.
-- **Kafka 2.4:** Everything that works with Kafka 2.3 should still work, but so far no features specific to Kafka 2.4 have been added.
-- **Kafka 2.5:** Everything that works with Kafka 2.4 should still work, but so far no features specific to Kafka 2.5 have been added.
+- **Kafka 2.2:** Everything that works with Kafka 2.1 should still work (\*), but so far no features specific to Kafka 2.2 have been added.
+- **Kafka 2.3:** Everything that works with Kafka 2.2 should still work (\*), but so far no features specific to Kafka 2.3 have been added.
+- **Kafka 2.4:** Everything that works with Kafka 2.3 should still work (\*), but so far no features specific to Kafka 2.4 have been added.
+- **Kafka 2.5:** Everything that works with Kafka 2.4 should still work (\*), but so far no features specific to Kafka 2.5 have been added.
 
 This library requires Ruby 2.1 or higher.
 


### PR DESCRIPTION
To prevent giving the false impression that it is safe to use Ruby client with those clusters.