### PR TITLE
Bump DescribeConfigs API to version 1

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -637,8 +637,8 @@ module Kafka
     # @param name [String] the name of the topic.
     # @param configs [Array<String>] array of desired config names.
     # @return [Hash<String, String>]
-    def describe_topic(name, configs = [])
-      @cluster.describe_topic(name, configs)
+    def describe_topic(name, configs: nil, config_source: nil)
+      @cluster.describe_topic(name, configs, config_source)
     end
 
     # Alter the configuration of a topic.

--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -246,7 +246,7 @@ module Kafka
       @logger.info "Topic `#{name}` was deleted"
     end
 
-    def describe_topic(name, configs = [])
+    def describe_topic(name, configs, config_source)
       options = {
         resources: [[Kafka::Protocol::RESOURCE_TYPE_TOPIC, name, configs]]
       }
@@ -261,6 +261,7 @@ module Kafka
       end
       topic_description = response.resources.first
       topic_description.configs.each_with_object({}) do |config, hash|
+        next unless config_source.nil? || config.config_source == config_source
         hash[config.name] = config.value
       end
     end

--- a/lib/kafka/protocol/describe_configs_request.rb
+++ b/lib/kafka/protocol/describe_configs_request.rb
@@ -4,8 +4,9 @@ module Kafka
   module Protocol
 
     class DescribeConfigsRequest
-      def initialize(resources:)
+      def initialize(resources:, include_synonyms: false)
         @resources = resources
+        @include_synonyms = include_synonyms
       end
 
       def api_key
@@ -13,7 +14,7 @@ module Kafka
       end
 
       def api_version
-        0
+        1
       end
 
       def response_class
@@ -28,6 +29,7 @@ module Kafka
             encoder.write_string(config)
           end
         end
+        encoder.write_boolean(@include_synonyms)
       end
     end
 

--- a/lib/kafka/protocol/describe_configs_response.rb
+++ b/lib/kafka/protocol/describe_configs_response.rb
@@ -16,14 +16,25 @@ module Kafka
       end
 
       class ConfigEntry
-        attr_reader :name, :value, :read_only, :is_default, :is_sensitive
+        attr_reader :name, :value, :read_only, :config_source, :is_sensitive, :synonyms
 
-        def initialize(name:, value:, read_only:, is_default:, is_sensitive:)
+        def initialize(name:, value:, read_only:, config_source:, is_sensitive:, synonyms:)
           @name = name
           @value = value
           @read_only = read_only
           @is_default = is_default
           @is_sensitive = is_sensitive
+          @synonyms = synonyms
+        end
+      end
+
+      class SynonymEntry
+        attr_reader :name, :value, :source
+
+        def initialize(name:, value:, source:)
+          @name = name
+          @value = value
+          @source = source
         end
       end
 
@@ -51,8 +62,15 @@ module Kafka
               name: decoder.string,
               value: decoder.string,
               read_only: decoder.boolean,
-              is_default: decoder.boolean,
+              config_source: decoder.int8,
               is_sensitive: decoder.boolean,
+              synonyms: decoder.array do
+                SynonymEntry.new(
+                  name: decoder.string,
+                  value: decoder.string,
+                  source: decoder.int8
+                )
+              end
             )
           end
 
@@ -68,6 +86,5 @@ module Kafka
         new(throttle_time_ms: throttle_time_ms, resources: resources)
       end
     end
-
   end
 end

--- a/lib/kafka/protocol/describe_configs_response.rb
+++ b/lib/kafka/protocol/describe_configs_response.rb
@@ -22,7 +22,7 @@ module Kafka
           @name = name
           @value = value
           @read_only = read_only
-          @is_default = is_default
+          @config_source = config_source
           @is_sensitive = is_sensitive
           @synonyms = synonyms
         end


### PR DESCRIPTION
Version 1 of this API exposes `config_source` which describes the origin of a particular config (topic, broker, default value, etc). We have tooling that manages topic-level configs so being able to filter on `config_source` would be very helpful.

As far as I can tell, `DescribeConfigs` is used in two places: `describe_topic` and `describe_configs` (broker configs). The former is noted to be an alpha API while the latter is not.

I'm not sure about the compatibility goals of this library (version 1 of this API was introduced in Kafka 1.1.0), so I just wanted to start a conversation.

Reference: https://kafka.apache.org/protocol#The_Messages_DescribeConfigs