### PR TITLE
Resolve RSpec::Mocks::OutsideOfExampleError

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
           LOG_LEVEL: DEBUG
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec
       - run: bundle exec rubocop
@@ -40,6 +41,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -72,6 +74,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -104,6 +107,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -136,6 +140,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -168,6 +173,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -200,6 +206,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -232,6 +239,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -264,6 +272,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -296,6 +305,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -328,6 +338,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 

--- a/spec/async_producer_spec.rb
+++ b/spec/async_producer_spec.rb
@@ -76,6 +76,8 @@ describe Kafka::AsyncProducer do
       sleep 0.2 # wait for worker to call produce
 
       expect(sync_producer).to have_received(:produce)
+
+      async_producer.shutdown
     end
 
     it "retries until configured max_retries" do
@@ -89,6 +91,8 @@ describe Kafka::AsyncProducer do
       metric = instrumenter.metrics_for("error.async_producer").first
       expect(metric.payload[:error]).to be_a(Kafka::BufferOverflow)
       expect(sync_producer).to have_received(:produce).exactly(3).times
+
+      async_producer.shutdown
     end
 
     it "requires `topic` to be a String" do


### PR DESCRIPTION
This PR resolves `RSpec::Mocks::OutsideOfExampleError` when spec/async_producer_spec.rb is executed.

## Before

```
% rspec spec/async_producer_spec.rb
Run options: exclude {:functional=>true, :performance=>true, :fuzz=>true}

Kafka::AsyncProducer
  #deliver_messages
    instruments the error after failing to deliver buffered messages
  #shutdown
    delivers buffered messages
    instruments a failure to deliver buffered messages
  #produce
    delivers buffered messages
    retries until configured max_retries
    requires `topic` to be a String

Finished in 0.73698 seconds (files took 0.63537 seconds to load)
6 examples, 0 failures

#<Thread:0x00007fc7ab171c70 /Users/arabiki/ghq/src/github.com/zendesk/ruby-kafka/lib/kafka/async_producer.rb:162 aborting> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
        9: from /Users/arabiki/ghq/src/github.com/zendesk/ruby-kafka/lib/kafka/async_producer.rb:162:in `block (2 levels) in ensure_threads_running!'
        8: from /Users/arabiki/ghq/src/github.com/zendesk/ruby-kafka/lib/kafka/async_producer.rb:253:in `run'
        7: from /Users/arabiki/ghq/src/github.com/zendesk/ruby-kafka/lib/kafka/async_producer.rb:252:in `ensure in run'
        6: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/method_double.rb:64:in `block (2 levels) in define_proxy_method'
        5: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/method_double.rb:77:in `proxy_method_invoked'
        4: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/proxy.rb:214:in `message_received'
        3: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/test_double.rb:75:in `method_missing'
        2: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/test_double.rb:112:in `__mock_proxy'
        1: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/space.rb:11:in `proxy_for'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/space.rb:51:in `raise_lifecycle_message': The use of doubles or partial doubles from rspec-mocks outside of the per-test lifecycle is not supported. (RSpec::Mocks::OutsideOfExampleError)
#<Thread:0x00007fc7ab16a150 /Users/arabiki/ghq/src/github.com/zendesk/ruby-kafka/lib/kafka/async_producer.rb:162 aborting> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
        9: from /Users/arabiki/ghq/src/github.com/zendesk/ruby-kafka/lib/kafka/async_producer.rb:162:in `block (2 levels) in ensure_threads_running!'
        8: from /Users/arabiki/ghq/src/github.com/zendesk/ruby-kafka/lib/kafka/async_producer.rb:253:in `run'
        7: from /Users/arabiki/ghq/src/github.com/zendesk/ruby-kafka/lib/kafka/async_producer.rb:252:in `ensure in run'
        6: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/method_double.rb:64:in `block (2 levels) in define_proxy_method'
        5: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/method_double.rb:77:in `proxy_method_invoked'
        4: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/proxy.rb:214:in `message_received'
        3: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/test_double.rb:75:in `method_missing'
        2: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/test_double.rb:112:in `__mock_proxy'
        1: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/space.rb:11:in `proxy_for'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/rspec-mocks-3.9.1/lib/rspec/mocks/space.rb:51:in `raise_lifecycle_message': The use of doubles or partial doubles from rspec-mocks outside of the per-test lifecycle is not supported. (RSpec::Mocks::OutsideOfExampleError)
```

## After

```
% rspec spec/async_producer_spec.rb
Run options: exclude {:functional=>true, :performance=>true, :fuzz=>true}

Kafka::AsyncProducer
  #deliver_messages
    instruments the error after failing to deliver buffered messages
  #shutdown
    delivers buffered messages
    instruments a failure to deliver buffered messages
  #produce
    delivers buffered messages
    retries until configured max_retries
    requires `topic` to be a String

Finished in 0.73808 seconds (files took 0.70865 seconds to load)
6 examples, 0 failures

```