### PR TITLE
kafka 2.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,6 +342,39 @@ jobs:
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
+  kafka-2.7:
+    docker:
+      - image: circleci/ruby:2.5.1-node
+        environment:
+          LOG_LEVEL: DEBUG
+      - image: wurstmeister/zookeeper
+      - image: wurstmeister/kafka:2.13-2.7.0
+        environment:
+          KAFKA_ADVERTISED_HOST_NAME: localhost
+          KAFKA_ADVERTISED_PORT: 9092
+          KAFKA_PORT: 9092
+          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+          KAFKA_DELETE_TOPIC_ENABLE: true
+      - image: wurstmeister/kafka:2.13-2.7.0
+        environment:
+          KAFKA_ADVERTISED_HOST_NAME: localhost
+          KAFKA_ADVERTISED_PORT: 9093
+          KAFKA_PORT: 9093
+          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+          KAFKA_DELETE_TOPIC_ENABLE: true
+      - image: wurstmeister/kafka:2.13-2.7.0
+        environment:
+          KAFKA_ADVERTISED_HOST_NAME: localhost
+          KAFKA_ADVERTISED_PORT: 9094
+          KAFKA_PORT: 9094
+          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+          KAFKA_DELETE_TOPIC_ENABLE: true
+    steps:
+      - checkout
+      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
+      - run: bundle install --path vendor/bundle
+      - run: bundle exec rspec --profile --tag functional spec/functional
+
 workflows:
   version: 2
   test:
@@ -357,3 +390,4 @@ workflows:
       - kafka-2.4
       - kafka-2.5
       - kafka-2.6
+      - kafka-2.7

--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ Or install it yourself as:
     <td>Limited support</td>
     <td>Limited support</td>
   </tr>
+  <tr>
+    <th>Kafka 2.7</th>
+    <td>Limited support</td>
+    <td>Limited support</td>
+  </tr>
 </table>
 
 This library is targeting Kafka 0.9 with the v0.4.x series and Kafka 0.10 with the v0.5.x series. There's limited support for Kafka 0.8, and things should work with Kafka 0.11, although there may be performance issues due to changes in the protocol.
@@ -150,6 +155,7 @@ This library is targeting Kafka 0.9 with the v0.4.x series and Kafka 0.10 with t
 - **Kafka 2.4:** Everything that works with Kafka 2.3 should still work, but so far no features specific to Kafka 2.4 have been added.
 - **Kafka 2.5:** Everything that works with Kafka 2.4 should still work, but so far no features specific to Kafka 2.5 have been added.
 - **Kafka 2.6:** Everything that works with Kafka 2.5 should still work, but so far no features specific to Kafka 2.6 have been added.
+- **Kafka 2.7:** Everything that works with Kafka 2.6 should still work, but so far no features specific to Kafka 2.7 have been added.
 
 This library requires Ruby 2.1 or higher.
 

--- a/spec/functional/topic_management_spec.rb
+++ b/spec/functional/topic_management_spec.rb
@@ -70,11 +70,10 @@ describe "Topic management API", functional: true do
 
     topic = generate_topic_name
     kafka.create_topic(topic, num_partitions: 3)
-    configs = kafka.describe_topic(topic, %w(retention.ms retention.bytes non_exists))
+    configs = kafka.describe_topic(topic, %w(retention.ms))
 
-    expect(configs.keys).to eql(%w(retention.ms retention.bytes))
+    expect(configs.keys).to eql(%w(retention.ms))
     expect(configs['retention.ms']).to be_a(String)
-    expect(configs['retention.bytes']).to be_a(String)
   end
 
   example "alter a topic configuration" do
@@ -90,8 +89,9 @@ describe "Topic management API", functional: true do
       'max.message.bytes' => '987654'
     )
 
-    configs = kafka.describe_topic(topic, %w(retention.ms max.message.bytes))
-    expect(configs['retention.ms']).to eql('1234567')
-    expect(configs['max.message.bytes']).to eql('987654')
+    retention_configs = kafka.describe_topic(topic, %w(retention.ms))
+    expect(retention_configs['retention.ms']).to eql('1234567')
+    max_msg_bytes_configs = kafka.describe_topic(topic, %w(max.message.bytes))
+    expect(max_msg_bytes_configs['max.message.bytes']).to eql('987654')
   end
 end


### PR DESCRIPTION
adds [kafka 2.7.0](https://downloads.apache.org/kafka/2.7.0/RELEASE_NOTES.html) to the CI tests