### PR TITLE
Positional and keyword argument handling in Ruby 2.7

### DIFF
--- a/lib/kafka/async_producer.rb
+++ b/lib/kafka/async_producer.rb
@@ -217,7 +217,7 @@ module Kafka
 
           case operation
           when :produce
-            produce(*payload)
+            produce(payload[0], **payload[1])
             deliver_messages if threshold_reached?
           when :deliver_messages
             deliver_messages


### PR DESCRIPTION
Ruby 2.7 deprecates automatic conversiom between positional and keyword
arguments.

See: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Resolves: #857