### PR TITLE
Use cimg/ruby:2.5.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   unit:
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:2.5.9
         environment:
           LOG_LEVEL: DEBUG
     steps:
@@ -14,7 +14,7 @@ jobs:
 
   kafka-0.11:
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:2.5.9
         environment:
           LOG_LEVEL: DEBUG
       - image: wurstmeister/zookeeper
@@ -47,7 +47,7 @@ jobs:
 
   kafka-1.0.0:
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:2.5.9
         environment:
           LOG_LEVEL: DEBUG
       - image: wurstmeister/zookeeper
@@ -80,7 +80,7 @@ jobs:
 
   kafka-1.1:
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:2.5.9
         environment:
           LOG_LEVEL: DEBUG
       - image: wurstmeister/zookeeper
@@ -113,7 +113,7 @@ jobs:
 
   kafka-2.0:
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:2.5.9
         environment:
           LOG_LEVEL: DEBUG
       - image: wurstmeister/zookeeper
@@ -146,7 +146,7 @@ jobs:
 
   kafka-2.1:
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:2.5.9
         environment:
           LOG_LEVEL: DEBUG
       - image: wurstmeister/zookeeper
@@ -179,7 +179,7 @@ jobs:
 
   kafka-2.2:
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:2.5.9
         environment:
           LOG_LEVEL: DEBUG
       - image: wurstmeister/zookeeper
@@ -212,7 +212,7 @@ jobs:
 
   kafka-2.3:
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:2.5.9
         environment:
           LOG_LEVEL: DEBUG
       - image: wurstmeister/zookeeper
@@ -245,7 +245,7 @@ jobs:
 
   kafka-2.4:
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:2.5.9
         environment:
           LOG_LEVEL: DEBUG
       - image: wurstmeister/zookeeper
@@ -278,7 +278,7 @@ jobs:
 
   kafka-2.5:
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:2.5.9
         environment:
           LOG_LEVEL: DEBUG
       - image: wurstmeister/zookeeper
@@ -311,7 +311,7 @@ jobs:
 
   kafka-2.6:
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:2.5.9
         environment:
           LOG_LEVEL: DEBUG
       - image: wurstmeister/zookeeper
@@ -344,7 +344,7 @@ jobs:
 
   kafka-2.7:
     docker:
-      - image: circleci/ruby:2.5.1-node
+      - image: cimg/ruby:2.5.9
         environment:
           LOG_LEVEL: DEBUG
       - image: bitnami/zookeeper


### PR DESCRIPTION
CI sometimes times out due to "log writing failed. deadlock; recursive locking" as follows, and it might be related to https://bugs.ruby-lang.org/issues/15360. If so, using the image "cimg/ruby:2.5.9" resolves the problem.

* https://app.circleci.com/pipelines/github/zendesk/ruby-kafka/233/workflows/b80d0db8-1334-49e2-abf9-9d51580c42bc/jobs/6940
* https://app.circleci.com/pipelines/github/zendesk/ruby-kafka/232/workflows/a612607f-f20d-4bb0-b6b4-47e184a26474/jobs/6921
* https://app.circleci.com/pipelines/github/zendesk/ruby-kafka/231/workflows/03476478-d34a-4ce1-ba6a-be0a118a2734/jobs/6916

By the way, I think https://github.com/zendesk/ruby-kafka/pull/940 is useful to manage Ruby versions and Kafka versions and should be managed.