### PR TITLE
Use CircleCI matrix jobs to test with the latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,11 @@
-version: 2
+version: 2.1
 jobs:
   unit:
+    parameters:
+      ruby-version:
+        type: string
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:<< parameters.ruby-version >>
         environment:
           LOG_LEVEL: DEBUG
     steps:
@@ -12,27 +15,30 @@ jobs:
       - run: bundle exec rspec
       - run: bundle exec rubocop
 
-  kafka-0.11:
+  functional-with-wurstmeister:
+    parameters:
+      kafka-version:
+        type: string
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:2.5
         environment:
           LOG_LEVEL: DEBUG
       - image: wurstmeister/zookeeper
-      - image: wurstmeister/kafka:2.11-0.11.0.3
+      - image: wurstmeister/kafka:<< parameters.kafka-version >>
         environment:
           KAFKA_ADVERTISED_HOST_NAME: localhost
           KAFKA_ADVERTISED_PORT: 9092
           KAFKA_PORT: 9092
           KAFKA_ZOOKEEPER_CONNECT: localhost:2181
           KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.11-0.11.0.3
+      - image: wurstmeister/kafka:<< parameters.kafka-version >>
         environment:
           KAFKA_ADVERTISED_HOST_NAME: localhost
           KAFKA_ADVERTISED_PORT: 9093
           KAFKA_PORT: 9093
           KAFKA_ZOOKEEPER_CONNECT: localhost:2181
           KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.11-0.11.0.3
+      - image: wurstmeister/kafka:<< parameters.kafka-version >>
         environment:
           KAFKA_ADVERTISED_HOST_NAME: localhost
           KAFKA_ADVERTISED_PORT: 9094
@@ -45,326 +51,32 @@ jobs:
       - run: bundle install --path vendor/bundle
       - run: bundle exec rspec --profile --tag functional spec/functional
 
-  kafka-1.0.0:
+  functional-with-bitnami:
+    parameters:
+      kafka-version:
+        type: string
     docker:
