### PR TITLE
Improved Exceptions in TransactionManager

### DIFF
--- a/lib/kafka/transaction_manager.rb
+++ b/lib/kafka/transaction_manager.rb
@@ -95,7 +95,7 @@ module Kafka
       force_transactional!
 
       if @transaction_state.uninitialized?
-        raise 'Transaction is uninitialized'
+        raise Kafka::InvalidTxnStateError, 'Transaction is uninitialized'
       end
 
       # Extract newly created partitions
@@ -138,8 +138,8 @@ module Kafka
 
     def begin_transaction
       force_transactional!
-      raise 'Transaction has already started' if @transaction_state.in_transaction?
-      raise 'Transaction is not ready' unless @transaction_state.ready?
+      raise Kafka::InvalidTxnStateError, 'Transaction has already started' if @transaction_state.in_transaction?
+      raise Kafka::InvalidTxnStateError, 'Transaction is not ready' unless @transaction_state.ready?
       @transaction_state.transition_to!(TransactionStateMachine::IN_TRANSACTION)
 
       @logger.info "Begin transaction #{@transactional_id}, Producer ID: #{@producer_id} (Epoch #{@producer_epoch})"
@@ -159,7 +159,7 @@ module Kafka
       end
 
       unless @transaction_state.in_transaction?
-        raise 'Transaction is not valid to commit'
+        raise Kafka::InvalidTxnStateError, 'Transaction is not valid to commit'
       end
 
       @transaction_state.transition_to!(TransactionStateMachine::COMMITTING_TRANSACTION)
@@ -192,7 +192,7 @@ module Kafka
       end
 
       unless @transaction_state.in_transaction?
-        raise 'Transaction is not valid to abort'
+        raise Kafka::InvalidTxnStateError, 'Transaction is not valid to abort'
       end
 
       @transaction_state.transition_to!(TransactionStateMachine::ABORTING_TRANSACTION)
@@ -221,7 +221,7 @@ module Kafka
       force_transactional!
 
       unless @transaction_state.in_transaction?
