### PR TITLE
Make example "create partitions" stable

### DIFF
--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -814,6 +814,10 @@ module Kafka
       @cluster.disconnect
     end
 
+    def refresh_metadata
+      @cluster.refresh_metadata!
+    end
+
     private
 
     def initialize_cluster

--- a/spec/functional/topic_management_spec.rb
+++ b/spec/functional/topic_management_spec.rb
@@ -60,7 +60,10 @@ describe "Topic management API", functional: true do
     expect(kafka.partitions_for(topic)).to eq 3
 
     kafka.create_partitions_for(topic, num_partitions: 10)
-    with_retry { expect(kafka.partitions_for(topic)).to eq 10 }
+    with_retry {
+      kafka.refresh_metadata
+      expect(kafka.partitions_for(topic)).to eq 10
+    }
   end
 
   example "describe a topic" do


### PR DESCRIPTION
This PR prevents the example "create partitions" from failing like https://app.circleci.com/pipelines/github/zendesk/ruby-kafka/221/workflows/7d51470f-c102-4b30-b2e0-68c618eeb1d2/jobs/6799?invite=true#step-104-122.

As there is a time lag for Kafka's metadata to be updated, `Kafka::Client#partitions_for` is needed to be executed until the metadata is updated to check the latest partition count. However, `Kafka::Cluster` never fetches new metadata until it considers the current metadata stale.
So, this PR adds the method `Kafka#refresh_metadata` in order to force Kafka::Cluster to fetch metadata. The option helps in production code as well to ensure we get the latest metadata.