### PR TITLE
Set timeout period to wait for messages

### DIFF
--- a/spec/functional/batch_consumer_spec.rb
+++ b/spec/functional/batch_consumer_spec.rb
@@ -45,7 +45,12 @@ describe "Batch Consumer API", functional: true do
     duplicates = Set.new
 
     loop do
-      message = message_queue.pop
+      message = begin
+        Timeout.timeout(10) { message_queue.pop }
+      rescue Timeout::Error
+        $stderr.puts "Timeout::Error: No message was added within the time-out period"
+        break
+      end
 
       if received_messages.include?(message)
         duplicates.add(message)


### PR DESCRIPTION
The example "consuming messages using the batch API" sometimes gets stuck as follows, and the reason might be `Queue#pop` waits for a message unlimitedly.

* https://app.circleci.com/pipelines/github/zendesk/ruby-kafka/233/workflows/b80d0db8-1334-49e2-abf9-9d51580c42bc/jobs/6931
* https://app.circleci.com/pipelines/github/zendesk/ruby-kafka/232/workflows/a612607f-f20d-4bb0-b6b4-47e184a26474/jobs/6920
* https://app.circleci.com/pipelines/github/zendesk/ruby-kafka/230/workflows/fedf26e8-22af-4deb-878d-aa6c5fc5ae6f/jobs/6895