### PR TITLE
Handle SyncGroup responses with a non-zero error and no assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes and additions to the library will be listed here.
 - Fix `Kafka::TransactionManager#send_offsets_to_txn` (#866).
 - Add support for `murmur2` based partitioning.
 - Add `resolve_seed_brokers` option to support seed brokers' hostname with multiple addresses (#877).
+- Handle SyncGroup responses with a non-zero error and no assignments (#896).
 
 ## 1.3.0
 

--- a/lib/kafka/protocol/sync_group_response.rb
+++ b/lib/kafka/protocol/sync_group_response.rb
@@ -13,9 +13,12 @@ module Kafka
       end
 
       def self.decode(decoder)
+        error_code = decoder.int16
+        member_assignment_bytes = decoder.bytes
+
         new(
-          error_code: decoder.int16,
-          member_assignment: MemberAssignment.decode(Decoder.from_string(decoder.bytes)),
+          error_code: error_code,
+          member_assignment: member_assignment_bytes ? MemberAssignment.decode(Decoder.from_string(member_assignment_bytes)) : nil
         )
       end
     end

--- a/spec/protocol/sync_group_response_spec.rb
+++ b/spec/protocol/sync_group_response_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe Kafka::Protocol::SyncGroupResponse do
+  describe ".decode" do
+    subject(:response) { Kafka::Protocol::SyncGroupResponse.decode(decoder) }
+
+    let(:decoder) { Kafka::Protocol::Decoder.new(buffer) }
+    let(:buffer) { StringIO.new(response_bytes) }
+
+    context "the response is successful" do
+      let(:response_bytes) { "\x00\x00\x00\x00\x007\x00\x00\x00\x00\x00\x01\x00\x1Fsome-topic-f064d6897583eb395896\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x01\xFF\xFF\xFF\xFF" }
+
+      it "decodes the response including the member assignment" do
+        expect(response.error_code).to eq 0
+        expect(response.member_assignment.topics).to eq({ "some-topic-f064d6897583eb395896" => [0, 1] })
+      end
+    end
+
+    context "the response is not successful" do
+      let(:response_bytes) { "\x00\x19\xFF\xFF\xFF\xFF" }
+
+      it "decodes the response including the member assignment" do
+        expect(response.error_code).to eq 25
+        expect(response.member_assignment).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the error code is non-zero there isn't necessarily (ever?) an assignment. Currently the decoder raises a `TypeError` ("no implicit conversion of nil into String") - this updates the logic to only try to decode the assignment if there are any bytes.