-      - image: circleci/ruby:2.5.1-node
-        environment:
-          LOG_LEVEL: DEBUG
-      - image: wurstmeister/zookeeper
-      - image: wurstmeister/kafka:2.11-1.0.2
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9092
-          KAFKA_PORT: 9092
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.11-1.0.2
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9093
-          KAFKA_PORT: 9093
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.11-1.0.2
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9094
-          KAFKA_PORT: 9094
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-    steps:
-      - checkout
-      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
-      - run: bundle install --path vendor/bundle
-      - run: bundle exec rspec --profile --tag functional spec/functional
-
-  kafka-1.1:
-    docker:
-      - image: circleci/ruby:2.5.1-node
-        environment:
-          LOG_LEVEL: DEBUG
-      - image: wurstmeister/zookeeper
-      - image: wurstmeister/kafka:2.11-1.1.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9092
-          KAFKA_PORT: 9092
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.11-1.1.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9093
-          KAFKA_PORT: 9093
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.11-1.1.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9094
-          KAFKA_PORT: 9094
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-    steps:
-      - checkout
-      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
-      - run: bundle install --path vendor/bundle
-      - run: bundle exec rspec --profile --tag functional spec/functional
-
-  kafka-2.0:
-    docker:
-      - image: circleci/ruby:2.5.1-node
-        environment:
-          LOG_LEVEL: DEBUG
-      - image: wurstmeister/zookeeper
-      - image: wurstmeister/kafka:2.11-2.0.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9092
-          KAFKA_PORT: 9092
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.11-2.0.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9093
-          KAFKA_PORT: 9093
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.11-2.0.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9094
-          KAFKA_PORT: 9094
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-    steps:
-      - checkout
-      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
-      - run: bundle install --path vendor/bundle
-      - run: bundle exec rspec --profile --tag functional spec/functional
-
-  kafka-2.1:
-    docker:
-      - image: circleci/ruby:2.5.1-node
-        environment:
-          LOG_LEVEL: DEBUG
-      - image: wurstmeister/zookeeper
-      - image: wurstmeister/kafka:2.12-2.1.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9092
-          KAFKA_PORT: 9092
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.12-2.1.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9093
-          KAFKA_PORT: 9093
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.12-2.1.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9094
-          KAFKA_PORT: 9094
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-    steps:
-      - checkout
-      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
-      - run: bundle install --path vendor/bundle
-      - run: bundle exec rspec --profile --tag functional spec/functional
-
-  kafka-2.2:
-    docker:
-      - image: circleci/ruby:2.5.1-node
-        environment:
-          LOG_LEVEL: DEBUG
-      - image: wurstmeister/zookeeper
-      - image: wurstmeister/kafka:2.12-2.2.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9092
-          KAFKA_PORT: 9092
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.12-2.2.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9093
-          KAFKA_PORT: 9093
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.12-2.2.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9094
-          KAFKA_PORT: 9094
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-    steps:
-      - checkout
-      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
-      - run: bundle install --path vendor/bundle
-      - run: bundle exec rspec --profile --tag functional spec/functional
-
-  kafka-2.3:
-    docker:
-      - image: circleci/ruby:2.5.1-node
-        environment:
-          LOG_LEVEL: DEBUG
-      - image: wurstmeister/zookeeper
-      - image: wurstmeister/kafka:2.12-2.3.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9092
-          KAFKA_PORT: 9092
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.12-2.3.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9093
-          KAFKA_PORT: 9093
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.12-2.3.1
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9094
-          KAFKA_PORT: 9094
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-    steps:
-      - checkout
-      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
-      - run: bundle install --path vendor/bundle
-      - run: bundle exec rspec --profile --tag functional spec/functional
-
-  kafka-2.4:
-    docker:
-      - image: circleci/ruby:2.5.1-node
-        environment:
-          LOG_LEVEL: DEBUG
-      - image: wurstmeister/zookeeper
-      - image: wurstmeister/kafka:2.12-2.4.0
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9092
-          KAFKA_PORT: 9092
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.12-2.4.0
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9093
-          KAFKA_PORT: 9093
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.12-2.4.0
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9094
-          KAFKA_PORT: 9094
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-    steps:
-      - checkout
-      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
-      - run: bundle install --path vendor/bundle
-      - run: bundle exec rspec --profile --tag functional spec/functional
-
-  kafka-2.5:
-    docker:
-      - image: circleci/ruby:2.5.1-node
-        environment:
-          LOG_LEVEL: DEBUG
-      - image: wurstmeister/zookeeper
-      - image: wurstmeister/kafka:2.12-2.5.0
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9092
-          KAFKA_PORT: 9092
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.12-2.5.0
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9093
-          KAFKA_PORT: 9093
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.12-2.5.0
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9094
-          KAFKA_PORT: 9094
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-    steps:
-      - checkout
-      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
-      - run: bundle install --path vendor/bundle
-      - run: bundle exec rspec --profile --tag functional spec/functional
-
-  kafka-2.6:
-    docker:
-      - image: circleci/ruby:2.5.1-node
-        environment:
-          LOG_LEVEL: DEBUG
-      - image: wurstmeister/zookeeper
-      - image: wurstmeister/kafka:2.13-2.6.0
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9092
-          KAFKA_PORT: 9092
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.13-2.6.0
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9093
-          KAFKA_PORT: 9093
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: wurstmeister/kafka:2.13-2.6.0
-        environment:
-          KAFKA_ADVERTISED_HOST_NAME: localhost
-          KAFKA_ADVERTISED_PORT: 9094
-          KAFKA_PORT: 9094
-          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
-          KAFKA_DELETE_TOPIC_ENABLE: true
-    steps:
-      - checkout
-      - run: sudo apt-get update && sudo apt-get install -y cmake # For installing snappy
-      - run: bundle install --path vendor/bundle
-      - run: bundle exec rspec --profile --tag functional spec/functional
-
-  kafka-2.7:
-    docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:2.5
         environment:
           LOG_LEVEL: DEBUG
       - image: bitnami/zookeeper
         environment:
           ALLOW_ANONYMOUS_LOGIN: yes
-      - image: bitnami/kafka:2.7.0
+      - image: bitnami/kafka:<< parameters.kafka-version >>
         environment:
           ALLOW_PLAINTEXT_LISTENER: yes
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
           KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
           KAFKA_CFG_ZOOKEEPER_CONNECT: localhost:2181
           KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: bitnami/kafka:2.7.0
