### PR TITLE
Change noisy log from info to debug

### DIFF
--- a/lib/kafka/produce_operation.rb
+++ b/lib/kafka/produce_operation.rb
@@ -104,7 +104,7 @@ module Kafka
 
       messages_for_broker.each do |broker, message_buffer|
         begin
-          @logger.info "Sending #{message_buffer.size} messages to #{broker}"
+          @logger.debug "Sending #{message_buffer.size} messages to #{broker}"
 
           records_for_topics = {}
 


### PR DESCRIPTION
Logging it as `info` produces a bunch of messages. All other "Sending..." logs are already at `debug` level.

I wonder what do you think about this change. If rejected I would mute this some other way in my project.