### PR TITLE
Updated to ignore all control batches

### DIFF
--- a/lib/kafka/protocol/record_batch.rb
+++ b/lib/kafka/protocol/record_batch.rb
@@ -213,7 +213,7 @@ module Kafka
       end
 
       def mark_control_record
-        if in_transaction && is_control_batch
+        if is_control_batch
           record = @records.first
           record.is_control_record = true unless record.nil?
         end


### PR DESCRIPTION
Control batches can show up even outside of transactions. This change drops the requirement that you must be in a transaction for a record to be labeled a control batch.

All tests pass with this change. 

This change is very similar to the ones made in other Kafka clients: 

- Sarama: https://github.com/Shopify/sarama/pull/1898
- librdkafka: https://github.com/edenhill/librdkafka/blob/master/src/rdkafka_msgset_reader.c#L860