### PR TITLE
remove concurrent map and use a Hash

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -79,7 +79,7 @@ module Kafka
       @current_offsets = Hash.new { |h, k| h[k] = {} }
 
       # Map storing subscribed topics with their configuration
-      @subscribed_topics = Concurrent::Map.new
+      @subscribed_topics = Hash.new
 
       # Set storing topics that matched topics in @subscribed_topics
       @matched_topics = Set.new


### PR DESCRIPTION
From the comment: `It seems it doesn't need to be threadsafe.`
Via https://github.com/zendesk/ruby-kafka/pull/835#issuecomment-646030465

I took a quick look and it seems it's safe to use a simple Hash

Fixes: https://github.com/zendesk/ruby-kafka/issues/842
Fixes: https://github.com/zendesk/ruby-kafka/issues/840