### PR TITLE
Remove unnecessary set_encoding

### DIFF
--- a/lib/kafka/protocol/encoder.rb
+++ b/lib/kafka/protocol/encoder.rb
@@ -12,7 +12,6 @@ module Kafka
       # @param io [IO] an object that acts as an IO.
       def initialize(io)
         @io = io
-        @io.set_encoding(Encoding::BINARY)
       end
 
       # Writes bytes directly to the IO object.


### PR DESCRIPTION
Motivation: 
I'm working on compatibility with [async gem](https://github.com/socketry/async) 
and I want to reuse Encoder by passing `Async::IO::Socket` instead of `Kafka::SocketWithTimeout`

Do you think it's necessary to be setting encoding here?

