### PR TITLE
Switch to trusted publishing workflow and run it on version.rb changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to RubyGems.org
+
+on:
+  push:
+    branches: main
+    paths: lib/kafka/version.rb
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: rubygems-publish
+    if: github.repository_owner == 'zendesk'
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: false
+          
+      - name: Install dependencies
+        run: bundle install
+      - uses: rubygems/release-gem@v1

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A Ruby client library for [Apache Kafka](http://kafka.apache.org/), a distribute
     2. [Asynchronous Producer Design](#asynchronous-producer-design)
     3. [Consumer Design](#consumer-design)
 5. [Development](#development)
+    - [Releasing a new version](#releasing-a-new-version)
 6. [Support and Discussion](#support-and-discussion)
 7. [Roadmap](#roadmap)
 8. [Higher level libraries](#higher-level-libraries)
@@ -1298,6 +1299,20 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 If you would like to contribute to ruby-kafka, please [join our Slack team](https://ruby-kafka-slack.herokuapp.com/) and ask how best to do it.
 
+### Releasing a new version
+A new version is published to RubyGems.org every time a change to `version.rb` is pushed to the `main` branch.
+In short, follow these steps:
+1. Update `version.rb`,
+2. merge this change into `main`, and
+3. look at [the action](https://github.com/zendesk/ruby-kafka/actions/workflows/publish.yml) for output.
+
+To create a pre-release from a non-main branch:
+1. change the version in `version.rb` to something like `1.2.0.pre.1` or `2.0.0.beta.2`,
+2. push this change to your branch,
+3. go to [Actions → “Publish to RubyGems.org” on GitHub](https://github.com/zendesk/ruby-kafka/actions/workflows/publish.yml),
+4. click the “Run workflow” button,
+5. pick your branch from a dropdown.
+
 [![Circle CI](https://circleci.com/gh/zendesk/ruby-kafka.svg?style=shield)](https://circleci.com/gh/zendesk/ruby-kafka/tree/master)
 
 ## Support and Discussion
@@ -1352,7 +1367,7 @@ We needed a robust client that could be used from our existing Ruby apps, allowe
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/zendesk/ruby-kafka.
 
-
+  
 ## Copyright and license
 
 Copyright 2015 Zendesk

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "bundler/setup"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 


### PR DESCRIPTION
Switches to [a Trusted Publishing workflow](https://guides.rubygems.org/trusted-publishing/).
This workflow will run whenever `version.rb` is changed in the `main` branch.
Setting `ENV["gem_push"]` is also not necessary anymore.
This workflow relies on the main branch being named `main`. Please rename it (`main` is the standard name across Zendesk).
`bundler-cache` for `setup-ruby` is set to false to prevent [cache poisoning attacks](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/).
Finally, we add a description of the new release process. Our README and CONTRIBUTING files don’t have a standard structure, so please check that we have updated a correct file and that the new section makes sense for this gem.
- [ ] Release description has been updated correctly.
- [ ] The main branch is renamed from `master` to `main`.