+      - image: bitnami/kafka:<< parameters.kafka-version >>
         environment:
           ALLOW_PLAINTEXT_LISTENER: yes
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9093
           KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9093
           KAFKA_CFG_ZOOKEEPER_CONNECT: localhost:2181
           KAFKA_DELETE_TOPIC_ENABLE: true
-      - image: bitnami/kafka:2.7.0
+      - image: bitnami/kafka:<< parameters.kafka-version >>
         environment:
           ALLOW_PLAINTEXT_LISTENER: yes
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9094
@@ -381,15 +93,30 @@ workflows:
   version: 2
   test:
     jobs:
-      - unit
-      - kafka-0.11
-      - kafka-1.0.0
-      - kafka-1.1
-      - kafka-2.0
-      - kafka-2.1
-      - kafka-2.2
-      - kafka-2.3
-      - kafka-2.4
-      - kafka-2.5
-      - kafka-2.6
-      - kafka-2.7
+      - unit:
+          name: unit-ruby-<< matrix.ruby-version >>
+          matrix:
+            parameters:
+              ruby-version:
+                - "2.5"
+      - functional-with-wurstmeister:
+          name: functional-kafka-<< matrix.kafka-version >>
+          matrix:
+            parameters:
+              kafka-version:
+                - 2.11-0.11.0.3
+                - 2.11-1.0.2
+                - 2.11-1.1.1
+                - 2.11-2.0.1
+                - 2.12-2.1.1
+                - 2.12-2.2.1
+                - 2.12-2.3.1
+                - 2.12-2.4.0
+                - 2.12-2.5.0
+                - 2.13-2.6.0
+      - functional-with-bitnami:
+          name: functional-kafka-<< matrix.kafka-version >>
+          matrix:
+            parameters:
+              kafka-version:
+                - "2.7.0"


### PR DESCRIPTION
This PR updates `.circleci/config.yml` to use CircleCI matrix jobs.
It can make it easy to test with multiple Ruby and Kafka versions, and also can simplify duplicate statements.
Here are the details:
- Upgrade to next-gen Docker convenience images
  The following message is shown in Circle CI job page.
  > You’re using a [deprecated Docker convenience image.](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) Upgrade to a next-gen Docker convenience image.
  
  The link above states the following.

  > Moving from a legacy to next-gen image requires a change to the namespace. All legacy images have a Docker namespace of circleci, while next-gen images have a Docker namespace of cimg. For example, migrating from the legacy Ruby or Python image to the respective next-gen image can be done as follows:

  > circleci/ruby:2.3.0 → cimg/ruby:2.3.0
  > circleci/python:3.8.4 → cimg/python:3.8.4

  `circleci/ruby:2.5.1-node` is used now, but because of the following reasons, `cimg/ruby:2.5` will be used.
  - cimg doesn't provide Ruby 2.5.1, and the latest patch version is 2.5.9.
  - Specify a minor release tag for the latest patch version to use.
    https://circleci.com/developer/images/image/cimg/ruby#image-tags
  - It seems that Node.js is not needed, so I omit the suffix `-node`.

  BTW, Ruby 2.5 has already reached EOL, but it's left as is in this PR.
- While unit tests are currently only run on Ruby 2.5, matrix is used so that we can add test for other Ruby versions later.
- There are two types of kafka images(provided by wurstmeister/bitnami), with different environment variables to pass.
  So I defined jobs for each(`functional-with-wurstmeister`/`functional-with-bitnami`).
- The workflow name was set for clarity. Note that the name has changed from the previous name.
  Before: 
  <details><summary>Show image</summary>

  ![image](https://user-images.githubusercontent.com/32959831/166246573-3c547275-fde1-4bdd-bc9a-e90ab3ae94de.png)
  </details>

  After: 
  <details><summary>Show image</summary>

  ![image](https://user-images.githubusercontent.com/32959831/166246523-03a504fb-0fcd-462f-8dee-d803339c5398.png)
  </details>

The CI status can be seen [here](https://app.circleci.com/pipelines/github/mishina2228/ruby-kafka/11/workflows/bb2f4945-9b3f-42ce-9d27-91670afd69d7).
Functional tests fail randomly, but I believe this is not related with changes in this PR.