-        raise 'Transaction is not valid to send offsets'
+        raise Kafka::InvalidTxnStateError, 'Transaction is not valid to send offsets'
       end
 
       add_response = transaction_coordinator.add_offsets_to_txn(
@@ -264,11 +264,11 @@ module Kafka
 
     def force_transactional!
       unless transactional?
-        raise 'Please turn on transactional mode to use transaction'
+        raise Kafka::InvalidTxnStateError, 'Please turn on transactional mode to use transaction'
       end
 
       if @transactional_id.nil? || @transactional_id.empty?
-        raise 'Please provide a transaction_id to use transactional mode'
+        raise Kafka::InvalidTxnStateError, 'Please provide a transaction_id to use transactional mode'
       end
     end
 

--- a/lib/kafka/transaction_manager.rb
+++ b/lib/kafka/transaction_manager.rb
@@ -192,7 +192,8 @@ module Kafka
       end
 
       unless @transaction_state.in_transaction?
-        raise Kafka::InvalidTxnStateError, 'Transaction is not valid to abort'
+        @logger.warn('Aborting transaction that was never opened on brokers')
+        return
       end
 
       @transaction_state.transition_to!(TransactionStateMachine::ABORTING_TRANSACTION)
@@ -248,6 +249,10 @@ module Kafka
 
     def error?
       @transaction_state.error?
+    end
+
+    def ready?
+      @transaction_state.ready?
     end
 
     def close

--- a/spec/transaction_manager_spec.rb
+++ b/spec/transaction_manager_spec.rb
@@ -401,17 +401,15 @@ describe ::Kafka::TransactionManager do
         manager.init_transactions
       end
 
-      it 'raises exception' do
-        expect do
-          manager.abort_transaction
-        end.to raise_error(Kafka::InvalidTxnStateError, /transaction is not valid to abort/i)
+      it 'does not raise an exception' do
+        expect { manager.abort_transaction }.not_to raise_error
       end
 
-      it 'changes state to error' do
+      it 'leaves transaction manager in ready state' do
         begin
           manager.abort_transaction
         rescue; end
-        expect(manager.error?).to eql(true)
+        expect(manager.ready?).to eql(true)
       end
     end
 

--- a/spec/transaction_manager_spec.rb
+++ b/spec/transaction_manager_spec.rb
@@ -210,7 +210,7 @@ describe ::Kafka::TransactionManager do
           manager.add_partitions_to_transaction(
             'hello' => [1, 2, 3]
           )
-        end.to raise_error(/please turn on transactional mode/i)
+        end.to raise_error(Kafka::InvalidTxnStateError, /please turn on transactional mode/i)
       end
     end
   end
@@ -256,7 +256,7 @@ describe ::Kafka::TransactionManager do
       it 'raises exception' do
         expect do
           manager.init_transactions
-        end.to raise_error(/please turn on transactional mode/i)
+        end.to raise_error(Kafka::InvalidTxnStateError, /please turn on transactional mode/i)
       end
 
       it 'changes state to error' do
@@ -291,7 +291,7 @@ describe ::Kafka::TransactionManager do
       it 'raises exception' do
         expect do
           manager.begin_transaction
-        end.to raise_error(/transaction has already started/i)
+        end.to raise_error(Kafka::InvalidTxnStateError, /transaction has already started/i)
       end
 
       it 'changes state to error' do
@@ -306,7 +306,7 @@ describe ::Kafka::TransactionManager do
       it 'raises exception' do
         expect do
           manager.begin_transaction
-        end.to raise_error(/transaction is not ready/i)
+        end.to raise_error(Kafka::InvalidTxnStateError, /transaction is not ready/i)
       end
 
       it 'changes state to error' do
@@ -325,7 +325,7 @@ describe ::Kafka::TransactionManager do
       it 'raises exception' do
         expect do
           manager.begin_transaction
-        end.to raise_error(/please turn on transactional mode/i)
+        end.to raise_error(Kafka::InvalidTxnStateError, /please turn on transactional mode/i)
       end
 
       it 'changes state to error' do
@@ -404,7 +404,7 @@ describe ::Kafka::TransactionManager do
       it 'raises exception' do
         expect do
           manager.abort_transaction
-        end.to raise_error(/transaction is not valid to abort/i)
+        end.to raise_error(Kafka::InvalidTxnStateError, /transaction is not valid to abort/i)
       end
 
       it 'changes state to error' do
@@ -423,7 +423,7 @@ describe ::Kafka::TransactionManager do
       it 'raises exception' do
         expect do
           manager.abort_transaction
-        end.to raise_error(/please turn on transactional mode/i)
+        end.to raise_error(Kafka::InvalidTxnStateError, /please turn on transactional mode/i)
       end
 
       it 'changes state to error' do
@@ -502,7 +502,7 @@ describe ::Kafka::TransactionManager do
       it 'raises exception' do
         expect do
           manager.commit_transaction
-        end.to raise_error(/transaction is not valid to commit/i)
+        end.to raise_error(Kafka::InvalidTxnStateError, /transaction is not valid to commit/i)
       end
 
       it 'changes state to error' do
@@ -521,7 +521,7 @@ describe ::Kafka::TransactionManager do
       it 'raises exception' do
         expect do
           manager.commit_transaction
-        end.to raise_error(/please turn on transactional mode/i)
+        end.to raise_error(Kafka::InvalidTxnStateError, /please turn on transactional mode/i)
       end
 
       it 'changes state to error' do


### PR DESCRIPTION
The use of generic RuntimeError exceptions coming from the `TransactionManager` requires brittle error-handling in dependant code, so I've changed most of the `raise` statements in the `TransactionManager` to use the `Kafka::InvalidTxnStateError` exception.

Additionally, there may be cases where dependant code starts a transaction using the producer's `#transaction` block syntax and then an exception is raised within that block *before* the transaction manager actually opens up a transaction. In such cases, prior to this change, the real exception is obfuscated, because the transaction manager would raise an exception
about not being in a valid transactional state.

With this change, attempting to abort a transaction that has not actually been opened will no longer result in an exception. Instead it will log a warning message and leave the transaction manager in its ready state.