### PR TITLE
Resolve "Passing the keyword argument as ..." deprecation warning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
           LOG_LEVEL: DEBUG
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec
       - run: bundle exec rubocop
@@ -40,6 +41,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -72,6 +74,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -104,6 +107,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -136,6 +140,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -168,6 +173,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -200,6 +206,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -232,6 +239,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -264,6 +272,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -296,6 +305,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
@@ -328,6 +338,7 @@ jobs:
           KAFKA_DELETE_TOPIC_ENABLE: true
     steps:
       - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,9 +61,9 @@ module SpecHelpers
     "#{RUN_ID}-topic-#{SecureRandom.uuid}"
   end
 
-  def create_random_topic(*args)
+  def create_random_topic(**args)
     topic = generate_topic_name
-    create_topic(topic, *args)
+    create_topic(topic, **args)
     topic
   end
 

--- a/spec/transaction_manager_spec.rb
+++ b/spec/transaction_manager_spec.rb
@@ -591,10 +591,10 @@ describe ::Kafka::TransactionManager do
           )
         )
         allow(group_coordinator).to receive(:txn_offset_commit).and_return(
-          txn_offset_commit_response(
+          txn_offset_commit_response({
             'hello' => [1],
             'world' => [2]
-          )
+          })
         )
       end
 


### PR DESCRIPTION
This PR resolves a deprecation warning like below when the Ruby version is 2.7:

```
/path/to/ruby-kafka/spec/transaction_manager_spec.rb:594: warning: Passing the keyword argument as the last hash parameter is deprecated
/path/to/ruby-kafka/spec/transaction_manager_spec.rb:682: warning: The called method `txn_offset_commit_response' is defined here
```

## Before

```
% rspec --tag functional spec/transaction_manager_spec.rb:601 spec/functional/consumer_group_spec.rb:438
Run options:
  include {:functional=>true, :locations=>{"./spec/transaction_manager_spec.rb"=>[601], "./spec/functional/consumer_group_spec.rb"=>[438]}}
  exclude {:performance=>true, :fuzz=>true}

Kafka::TransactionManager
  #send_offsets_to_txn
    currently in transaction
/Users/arabiki/ghq/src/github.com/zendesk/ruby-kafka/spec/transaction_manager_spec.rb:594: warning: Passing the keyword argument as the last hash parameter is deprecated
/Users/arabiki/ghq/src/github.com/zendesk/ruby-kafka/spec/transaction_manager_spec.rb:682: warning: The called method `txn_offset_commit_response' is defined here
      notifies transaction coordinator

Consumer API
/Users/arabiki/ghq/src/github.com/zendesk/ruby-kafka/spec/spec_helper.rb:66: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/arabiki/ghq/src/github.com/zendesk/ruby-kafka/spec/spec_helper.rb:70: warning: The called method `create_topic' is defined here
  consuming messages with a custom assignment strategy

Finished in 3.72 seconds (files took 0.72687 seconds to load)
2 examples, 0 failures

```

## After

```
% rspec --tag functional spec/transaction_manager_spec.rb:601 spec/functional/consumer_group_spec.rb:438
Run options:
  include {:functional=>true, :locations=>{"./spec/transaction_manager_spec.rb"=>[601], "./spec/functional/consumer_group_spec.rb"=>[438]}}
  exclude {:performance=>true, :fuzz=>true}

Kafka::TransactionManager
  #send_offsets_to_txn
    currently in transaction
      notifies transaction coordinator

Consumer API
  consuming messages with a custom assignment strategy

Finished in 3.72 seconds (files took 0.61582 seconds to load)
2 examples, 0 failures

```