### PR TITLE
Recover from Kafka::MessageSizeTooLarge exception in async producer.

### DIFF
--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -215,7 +215,7 @@ module Kafka
           when :shutdown
             begin
               # Deliver any pending messages first.
-              @producer.deliver_messages
+              @producer.deliver_messages(async: true)
             rescue Error => e
               @logger.error("Failed to deliver messages during shutdown: #{e.message}")
 
@@ -266,7 +266,7 @@ module Kafka
       end
 
       def deliver_messages
-        @producer.deliver_messages
+        @producer.deliver_messages(async: true)
       rescue DeliveryFailed, ConnectionError => e
         # Failed to deliver messages -- nothing to do but log and try again later.
         @logger.error("Failed to asynchronously deliver messages: #{e.message}")


### PR DESCRIPTION
You can get into a bad unrecoverable state when a Kafka::MessageSizeTooLarge exception is raised.

When we receive this exception, if we're using the sync producer, then we simply re-raise this exception. If we're using the async producer, then we attempt to remove the largest message from the buffer and simply retry. Once retried, if the buffer is still too large, we'll continue removing the largest message until we can successfully flush the buffer.

This will re-raise the exception since it is done synchronously:
```ruby
DeliveryBoy.deliver('a' * 1_500_000, topic: 'test')
```

This will remove the largest message and continue to retry:
```ruby
DeliveryBoy.deliver_async('a' * 1_500_000, topic: 'test')
```

Would love to get some feedback on this approach.  Specifically @dasch since you had some opinions on the approach here:
https://github.com/zendesk/ruby-kafka/pull/358