### PR TITLE
Make ssl_ca_cert_file_path support an array of files

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "kafka/ssl_context"
@@ -38,8 +39,8 @@ module Kafka
     # @param ssl_ca_cert [String, Array<String>, nil] a PEM encoded CA cert, or an Array of
     #   PEM encoded CA certs, to use with an SSL connection.
     #
-    # @param ssl_ca_cert_file_path [String, nil] a path on the filesystem to a PEM encoded CA cert
-    #   to use with an SSL connection.
+    # @param ssl_ca_cert_file_path [String, Array<String>, nil] a path on the filesystem, or an
+    #    Array of paths, to PEM encoded CA cert(s) to use with an SSL connection.
     #
     # @param ssl_client_cert [String, nil] a PEM encoded client cert to use with an
     #   SSL connection. Must be used in combination with ssl_client_cert_key.

--- a/lib/kafka/ssl_context.rb
+++ b/lib/kafka/ssl_context.rb
@@ -47,8 +47,8 @@ module Kafka
         Array(ca_cert).each do |cert|
           store.add_cert(OpenSSL::X509::Certificate.new(cert))
         end
-        if ca_cert_file_path
-          store.add_file(ca_cert_file_path)
+        Array(ca_cert_file_path).each do |cert_file_path|
+          store.add_file(cert_file_path)
         end
         if ca_certs_from_system
           store.set_default_paths

--- a/spec/ssl_context_spec.rb
+++ b/spec/ssl_context_spec.rb
@@ -31,6 +31,12 @@ describe Kafka::SslContext do
     }.to raise_exception(ArgumentError)
   end
 
+  it "raises an OpenSSL::X509::StoreError if an array of non-existing files is passed for ca_cert_file_path" do
+    expect {
+      Kafka::SslContext.build(ca_cert_file_path: ["no_such_file", "no_such_file_either"])
+    }.to raise_exception(OpenSSL::X509::StoreError)
+  end
+
   context "with self signed cert fixtures" do
     # How the certificates were generated, they are not actually in a chain
     # openssl req -newkey rsa:2048 -nodes -keyout spec/fixtures/client_cert_key.pem -x509 -days 365 -out spec/fixtures/client_cert.pem


### PR DESCRIPTION
A proposed change to facilitate fixing https://github.com/fluent/fluent-plugin-kafka/issues/287. It would help to avoid parsing certs in the upper level code that should not need to know how to do that.