### PR TITLE
Replicate idempotent behavior when no keys

### DIFF
--- a/spec/functional/idempotent_async_producer_spec.rb
+++ b/spec/functional/idempotent_async_producer_spec.rb
@@ -106,7 +106,11 @@ describe "Idempotent async producer", functional: true do
     allow_any_instance_of(Kafka::SocketWithTimeout).to receive(:read).and_call_original
     sleep 10
 
-    records = kafka.fetch_messages(topic: topic, offset: :earliest)
+    records = [
+      kafka.fetch_messages(topic: topic, offset: :earliest, partition: 0),
+      kafka.fetch_messages(topic: topic, offset: :earliest, partition: 1),
+      kafka.fetch_messages(topic: topic, offset: :earliest, partition: 2),
+    ].flatten
     expect(records.length).to eql(20)
   end
 


### PR DESCRIPTION
I am trying to replicate idempotent async producer behavior when no partitioning info is provided so that messages are routed to random partitions. I think it leads to incorrect behavior.