### PR TITLE
ISSUE-525 / 764: ruby-kafka does not support different topic subscriptions in the same consumer group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes and additions to the library will be listed here.
 - Add support for `murmur2` based partitioning.
 - Add `resolve_seed_brokers` option to support seed brokers' hostname with multiple addresses (#877).
 - Handle SyncGroup responses with a non-zero error and no assignments (#896).
+- Add support for non-identical topic subscriptions within the same consumer group (#525 / #764).
 
 ## 1.3.0
 

--- a/lib/kafka/consumer_group.rb
+++ b/lib/kafka/consumer_group.rb
@@ -189,9 +189,14 @@ module Kafka
       if group_leader?
         @logger.info "Chosen as leader of group `#{@group_id}`"
 
+        topics = Set.new
+        @members.each do |_member, metadata|
+          metadata.topics.each { |t| topics.add(t) }
+        end
+
         group_assignment = @assignor.assign(
           members: @members,
-          topics: @topics,
+          topics: topics,
         )
       end
 

--- a/spec/round_robin_assignment_strategy_spec.rb
+++ b/spec/round_robin_assignment_strategy_spec.rb
@@ -4,7 +4,7 @@ describe Kafka::RoundRobinAssignmentStrategy do
   let(:strategy) { described_class.new }
 
   it "assigns all partitions" do
-    members = Hash[(0...10).map {|i| ["member#{i}", nil] }]
+    members = Hash[(0...10).map {|i| ["member#{i}", double(topics: ['greetings'])] }]
     partitions = (0...30).map {|i| double(:"partition#{i}", topic: "greetings", partition_id: i) }
 
     assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
@@ -21,8 +21,8 @@ describe Kafka::RoundRobinAssignmentStrategy do
   end
 
   it "spreads all partitions between members" do
-    members = Hash[(0...10).map {|i| ["member#{i}", nil] }]
     topics = ["topic1", "topic2"]
+    members = Hash[(0...10).map {|i| ["member#{i}", double(topics: topics)] }]
     partitions = topics.product((0...5).to_a).map {|topic, i|
       double(:"partition#{i}", topic: topic, partition_id: i)
     }
@@ -46,36 +46,50 @@ describe Kafka::RoundRobinAssignmentStrategy do
     expect(num_partitions_assigned).to all eq(1)
   end
 
+  Metadata = Struct.new(:topics)
   [
     {
       name: "uneven topics",
       topics: { "topic1" => [0], "topic2" => (0..50).to_a },
-      members: { "member1" => nil, "member2" => nil },
+      members: {
+        "member1" => Metadata.new(["topic1", "topic2"]),
+        "member2" => Metadata.new(["topic1", "topic2"])
+      },
     },
     {
       name: "only one partition",
       topics: { "topic1" => [0] },
-      members: { "member1" => nil, "member2" => nil },
+      members: {
+        "member1" => Metadata.new(["topic1"]),
+        "member2" => Metadata.new(["topic1"])
+      },
     },
     {
       name: "lots of partitions",
       topics: { "topic1" => (0..100).to_a },
-      members: { "member1" => nil },
+      members: { "member1" => Metadata.new(["topic1"]) },
     },
     {
       name: "lots of members",
       topics: { "topic1" => (0..10).to_a, "topic2" => (0..10).to_a },
-      members: Hash[(0..50).map { |i| ["member#{i}", nil] }]
+      members: Hash[(0..50).map { |i| ["member#{i}", Metadata.new(["topic1", "topic2"])] }]
     },
     {
       name: "odd number of partitions",
       topics: { "topic1" => (0..14).to_a },
-      members: { "member1" => nil, "member2" => nil },
+      members: {
+        "member1" => Metadata.new(["topic1"]),
+        "member2" => Metadata.new(["topic1"])
+      },
     },
     {
       name: "five topics, 10 partitions, 3 consumers",
       topics: { "topic1" => [0, 1], "topic2" => [0, 1], "topic3" => [0, 1], "topic4" => [0, 1], "topic5" => [0, 1] },
-      members: { "member1" => nil, "member2" => nil, "member3" => nil },
+      members: {
+        "member1" => Metadata.new(["topic1", "topic2", "topic3", "topic4", "topic5"]),
+        "member2" => Metadata.new(["topic1", "topic2", "topic3", "topic4", "topic5"]),
+        "member3" => Metadata.new(["topic1", "topic2", "topic3", "topic4", "topic5"])
+      },
     }
   ].each do |options|
     name, topics, members = options[:name], options[:topics], options[:members]
@@ -111,6 +125,210 @@ describe Kafka::RoundRobinAssignmentStrategy do
     assignments.values.each do |assigned_partition|
       num_assigned = assigned_partition.count
       expect(num_assigned).to be_within(1).of(num_partitions.to_f / assignments.count)
+    end
+  end
+
+  context 'one consumer no subscriptions or topics / partitions' do
+    it 'returns empty assignments' do
+      members = { 'member1' => nil }
+      partitions = []
+
+      assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
+
+      expect(assignments).to eq({})
+    end
+  end
+
+  context 'one consumer with subscription but no matching topic partition' do
+    it 'returns empty assignments' do
+      members = { 'member1' => double(topics: ['topic1']) }
+      partitions = []
+
+      assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
+
+      expect(assignments).to eq({})
+    end
+  end
+
+  context 'one consumer subscribed to one topic with one partition' do
+    it 'assigns the partition to the consumer' do
+      members = { 'member1' => double(topics: ['topic1']) }
+      partitions = [
+        t1p0 = double(:"t1p0", topic: "topic1", partition_id: 0),
+      ]
+
+      assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
+
+      expect(assignments).to eq({
+        'member1' => [t1p0]
+      })
+    end
+  end
+
+  context 'one consumer subscribed to one topic with multiple partitions' do
+    it 'assigns all partitions to the consumer' do
+      members = { 'member1' => double(topics: ['topic1']) }
+      partitions = [
+        t1p0 = double(:"t1p0", topic: "topic1", partition_id: 0),
+        t1p1 = double(:"t1p1", topic: "topic1", partition_id: 1),
+      ]
+
+      assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
+
+      expect(assignments).to eq({
+        'member1' => [t1p0, t1p1]
+      })
+    end
+  end
+
+  context 'one consumer subscribed to one topic but with multiple different topic partitions' do
+    it 'only assigns partitions for the subscribed topic' do
+      members = { 'member1' => double(topics: ['topic1']) }
+      partitions = [
+        t1p0 = double(:"t1p0", topic: "topic1", partition_id: 0),
+        t1p1 = double(:"t1p1", topic: "topic1", partition_id: 1),
+        t2p0 = double(:"t2p0", topic: "topic2", partition_id: 0),
+      ]
+
+      assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
+
+      expect(assignments).to eq({
+        'member1' => [t1p0, t1p1]
+      })
+    end
+  end
+
+  context 'one consumer subscribed to multiple topics' do
+    it 'assigns all the topics partitions to the consumer' do
+      members = { 'member1' => double(topics: ['topic1', 'topic2']) }
+
+      partitions = [
+        t1p0 = double(:"t1p0", topic: "topic1", partition_id: 0),
+        t1p1 = double(:"t1p1", topic: "topic1", partition_id: 1),
+        t2p0 = double(:"t2p0", topic: "topic2", partition_id: 0),
+      ]
+
+      assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
+
+      expect(assignments).to eq({
+        'member1' => [t1p0, t1p1, t2p0]
+      })
+    end
+  end
+
+  context 'two consumers with one topic and only one partition' do
+    it 'only assigns the partition to one consumer' do
+      members = {
+        'member1' => double(topics: ['topic1']),
+        'member2' => double(topics: ['topic1'])
+      }
+      partitions = [
+        t1p0 = double(:"t1p0", topic: "topic1", partition_id: 0),
+      ]
+
+      assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
+
+      expect(assignments).to eq({
+        'member1' => [t1p0]
+      })
+    end
+  end
+
+  context 'two consumers subscribed to one topic with two partitions' do
+    it 'assigns a partition to each consumer' do
+      members = {
+        'member1' => double(topics: ['topic1']),
+        'member2' => double(topics: ['topic1'])
+      }
+      partitions = [
+        t1p0 = double(:"t1p0", topic: "topic1", partition_id: 0),
+        t1p1 = double(:"t1p1", topic: "topic1", partition_id: 1),
+      ]
+
+      assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
+
+      expect(assignments).to eq({
+        'member1' => [t1p0],
+        'member2' => [t1p1]
+      })
+    end
+  end
+
+  context 'multiple consumers with mixed topics subscriptions' do
+    it 'creates a balanced assignment' do
+      members = {
+        'member1' => double(topics: ['topic1']),
+        'member2' => double(topics: ['topic1', 'topic2']),
+        'member3' => double(topics: ['topic1'])
+      }
+      partitions = [
+        t1p0 = double(:"t1p0", topic: "topic1", partition_id: 0),
+        t1p1 = double(:"t1p1", topic: "topic1", partition_id: 1),
+        t1p2 = double(:"t1p2", topic: "topic1", partition_id: 2),
+        t2p0 = double(:"t2p0", topic: "topic2", partition_id: 0),
+        t2p1 = double(:"t2p1", topic: "topic2", partition_id: 1),
+      ]
+
+      assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
+
+      expect(assignments).to eq({
+        'member1' => [t1p0],
+        'member2' => [t1p1, t2p0, t2p1],
+        'member3' => [t1p2]
+      })
+    end
+  end
+
+  context 'two consumers subscribed to two topics with three partitions each' do
+    it 'creates a balanced assignment' do
+      members = {
+        'member1' => double(topics: ['topic1', 'topic2']),
+        'member2' => double(topics: ['topic1', 'topic2'])
+      }
+      partitions = [
+        t1p0 = double(:"t1p0", topic: "topic1", partition_id: 0),
+        t1p1 = double(:"t1p1", topic: "topic1", partition_id: 1),
+        t1p2 = double(:"t1p2", topic: "topic1", partition_id: 2),
+        t2p0 = double(:"t2p0", topic: "topic2", partition_id: 0),
+        t2p1 = double(:"t2p1", topic: "topic2", partition_id: 1),
+        t2p2 = double(:"t2p2", topic: "topic2", partition_id: 2),
+      ]
+
+      assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
+
+      expect(assignments).to eq({
+        'member1' => [t1p0, t1p2, t2p1],
+        'member2' => [t1p1, t2p0, t2p2]
+      })
+    end
+  end
+
+  context 'many consumers subscribed to one topic with partitions given out of order' do
+    it 'produces balanced assignments' do
+      members = {
+        'member1' => double(topics: ['topic1']),
+        'member2' => double(topics: ['topic1']),
+        'member3' => double(topics: ['topic2']),
+      }
+
+      partitions = [
+        t2p0 = double(:"t2p0", topic: "topic2", partition_id: 0),
+        t1p0 = double(:"t1p0", topic: "topic1", partition_id: 0),
+        t2p1 = double(:"t2p1", topic: "topic2", partition_id: 1),
+        t1p1 = double(:"t1p1", topic: "topic1", partition_id: 1),
+      ]
+
+      assignments = strategy.call(cluster: nil, members: members, partitions: partitions)
+
+      # Without sorting the partitions by topic this input would produce a non balanced assignment:
+      # member1 => [t1p0, t1p1]
+      # member2 => []
+      # member3 => [t2p0, t2p1]
+      expect(assignments).to eq({
+        'member1' => [t1p0],
+        'member2' => [t1p1],
+        'member3' => [t2p0, t2p1]
+      })
     end
   end
 end


### PR DESCRIPTION
There are 2 issues that currently prevent supporting this feature:

1. **The current `RoundRobinAssignmentStrategy` assumes all subscriptions are equal**

We need a more generalized algorithm to perform assignments now that we have different subscriptions across the consumer group. This PR introduces a new additional strategy heavily inspired in the java kafka client [RoundRobinAssignor](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/RoundRobinAssignor.java) that properly handle this case.

2. **The leader consumer thread assumes that all consumers subscription are equivalent**

If different consumers were to have different topic subscription we can't rely on the in-memory `@topics` variable to produce correct assignments. Instead, we can leverage the subscription information provided by the cluster, and stored in`@members`, to determine the correct consumer subscriptions for a particular consumer group. Once we have the correct list of topics the downstream code in the assignor can then fetch the corresponding partitions from the cluster in preparation for the assignments.