### PR TITLE
Refresh metadata if necessary on deliver_message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes and additions to the library will be listed here.
 
 ## Unreleased
 
+- Refresh a stale cluster's metadata if necessary on `Kafka::Client#deliver_message` (#901).
 - Fix `Kafka::TransactionManager#send_offsets_to_txn` (#866).
 - Add support for `murmur2` based partitioning.
 - Add `resolve_seed_brokers` option to support seed brokers' hostname with multiple addresses (#877).

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -210,6 +210,8 @@ module Kafka
       attempt = 1
 
       begin
+        @cluster.refresh_metadata_if_necessary!
+
         operation.execute
 
         unless buffer.empty?


### PR DESCRIPTION
This introduces a very small change, to ensure a stale cluster gets its metadata refreshed when using `Kafka::Client#deliver_message`

See #900 for details and motivation