### PR TITLE
Run unit tests with against more Rubies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,13 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "2.7.1"
+          - "2.7"
+          - "3.0"
+          - "3.1"
+          - "3.2"
+          - "3.3"
+          - "3.4"
+          - "4.0"
 
     steps:
     - uses: actions/checkout@v5

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@
 
 source "https://rubygems.org"
 
+gem "bigdecimal"
+gem "mutex_m"
 gemspec

--- a/spec/produce_operation_spec.rb
+++ b/spec/produce_operation_spec.rb
@@ -394,9 +394,11 @@ describe Kafka::ProduceOperation do
 
       expect(transaction_manager).to receive(:init_producer_id).once
       expect(transaction_manager).to receive(:add_partitions_to_transaction).with(
-        'hello' => [0, 1],
-        'hi' => [0, 1],
-        'bye' => [0]
+        {
+          'hello' => [0, 1],
+          'hi' => [0, 1],
+          'bye' => [0]
+        }
       ).ordered
       expect(transaction_manager).to receive(:update_sequence_for).with('hello', 0, 100).ordered
       expect(transaction_manager).to receive(:update_sequence_for).with('hello', 1, 101).ordered


### PR DESCRIPTION
- Tests with Ruby 2.7 -> 4.0..
- No longer tests patch versions, just latest patch per minor.
- Added a few gems to the Gemfile that were removed from default gems.
- Updated one test to expect a hash instead of kwargs for more explicit expectations that pass with later Rubies.