### PR TITLE
Strip trailing `.` in broker hostnames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changes and additions to the library will be listed here.
 
 ## Unreleased
 
+- Removes trailing dots from broker hostnames for [rfc6066](https://datatracker.ietf.org/doc/html/rfc6066#section-3:~:text=without%20a%20trailing%20dot) compatibility.
+
 ## 1.5.0
 - Add support for AWS IAM Authentication to an MSK cluster (#907).
 - Added session token to the IAM mechanism; necessary for auth via temporary credentials (#937)

--- a/lib/kafka/broker_uri.rb
+++ b/lib/kafka/broker_uri.rb
@@ -33,6 +33,9 @@ module Kafka
         uri.scheme = 'kafka+ssl'
       end
 
+      # See rfc6066: https://datatracker.ietf.org/doc/html/rfc6066#section-3:~:text=without%20a%20trailing%20dot
+      uri.hostname.delete_suffix!(".")
+
       unless URI_SCHEMES.include?(uri.scheme)
         raise Kafka::Error, "invalid protocol `#{uri.scheme}` in `#{str}`"
       end

--- a/spec/broker_uri_spec.rb
+++ b/spec/broker_uri_spec.rb
@@ -19,4 +19,8 @@ describe Kafka::BrokerUri do
       Kafka::BrokerUri.parse("http://kafka")
     }.to raise_exception(Kafka::Error, "invalid protocol `http` in `http://kafka`")
   end
+
+  it "strips the trailing dot from fqdn hostnames" do
+    expect(Kafka::BrokerUri.parse("kafka://hello.").to_s).to eq "kafka://hello:9092"
+  end
 end


### PR DESCRIPTION
TSL Sever Name Indicators must not contain a trailing dot in the `HostName`[^1]. Currently, passing an
[fqdn](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) we get an  `SSLError`:

```ruby
OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 peeraddr=10.234.154.163:9093 state=error: sslv3 alert illegal parameter (SSL alert number 47) (OpenSSL::SSL::SSLError)
```

[^1]:(https://datatracker.ietf.org/doc/html/rfc6066#section-3:~:text=without%20a%20trailing%20dot)