### PR TITLE
fix: check that thread exists before waiting on it

### DIFF
--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -66,7 +66,7 @@ module Kafka
     def stop
       return unless @running
       @commands << [:stop, []]
-      @thread.join
+      @thread.join if @thread
     end
 
     def reset


### PR DESCRIPTION
Simple fix to hopefully let the shutdown process finish. The ruby-kafka client seems to get stuck here, during a shutdown presumably.

We've seen an issue where the client isn't able to reconnect to a broker that does rolling restart, the client is using SASL/PLAIN with SSL. We didn't see this issue before, when we didn't use SASL/PLAIN with SSL

Here is a sequence of events:


- Error committing offsets: Kafka::NotCoordinatorForGroup
- Error sending heartbeat: Kafka::RebalanceInProgress.
- Failed to fetch from events/1: Kafka::NotLeaderForPartition
- Error committing offsets: Kafka::NotCoordinatorForGroup 
- Error committing offsets: Connection error EOFError: end of file reached
ruby-kafka-1.4.0/lib/kafka/ssl_socket_with_timeout.rb:69:in connect_nonblock': SSL_connect SYSCALL returned=5 errno=0 state=SSLv3/TLS write client hello (OpenSSL::SSL::SSLError)

 (the ruby consumer must have attempted to shutdown after some retries)

- `undefined method join' for nil:NilClass ...`
