### PR TITLE
Fix "@param tag has unknown parameter name"

### DIFF
--- a/lib/kafka/cluster.rb
+++ b/lib/kafka/cluster.rb
@@ -117,7 +117,7 @@ module Kafka
 
     # Finds the broker acting as the coordinator of the given group.
     #
-    # @param group_id: [String]
+    # @param group_id [String]
     # @return [Broker] the broker that's currently coordinator.
     def get_group_coordinator(group_id:)
       @logger.debug "Getting group coordinator for `#{group_id}`"
@@ -127,7 +127,7 @@ module Kafka
 
     # Finds the broker acting as the coordinator of the given transaction.
     #
-    # @param transactional_id: [String]
+    # @param transactional_id [String]
     # @return [Broker] the broker that's currently coordinator.
     def get_transaction_coordinator(transactional_id:)
       @logger.debug "Getting transaction coordinator for `#{transactional_id}`"

--- a/lib/kafka/protocol/encoder.rb
+++ b/lib/kafka/protocol/encoder.rb
@@ -126,7 +126,7 @@ module Kafka
       # Writes an integer under varints serializing to the IO object.
       # https://developers.google.com/protocol-buffers/docs/encoding#varints
       #
-      # @param string [Integer]
+      # @param int [Integer]
       # @return [nil]
       def write_varint(int)
         int = int << 1


### PR DESCRIPTION
This PR resolves the following warnings:

```
% yard doc
[warn]: @param tag has unknown parameter name: group_id:
    in file `lib/kafka/cluster.rb' near line 122
[warn]: @param tag has unknown parameter name: transactional_id:
    in file `lib/kafka/cluster.rb' near line 132
[warn]: @param tag has unknown parameter name: string
    in file `lib/kafka/protocol/encoder.rb' near line 131
-- snip --
```